### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/examples/darwin/heap_find/heap.py
+++ b/examples/darwin/heap_find/heap.py
@@ -628,7 +628,7 @@ def display_match_results (process, result, options, arg_str_description, expr, 
                     result.AppendMessage(result_output)
                 if options.memory:
                     cmd_result = lldb.SBCommandReturnObject()
-                    if options.format == None:
+                    if options.format is None:
                         memory_command = "memory read --force 0x%x 0x%x" % (malloc_addr, malloc_addr + malloc_size)
                     else:
                         memory_command = "memory read --force -f %s 0x%x 0x%x" % (options.format, malloc_addr, malloc_addr + malloc_size)
@@ -704,7 +704,7 @@ def ptr_refs(debugger, command, result, dict):
         return
 
     options.type = 'pointer'
-    if options.format == None: 
+    if options.format is None: 
         options.format = "A" # 'A' is "address" format
 
     if args:
@@ -798,7 +798,7 @@ def cstr_refs(debugger, command, result, dict):
 
 
     options.type = 'cstr'
-    if options.format == None: 
+    if options.format is None: 
         options.format = "Y" # 'Y' is "bytes with ASCII" format
 
     if args:
@@ -1086,7 +1086,7 @@ def objc_refs(debugger, command, result, dict):
         return
 
     options.type = 'isa'
-    if options.format == None: 
+    if options.format is None: 
         options.format = "A" # 'A' is "address" format
 
     expr_options = lldb.SBExpressionOptions()

--- a/examples/python/crashlog.py
+++ b/examples/python/crashlog.py
@@ -173,7 +173,7 @@ class CrashLog(symbolication.Symbolicator):
                 self.idents.append(ident)
             
         def did_crash(self):
-            return self.reason != None
+            return self.reason is not None
         
         def __str__(self):
             if self.app_specific_backtrace:

--- a/examples/python/diagnose_unwind.py
+++ b/examples/python/diagnose_unwind.py
@@ -27,11 +27,11 @@ def backtrace_print_frame (target, frame_num, addr, fp):
     if sbaddr.GetModule():
       module_filename = ""
       module_uuid_str = sbaddr.GetModule().GetUUIDString()
-      if module_uuid_str == None:
+      if module_uuid_str is None:
         module_uuid_str = ""
       if sbaddr.GetModule().GetFileSpec():
         module_filename = sbaddr.GetModule().GetFileSpec().GetFilename()
-        if module_filename == None:
+        if module_filename is None:
           module_filename = ""
       if module_uuid_str != "" or module_filename != "":
         module_description = '%s %s' % (module_filename, module_uuid_str)
@@ -71,7 +71,7 @@ def simple_backtrace(debugger):
   this_module = backtrace_print_frame (target, 0, cur_thread.GetFrameAtIndex(0).GetPC(), initial_fp)
   print_stack_frame (process, initial_fp)
   print ""
-  if this_module != None:
+  if this_module is not None:
     module_list.append (this_module)
   if cur_thread.GetNumFrames() < 2:
     return [module_list, address_list]
@@ -86,7 +86,7 @@ def simple_backtrace(debugger):
     this_module = backtrace_print_frame (target, frame_num, cur_pc, cur_fp)
     print_stack_frame (process, cur_fp)
     print ""
-    if this_module != None:
+    if this_module is not None:
       module_list.append (this_module)
     frame_num = frame_num + 1
     next_pc = 0
@@ -107,7 +107,7 @@ def simple_backtrace(debugger):
   this_module = backtrace_print_frame (target, frame_num, cur_pc, cur_fp)
   print_stack_frame (process, cur_fp)
   print ""
-  if this_module != None:
+  if this_module is not None:
     module_list.append (this_module)
   return [module_list, address_list]
 
@@ -182,7 +182,7 @@ to be helpful when reporting the problem.
             this_module = backtrace_print_frame (target, frame_num, frame.GetPC(), frame.GetFP())
             print_stack_frame (process, frame.GetFP())
             print ""
-            if this_module != None:
+            if this_module is not None:
               modules_seen.append (this_module)
             addresses_seen.append (frame.GetPC())
             frame_num = frame_num + 1
@@ -192,9 +192,9 @@ to be helpful when reporting the problem.
         print "Simple stack walk algorithm:"
         print ""
         (module_list, address_list) = simple_backtrace(debugger)
-        if module_list and module_list != None:
+        if module_list and module_list is not None:
           modules_seen += module_list
-        if address_list and address_list != None:
+        if address_list and address_list is not None:
           addresses_seen = set(addresses_seen)
           addresses_seen.update(set(address_list))
 
@@ -205,7 +205,7 @@ to be helpful when reporting the problem.
         print ""
         modules_already_seen = set()
         for module in modules_seen:
-          if module != None and module.GetFileSpec().GetFilename() != None:
+          if module is not None and module.GetFileSpec().GetFilename() is not None:
             if not module.GetFileSpec().GetFilename() in modules_already_seen:
               debugger.HandleCommand('image list %s' % module.GetFileSpec().GetFilename())
               modules_already_seen.add(module.GetFileSpec().GetFilename())

--- a/examples/python/dict_utils.py
+++ b/examples/python/dict_utils.py
@@ -53,7 +53,7 @@ class Enum(LookupDictionary):
 
     def __str__(self):
         s = self.get_first_key_for_value (self.value, None)
-        if s == None:
+        if s is None:
             s = "%#8.8x" % self.value
         return s
     

--- a/examples/python/disasm-stress-test.py
+++ b/examples/python/disasm-stress-test.py
@@ -21,20 +21,20 @@ def AddLLDBToSysPathOnMacOSX():
     def GetLLDBFrameworkPath():
         lldb_path = subprocess.check_output(["xcrun", "-find", "lldb"])
         re_result = re.match("(.*)/Developer/usr/bin/lldb", lldb_path)
-        if re_result == None:
+        if re_result is None:
             return None
         xcode_contents_path = re_result.group(1)
         return xcode_contents_path + "/SharedFrameworks/LLDB.framework"
     
     lldb_framework_path = GetLLDBFrameworkPath()
     
-    if lldb_framework_path == None:
+    if lldb_framework_path is None:
         print "Couldn't find LLDB.framework"
         sys.exit(-1)
     
     sys.path.append(lldb_framework_path + "/Resources/Python")
 
-if arg_ns.lldb == None:
+if arg_ns.lldb is None:
     AddLLDBToSysPathOnMacOSX()
 else:
     sys.path.append(arg_ns.lldb + "/Resources/Python")
@@ -89,7 +89,7 @@ class SequentialInstructionProvider:
         return self
     def next(self):
         ret = self.GetNextInstruction()
-        if ret == None:
+        if ret is None:
             raise StopIteration
         return ret
 
@@ -111,7 +111,7 @@ class RandomInstructionProvider:
         return self
     def next(self):
         ret = self.GetNextInstruction()
-        if ret == None:
+        if ret is None:
             raise StopIteration
         return ret
 
@@ -119,7 +119,7 @@ log_file = None
 
 def GetProviderWithArguments(args):
     global log_file
-    if args.log != None:
+    if args.log is not None:
         log_file = open(args.log, 'w')
     else:
         log_file = sys.stdout
@@ -129,9 +129,9 @@ def GetProviderWithArguments(args):
     else:
         start = 0
         skip = 1
-        if args.start != None:
+        if args.start is not None:
             start = args.start
-        if args.skip != None:
+        if args.skip is not None:
             skip = args.skip
         instruction_provider = SequentialInstructionProvider(args.bytes, log_file, start, skip)
     return instruction_provider

--- a/examples/python/gdbremote.py
+++ b/examples/python/gdbremote.py
@@ -312,7 +312,7 @@ class RegisterInfo:
                 return '0x%16.16x' % (uval)
         bytes = list();
         uval = packet.get_hex_uint8()
-        while uval != None:
+        while uval is not None:
             bytes.append(uval)
             uval = packet.get_hex_uint8()
         value_str = '0x'
@@ -461,16 +461,16 @@ class Packet:
     def get_hex_uint(self, byte_order, n = 0):
         if byte_order == 'big':
             hex_str = self.get_hex_chars(n)
-            if hex_str == None:
+            if hex_str is None:
                 return None
             return int(hex_str, 16)
         else:
             uval = self.get_hex_uint8()
-            if uval == None:
+            if uval is None:
                 return None
             uval_result = 0
             shift = 0
-            while uval != None:
+            while uval is not None:
                 uval_result |= (uval << shift)
                 shift += 8
                 uval = self.get_hex_uint8()
@@ -853,7 +853,7 @@ def dump_hex_memory_buffer(addr, hex_byte_str):
     idx = 0
     ascii = ''
     uval = packet.get_hex_uint8()
-    while uval != None:
+    while uval is not None:
         if ((idx % 16) == 0):
             if ascii:
                 print '  ', ascii
@@ -942,7 +942,7 @@ def cmd_read_one_reg(options, cmd, args):
     s = 'read_register (reg_num=%u' % reg_num
     if name:
         s += ' (%s)' % (name)
-    if tid != None:
+    if tid is not None:
         s += ', tid = 0x%4.4x' % (tid)
     s += ')'
     print s
@@ -967,7 +967,7 @@ def cmd_write_one_reg(options, cmd, args):
             s += ' (%s)' % (name)
         s += ', value = '
         s += get_register_name_equal_value(options, reg_num, hex_value_str)
-        if tid != None:
+        if tid is not None:
             s += ', tid = 0x%4.4x' % (tid)
         s += ')'
         print s
@@ -977,7 +977,7 @@ def dump_all_regs(packet):
     for reg_info in g_register_infos:
         nibble_size = reg_info.bit_size() / 4
         hex_value_str = packet.get_hex_chars(nibble_size)
-        if hex_value_str != None:
+        if hex_value_str is not None:
             value = reg_info.get_value_from_hex_string (hex_value_str)
             print '%*s = %s' % (g_max_register_info_name_len, reg_info.name(), value)
         else:
@@ -987,7 +987,7 @@ def cmd_read_all_regs(cmd, cmd_args):
     packet = Packet(cmd_args)
     packet.get_char() # toss the 'g' command character
     tid = get_thread_from_thread_suffix (packet.str)
-    if tid != None:
+    if tid is not None:
         print 'read_all_register(thread = 0x%4.4x)' % tid
     else:
         print 'read_all_register()'

--- a/examples/python/jump.py
+++ b/examples/python/jump.py
@@ -21,7 +21,7 @@ def parse_linespec (linespec, frame, result):
 
     if (not matched):
         mo = re.match("^([0-9]+)$", linespec)
-        if (mo != None):
+        if (mo is not None):
             matched = True
             #print "Matched <linenum>"
             line_number = int(mo.group(1))
@@ -33,7 +33,7 @@ def parse_linespec (linespec, frame, result):
 
     if (not matched):
         mo = re.match("^\+([0-9]+)$", linespec)
-        if (mo != None):
+        if (mo is not None):
             matched = True
             #print "Matched +<count>"
             line_number = int(mo.group(1))
@@ -45,7 +45,7 @@ def parse_linespec (linespec, frame, result):
      
     if (not matched):
         mo = re.match("^\-([0-9]+)$", linespec)
-        if (mo != None):
+        if (mo is not None):
             matched = True
             #print "Matched -<count>"
             line_number = int(mo.group(1))
@@ -57,7 +57,7 @@ def parse_linespec (linespec, frame, result):
 
     if (not matched):
         mo = re.match("^(.*):([0-9]+)$", linespec)
-        if (mo != None):
+        if (mo is not None):
             matched = True
             #print "Matched <filename>:<linenum>"
             file_name = mo.group(1)
@@ -66,7 +66,7 @@ def parse_linespec (linespec, frame, result):
 
     if (not matched):
         mo = re.match("\*((0x)?([0-9a-f]+))$", linespec)
-        if (mo != None):
+        if (mo is not None):
             matched = True
             #print "Matched <address-expression>"
             address = long(mo.group(1), base=0)

--- a/examples/python/mach_o.py
+++ b/examples/python/mach_o.py
@@ -566,11 +566,11 @@ class Mach:
         else:
             self.content = None
 
-        if self.content != None:
+        if self.content is not None:
             self.content.unpack(data, self.magic)
 
     def is_valid(self):
-        return self.content != None
+        return self.content is not None
 
     class Universal:
         
@@ -1168,7 +1168,7 @@ class Mach:
 
             
         def __init__(self, c=None, l=0,o=0):   
-            if c != None:
+            if c is not None:
                 self.command = c
             else:
                 self.command = Mach.LoadCommand.Command(0)

--- a/examples/python/operating_system.py
+++ b/examples/python/operating_system.py
@@ -57,7 +57,7 @@ class OperatingSystemPlugIn(object):
         return self.threads
     
     def get_register_info(self):
-        if self.registers == None:
+        if self.registers is None:
             self.registers = dict()            
             triple = self.process.target.triple
             if triple:

--- a/examples/python/pytracer.py
+++ b/examples/python/pytracer.py
@@ -10,13 +10,13 @@ class TracebackFancy:
 		return FrameFancy(self.t.tb_frame)
 
 	def getLineNumber(self):
-		return self.t.tb_lineno if self.t != None else None
+		return self.t.tb_lineno if self.t is not None else None
 
 	def getNext(self):
 		return TracebackFancy(self.t.tb_next)
 
 	def __str__(self):
-		if self.t == None:
+		if self.t is None:
 			return ""
 		str_self = "%s @ %s" % (self.getFrame().getName(), self.getLineNumber())
 		return str_self + "\n" + self.getNext().__str__()
@@ -36,7 +36,7 @@ class ExceptionFancy:
 		return TracebackFancy(self.etraceback)
 
 	def __nonzero__(self):
-		return self.etraceback != None or self.etype != None or self.evalue != None
+		return self.etraceback is not None or self.etype is not None or self.evalue is not None
 
 	def getType(self):
 		return str(self.etype)
@@ -49,19 +49,19 @@ class CodeFancy:
 		self.c = code
 
 	def getArgCount(self):
-		return self.c.co_argcount if self.c != None else 0
+		return self.c.co_argcount if self.c is not None else 0
 
 	def getFilename(self):
-		return self.c.co_filename if self.c != None else ""
+		return self.c.co_filename if self.c is not None else ""
 
 	def getVariables(self):
-		return self.c.co_varnames if self.c != None else []
+		return self.c.co_varnames if self.c is not None else []
 
 	def getName(self):
-		return self.c.co_name if self.c != None else ""
+		return self.c.co_name if self.c is not None else ""
 
 	def getFileName(self):
-		return self.c.co_filename if self.c != None else ""
+		return self.c.co_filename if self.c is not None else ""
 
 class ArgsFancy:
 	def __init__(self,frame,arginfo):
@@ -124,25 +124,25 @@ class FrameFancy:
 		return FrameFancy(self.f.f_back)
 
 	def getLineNumber(self):
-		return self.f.f_lineno if self.f != None else 0
+		return self.f.f_lineno if self.f is not None else 0
 
 	def getCodeInformation(self):
-		return CodeFancy(self.f.f_code) if self.f != None else None
+		return CodeFancy(self.f.f_code) if self.f is not None else None
 
 	def getExceptionInfo(self):
-		return ExceptionFancy(self.f) if self.f != None else None
+		return ExceptionFancy(self.f) if self.f is not None else None
 
 	def getName(self):
-		return self.getCodeInformation().getName() if self.f != None else ""
+		return self.getCodeInformation().getName() if self.f is not None else ""
 
 	def getFileName(self):
-		return self.getCodeInformation().getFileName() if self.f != None else ""
+		return self.getCodeInformation().getFileName() if self.f is not None else ""
 
 	def getLocals(self):
-		return self.f.f_locals if self.f != None else {}
+		return self.f.f_locals if self.f is not None else {}
 		
 	def getArgumentInfo(self):
-		return ArgsFancy(self.f,inspect.getargvalues(self.f)) if self.f != None else None
+		return ArgsFancy(self.f,inspect.getargvalues(self.f)) if self.f is not None else None
 
 class TracerClass:
 	def callEvent(self,frame):
@@ -170,7 +170,7 @@ tracer_impl = TracerClass()
 
 
 def the_tracer_entrypoint(frame,event,args):
-	if tracer_impl == None:
+	if tracer_impl is None:
 		return None
 	if event == "call":
 		call_retval = tracer_impl.callEvent(FrameFancy(frame))

--- a/examples/python/symbolication.py
+++ b/examples/python/symbolication.py
@@ -58,7 +58,7 @@ class Address:
         return s
 
     def resolve_addr(self):
-        if self.so_addr == None:
+        if self.so_addr is None:
             self.so_addr = self.target.ResolveLoadAddress (self.load_addr)
         return self.so_addr
 
@@ -66,7 +66,7 @@ class Address:
         return self.inlined
     
     def get_symbol_context(self):
-        if self.sym_ctx == None:
+        if self.sym_ctx is None:
             sb_addr = self.resolve_addr()
             if sb_addr:
                 self.sym_ctx = self.target.ResolveSymbolContextForAddress (sb_addr, lldb.eSymbolContextEverything)
@@ -84,7 +84,7 @@ class Address:
         return None
     
     def symbolicate(self, verbose = False):
-        if self.symbolication == None:
+        if self.symbolication is None:
             self.symbolication = ''
             self.inlined = False
             sym_ctx = self.get_symbol_context()
@@ -195,11 +195,11 @@ class Section:
         
     def __str__(self):
         if self.name:
-            if self.end_addr != None:
-                if self.start_addr != None:
+            if self.end_addr is not None:
+                if self.start_addr is not None:
                     return "%s=[0x%16.16x - 0x%16.16x)" % (self.name, self.start_addr, self.end_addr)
             else:
-                if self.start_addr != None:
+                if self.start_addr is not None:
                     return "%s=0x%16.16x" % (self.name, self.start_addr)
             return self.name
         return "<invalid>"
@@ -268,7 +268,7 @@ class Image:
             s += "%s " % (resolved_path)
         for section_info in self.section_infos:
             s += ", %s" % (section_info)
-        if self.slide != None:
+        if self.slide is not None:
             s += ', slide = 0x%16.16x' % self.slide
         return s        
     
@@ -301,7 +301,7 @@ class Image:
         return None
     
     def has_section_load_info(self):
-        return self.section_infos or self.slide != None
+        return self.section_infos or self.slide is not None
     
     def load_module(self, target):
         if self.unavailable:
@@ -617,7 +617,7 @@ def Symbolicate(command_args):
                     image.add_section (section)
                 else:
                     sys.exit(1)
-        if options.slide != None:
+        if options.slide is not None:
             image.slide = options.slide
         symbolicator.images.append(image)
     

--- a/examples/python/x86_64_linux_target_definition.py
+++ b/examples/python/x86_64_linux_target_definition.py
@@ -314,7 +314,7 @@ g_target_definition = None
 
 def get_target_definition ():
     global g_target_definition
-    if g_target_definition == None:
+    if g_target_definition is None:
         g_target_definition = {}
         offset = 0
         for reg_info in x86_64_register_infos:

--- a/examples/python/x86_64_qemu_target_definition.py
+++ b/examples/python/x86_64_qemu_target_definition.py
@@ -313,7 +313,7 @@ g_target_definition = None
 
 def get_target_definition ():
     global g_target_definition
-    if g_target_definition == None:
+    if g_target_definition is None:
         g_target_definition = {}
         offset = 0
         for reg_info in x86_64_register_infos:

--- a/examples/python/x86_64_target_definition.py
+++ b/examples/python/x86_64_target_definition.py
@@ -319,7 +319,7 @@ g_target_definition = None
 
 def get_target_definition ():
     global g_target_definition
-    if g_target_definition == None:
+    if g_target_definition is None:
         g_target_definition = {}
         offset = 0
         for reg_info in x86_64_register_infos:

--- a/examples/scripting/tree_utils.py
+++ b/examples/scripting/tree_utils.py
@@ -59,7 +59,7 @@ def DFS (root, word, cur_path):
 
         # Check to see if left child is NULL
 
-        if left_child_ptr.GetValue() == None:
+        if left_child_ptr.GetValue() is None:
             return ""
         else:
             cur_path = cur_path + "L"
@@ -68,7 +68,7 @@ def DFS (root, word, cur_path):
 
         # Check to see if right child is NULL
 
-        if right_child_ptr.GetValue() == None:
+        if right_child_ptr.GetValue() is None:
             return ""
         else:
             cur_path = cur_path + "R"
@@ -84,7 +84,7 @@ def tree_size (root):
     the one defined in dictionary.c  It uses LLDB API
     functions to examine and traverse the tree nodes.
     """
-    if (root.GetValue == None):
+    if (root.GetValue is None):
         return 0
 
     if (int (root.GetValue(), 16) == 0):
@@ -107,12 +107,12 @@ def print_tree (root):
     the one defined in dictionary.c  It uses LLDB API
     functions to examine and traverse the tree nodes.
     """
-    if (root.GetChildAtIndex(1).GetValue() != None) and (int (root.GetChildAtIndex(1).GetValue(), 16) != 0):
+    if (root.GetChildAtIndex(1).GetValue() is not None) and (int (root.GetChildAtIndex(1).GetValue(), 16) != 0):
         print_tree (root.GetChildAtIndex(1))
 
     print root.GetChildAtIndex(0).GetSummary()
 
-    if (root.GetChildAtIndex(2).GetValue() != None) and (int (root.GetChildAtIndex(2).GetValue(), 16) != 0):
+    if (root.GetChildAtIndex(2).GetValue() is not None) and (int (root.GetChildAtIndex(2).GetValue(), 16) != 0):
         print_tree (root.GetChildAtIndex(2))
 
 

--- a/examples/summaries/cocoa/CFArray.py
+++ b/examples/summaries/cocoa/CFArray.py
@@ -133,17 +133,17 @@ class NSArray_SynthProvider:
 		self.adjust_for_architecture()
 		self.error = False
 		self.wrapper = self.make_wrapper()
-		self.invalid = (self.wrapper == None)
+		self.invalid = (self.wrapper is None)
 
 	def num_children(self):
 		logger = lldb.formatters.Logger.Logger()
-		if self.wrapper == None:
+		if self.wrapper is None:
 			return 0;
 		return self.wrapper.num_children()
 
 	def update(self):
 		logger = lldb.formatters.Logger.Logger()
-		if self.wrapper == None:
+		if self.wrapper is None:
 			return
 		self.wrapper.update()
 
@@ -190,7 +190,7 @@ def CFArray_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "provider gave me " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSArray>'
 		elif isinstance(summary,basestring):
 			pass

--- a/examples/summaries/cocoa/CFBag.py
+++ b/examples/summaries/cocoa/CFBag.py
@@ -115,7 +115,7 @@ def GetSummary_Impl(valobj):
 def CFBag_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -128,7 +128,7 @@ def CFBag_SummaryProvider (valobj,dict):
 		# the bit mask was derived through experimentation
 		# (if counts start looking weird, then most probably
 		#  the mask needs to be changed)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not CFBag>'
 		elif isinstance(summary,basestring):
 			pass

--- a/examples/summaries/cocoa/CFBinaryHeap.py
+++ b/examples/summaries/cocoa/CFBinaryHeap.py
@@ -111,7 +111,7 @@ def GetSummary_Impl(valobj):
 def CFBinaryHeap_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -124,7 +124,7 @@ def CFBinaryHeap_SummaryProvider (valobj,dict):
 		# the bit mask was derived through experimentation
 		# (if counts start looking weird, then most probably
 		#  the mask needs to be changed)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not CFBinaryHeap>'
 		elif isinstance(summary,basestring):
 			pass

--- a/examples/summaries/cocoa/CFBitVector.py
+++ b/examples/summaries/cocoa/CFBitVector.py
@@ -83,7 +83,7 @@ class CFBitVectorKnown_SummaryProvider:
 		data_list = []
 		cur_byte_pos = None
 		for i in range(0,count):
-			if cur_byte_pos == None:
+			if cur_byte_pos is None:
 				cur_byte_pos = byte_index(i)
 				cur_byte = grab_array_item_data(array_vo,cur_byte_pos)
 				cur_byte_val = cur_byte.uint8[0]
@@ -158,7 +158,7 @@ def GetSummary_Impl(valobj):
 def CFBitVector_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -166,7 +166,7 @@ def CFBitVector_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "summary got from provider: " + str(summary)
-		if summary == None or summary == '':
+		if summary is None or summary == '':
 			summary = '<variable is not CFBitVector>'
 		return summary
 	return 'Summary Unavailable'

--- a/examples/summaries/cocoa/CFDictionary.py
+++ b/examples/summaries/cocoa/CFDictionary.py
@@ -90,7 +90,7 @@ class NSDictionaryI_SummaryProvider:
 							self.offset(),
 							self.sys_params.types_cache.NSUInteger)
 		value = num_children_vo.GetValueAsUnsigned(0)
-		if value != None:
+		if value is not None:
 			# the MS6bits on immutable dictionaries seem to be taken by the LSB of capacity
 			# not sure if it is a bug or some weird sort of feature, but masking that out
 			# gets the count right
@@ -129,7 +129,7 @@ class NSDictionaryM_SummaryProvider:
 							self.offset(),
 							self.sys_params.types_cache.NSUInteger)
 		value = num_children_vo.GetValueAsUnsigned(0)
-		if value != None:
+		if value is not None:
 			# the MS6bits on immutable dictionaries seem to be taken by the LSB of capacity
 			# not sure if it is a bug or some weird sort of feature, but masking that out
 			# gets the count right
@@ -191,7 +191,7 @@ def GetSummary_Impl(valobj):
 def CFDictionary_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -199,7 +199,7 @@ def CFDictionary_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None:
+		if summary is None:
 			return '<variable is not NSDictionary>'
 		if isinstance(summary,basestring):
 			return summary
@@ -209,7 +209,7 @@ def CFDictionary_SummaryProvider (valobj,dict):
 def CFDictionary_SummaryProvider2 (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -217,7 +217,7 @@ def CFDictionary_SummaryProvider2 (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not CFDictionary>'
 		if isinstance(summary,basestring):
 			return summary

--- a/examples/summaries/cocoa/CFString.py
+++ b/examples/summaries/cocoa/CFString.py
@@ -23,7 +23,7 @@ def CFString_SummaryProvider (valobj,dict):
 				summary = '"' + summary + '"'
 		except:
 			summary = None
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSString>'
 		return '@'+summary
 	return ''
@@ -33,7 +33,7 @@ def CFAttributedString_SummaryProvider (valobj,dict):
 	offset = valobj.GetTarget().GetProcess().GetAddressByteSize()
 	pointee = valobj.GetValueAsUnsigned(0)
 	summary = '<variable is not NSAttributedString>'
-	if pointee != None and pointee != 0:
+	if pointee is not None and pointee != 0:
 		pointee = pointee + offset
 		child_ptr = valobj.CreateValueFromAddress("string_ptr",pointee,valobj.GetType())
 		child = child_ptr.CreateValueFromAddress("string_data",child_ptr.GetValueAsUnsigned(),valobj.GetType()).AddressOf()
@@ -43,7 +43,7 @@ def CFAttributedString_SummaryProvider (valobj,dict):
 				summary = provider.get_child_at_index(provider.get_child_index("content")).GetSummary();
 			except:
 				summary = '<variable is not NSAttributedString>'
-	if summary == None:
+	if summary is None:
 		summary = '<variable is not NSAttributedString>'
 	return '@'+summary
 
@@ -262,7 +262,7 @@ class CFStringSynthProvider:
 					self.valobj.GetType().GetBasicType(lldb.eBasicTypeChar));
 		cfinfo.SetFormat(11)
 		info = cfinfo.GetValue();
-		if info != None:
+		if info is not None:
 			self.invalid = False;
 			return int(info,0);
 		else:
@@ -311,7 +311,7 @@ class CFStringSynthProvider:
 	def compute_flags(self):
 		logger = lldb.formatters.Logger.Logger()
 		self.info_bits = self.read_info_bits();
-		if self.info_bits == None:
+		if self.info_bits is None:
 			return;
 		self.mutable = self.is_mutable();
 		self.inline = self.is_inline();

--- a/examples/summaries/cocoa/Class.py
+++ b/examples/summaries/cocoa/Class.py
@@ -12,10 +12,10 @@ import lldb.formatters.Logger
 def Class_Summary(valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	runtime =lldb.runtime.objc.objc_runtime.ObjCRuntime.runtime_from_isa(valobj)
-	if runtime == None or not runtime.is_valid():
+	if runtime is None or not runtime.is_valid():
 		return '<error: unknown Class>'
 	class_data = runtime.read_class_data()
-	if class_data == None or not class_data.is_valid():
+	if class_data is None or not class_data.is_valid():
 		return '<error: unknown Class>'
 	return class_data.class_name()
 

--- a/examples/summaries/cocoa/Logger.py
+++ b/examples/summaries/cocoa/Logger.py
@@ -43,17 +43,17 @@ class FileLogger:
 				pass
 
 	def write(self,data):
-		if self.file != None:
+		if self.file is not None:
 			print(data,file=self.file)
 		else:
 			print(data)
 
 	def flush(self):
-		if self.file != None:
+		if self.file is not None:
 			self.file.flush()
 
 	def close(self):
-		if self.file != None:
+		if self.file is not None:
 			self.file.close()
 			self.file = None
 
@@ -77,7 +77,7 @@ class Logger:
 			return
 		want_file = False
 		try:
-			want_file = (_lldb_formatters_debug_filename != None and _lldb_formatters_debug_filename != '' and _lldb_formatters_debug_filename != 0)
+			want_file = (_lldb_formatters_debug_filename is not None and _lldb_formatters_debug_filename != '' and _lldb_formatters_debug_filename != 0)
 		except:
 			pass
 		if want_file:
@@ -99,7 +99,7 @@ class Logger:
 	def _log_caller(self):
 		caller = inspect.stack()[2]
 		try:
-			if caller != None and len(caller) > 3:
+			if caller is not None and len(caller) > 3:
 				self.write('Logging from function ' + str(caller))
 			else:
 				self.write('Caller info not available - Required caller logging not possible')

--- a/examples/summaries/cocoa/NSBundle.py
+++ b/examples/summaries/cocoa/NSBundle.py
@@ -53,7 +53,7 @@ class NSBundleKnown_SummaryProvider:
 							self.offset(),
 							self.sys_params.types_cache.NSString)
 		my_string = text.GetSummary()
-		if (my_string == None) or (my_string == ''):
+		if (my_string is None) or (my_string == ''):
 			statistics.metric_hit('unknown_class',str(self.valobj.GetName()) + " triggered unknown pointer location")
 			return NSBundleUnknown_SummaryProvider(self.valobj, self.sys_params).url_text()
 		else:
@@ -110,7 +110,7 @@ def GetSummary_Impl(valobj):
 def NSBundle_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -118,7 +118,7 @@ def NSBundle_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None or summary == '':
+		if summary is None or summary == '':
 			summary = '<variable is not NSBundle>'
 		return summary
 	return 'Summary Unavailable'

--- a/examples/summaries/cocoa/NSData.py
+++ b/examples/summaries/cocoa/NSData.py
@@ -115,13 +115,13 @@ def NSData_SummaryProvider (valobj,dict):
 	logger >> "NSData_SummaryProvider"
 	provider = GetSummary_Impl(valobj);
 	logger >> "found a summary provider, it is: " + str(provider)
-	if provider != None:
+	if provider is not None:
 		try:
 			summary = provider.length();
 		except:
 			summary = None
 		logger >> "got a summary: it is " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSData>'
 		elif isinstance(summary,basestring):
 			pass
@@ -138,7 +138,7 @@ def NSData_SummaryProvider2 (valobj,dict):
 	logger >> "NSData_SummaryProvider2"
 	provider = GetSummary_Impl(valobj);
 	logger >> "found a summary provider, it is: " + str(provider)
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -146,7 +146,7 @@ def NSData_SummaryProvider2 (valobj,dict):
 		except:
 			summary = None
 		logger >> "got a summary: it is " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not CFData>'
 		elif isinstance(summary,basestring):
 			pass

--- a/examples/summaries/cocoa/NSDate.py
+++ b/examples/summaries/cocoa/NSDate.py
@@ -224,14 +224,14 @@ def GetSummary_Impl(valobj):
 def NSDate_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
 			summary = provider.value();
 		except:
 			summary = None
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSDate>'
 		return str(summary)
 	return 'Summary Unavailable'
@@ -239,7 +239,7 @@ def NSDate_SummaryProvider (valobj,dict):
 def NSTimeZone_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -247,7 +247,7 @@ def NSTimeZone_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSTimeZone>'
 		return str(summary)
 	return 'Summary Unavailable'

--- a/examples/summaries/cocoa/NSException.py
+++ b/examples/summaries/cocoa/NSException.py
@@ -97,7 +97,7 @@ def GetSummary_Impl(valobj):
 def NSException_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -105,7 +105,7 @@ def NSException_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSException>'
 		return str(summary)
 	return 'Summary Unavailable'

--- a/examples/summaries/cocoa/NSIndexSet.py
+++ b/examples/summaries/cocoa/NSIndexSet.py
@@ -128,7 +128,7 @@ def GetSummary_Impl(valobj):
 def NSIndexSet_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -136,7 +136,7 @@ def NSIndexSet_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSIndexSet>'
 		if isinstance(summary, basestring):
 			return summary

--- a/examples/summaries/cocoa/NSMachPort.py
+++ b/examples/summaries/cocoa/NSMachPort.py
@@ -104,7 +104,7 @@ def GetSummary_Impl(valobj):
 def NSMachPort_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -112,7 +112,7 @@ def NSMachPort_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSMachPort>'
 		if isinstance(summary, basestring):
 			return summay

--- a/examples/summaries/cocoa/NSNotification.py
+++ b/examples/summaries/cocoa/NSNotification.py
@@ -93,7 +93,7 @@ def GetSummary_Impl(valobj):
 def NSNotification_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -101,7 +101,7 @@ def NSNotification_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSNotification>'
 		return str(summary)
 	return 'Summary Unavailable'

--- a/examples/summaries/cocoa/NSNumber.py
+++ b/examples/summaries/cocoa/NSNumber.py
@@ -212,7 +212,7 @@ def GetSummary_Impl(valobj):
 def NSNumber_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -222,7 +222,7 @@ def NSNumber_SummaryProvider (valobj,dict):
 #		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSNumber>'
 		return str(summary)
 	return 'Summary Unavailable'

--- a/examples/summaries/cocoa/NSSet.py
+++ b/examples/summaries/cocoa/NSSet.py
@@ -113,7 +113,7 @@ class NSSetI_SummaryProvider:
 							self.offset(),
 							self.sys_params.types_cache.NSUInteger)
 		value = num_children_vo.GetValueAsUnsigned(0)
-		if value != None:
+		if value is not None:
 			# the MSB on immutable sets seems to be taken by some other data
 			# not sure if it is a bug or some weird sort of feature, but masking it out
 			# gets the count right (unless, of course, someone's dictionaries grow
@@ -216,12 +216,12 @@ def GetSummary_Impl(valobj):
 def NSSet_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		try:
 			summary = provider.count();
 		except:
 			summary = None
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not NSSet>'
 		if isinstance(summary, basestring):
 			return summary
@@ -233,7 +233,7 @@ def NSSet_SummaryProvider (valobj,dict):
 def NSSet_SummaryProvider2 (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -246,7 +246,7 @@ def NSSet_SummaryProvider2 (valobj,dict):
 		# this only happens on 64bit, and the bit mask was derived through
 		# experimentation (if counts start looking weird, then most probably
 		#                  the mask needs to be changed)
-		if summary == None:
+		if summary is None:
 			summary = '<variable is not CFSet>'
 		if isinstance(summary, basestring):
 			return summary

--- a/examples/summaries/cocoa/NSURL.py
+++ b/examples/summaries/cocoa/NSURL.py
@@ -120,7 +120,7 @@ def GetSummary_Impl(valobj):
 def NSURL_SummaryProvider (valobj,dict):
 	logger = lldb.formatters.Logger.Logger()
 	provider = GetSummary_Impl(valobj);
-	if provider != None:
+	if provider is not None:
 		if isinstance(provider,lldb.runtime.objc.objc_runtime.SpecialSituation_Description):
 			return provider.message()
 		try:
@@ -128,7 +128,7 @@ def NSURL_SummaryProvider (valobj,dict):
 		except:
 			summary = None
 		logger >> "got summary " + str(summary)
-		if summary == None or summary == '':
+		if summary is None or summary == '':
 			summary = '<variable is not NSURL>'
 		return summary
 	return 'Summary Unavailable'

--- a/examples/summaries/cocoa/objc_runtime.py
+++ b/examples/summaries/cocoa/objc_runtime.py
@@ -204,7 +204,7 @@ class RwT_Data:
 class Class_Data_V2:
 	def __init__(self,isa_pointer,params):
 		logger = lldb.formatters.Logger.Logger()
-		if (isa_pointer != None) and (Utilities.is_valid_pointer(isa_pointer.GetValueAsUnsigned(),params.pointer_size, allow_tagged=0)):
+		if (isa_pointer is not None) and (Utilities.is_valid_pointer(isa_pointer.GetValueAsUnsigned(),params.pointer_size, allow_tagged=0)):
 			self.sys_params = params
 			self.valobj = isa_pointer
 			self.check_valid()
@@ -325,7 +325,7 @@ class Class_Data_V2:
 class Class_Data_V1:
 	def __init__(self,isa_pointer,params):
 		logger = lldb.formatters.Logger.Logger()
-		if (isa_pointer != None) and (Utilities.is_valid_pointer(isa_pointer.GetValueAsUnsigned(),params.pointer_size, allow_tagged=0)):
+		if (isa_pointer is not None) and (Utilities.is_valid_pointer(isa_pointer.GetValueAsUnsigned(),params.pointer_size, allow_tagged=0)):
 			self.valid = 1
 			self.sys_params = params
 			self.valobj = isa_pointer
@@ -657,7 +657,7 @@ class ObjCRuntime:
 			if section.GetName() == '__OBJC':
 				section_objc = section
 				break
-		if section_objc != None and section_objc.IsValid():
+		if section_objc is not None and section_objc.IsValid():
 			logger >> "found __OBJC: v1"
 			return 1
 		logger >> "no __OBJC: v2"
@@ -702,7 +702,7 @@ class ObjCRuntime:
 
 	def read_isa(self):
 		logger = lldb.formatters.Logger.Logger()
-		if self.isa_value != None:
+		if self.isa_value is not None:
 			logger >> "using cached isa"
 			return self.isa_value
 		self.isa_pointer = self.valobj.CreateChildAtOffset("cfisa",
@@ -740,7 +740,7 @@ class ObjCRuntime:
 		if self.is_valid() == 0 or self.read_isa() is None:
 			return InvalidClass_Data()
 		data = self.sys_params.isa_cache.get_value(self.isa_value,default=None)
-		if data != None:
+		if data is not None:
 			return data
 		if self.sys_params.runtime_version == 2:
 			data = Class_Data_V2(self.isa_pointer,self.sys_params)

--- a/examples/summaries/pysummary.py
+++ b/examples/summaries/pysummary.py
@@ -1,7 +1,7 @@
 import lldb
 
 def pyobj_summary (value,unused):
-	if value == None or value.IsValid() == False or value.GetValueAsUnsigned(0) == 0:
+	if value is None or value.IsValid() == False or value.GetValueAsUnsigned(0) == 0:
 		return "<invalid>"
 	refcnt = value.GetChildMemberWithName("ob_refcnt")
 	expr = "(char*)PyString_AsString( (PyObject*)PyObject_Str( (PyObject*)0x%x) )" % (value.GetValueAsUnsigned(0))

--- a/examples/synthetic/gnu_libstdcpp.py
+++ b/examples/synthetic/gnu_libstdcpp.py
@@ -149,7 +149,7 @@ class StdVectorSynthProvider:
 			self.count = None
 
 		def num_children(self):
-			if self.count == None:
+			if self.count is None:
 				self.count = self.num_children_impl()
 			return self.count
 
@@ -353,7 +353,7 @@ class StdMapSynthProvider:
 
 	def num_children(self):
 		logger = lldb.formatters.Logger.Logger()
-		if self.count == None:
+		if self.count is None:
 			self.count = self.num_children_impl()
 		return self.count
 

--- a/examples/synthetic/libcxx.py
+++ b/examples/synthetic/libcxx.py
@@ -47,7 +47,7 @@ def stdstring_SummaryProvider(valobj,dict):
 		data_ptr = l.GetChildAtIndex(2)
 		size_vo = l.GetChildAtIndex(1)
 		size = size_vo.GetValueAsUnsigned(0)+1 # the NULL terminator must be accounted for
-		if size <= 1 or size == None: # should never be the case
+		if size <= 1 or size is None: # should never be the case
 			return '""'
 		try:
 			data = data_ptr.GetPointeeData(0,size)
@@ -185,7 +185,7 @@ class stdlist_iterator:
 	def next(self):
 		logger = lldb.formatters.Logger.Logger()
 		node = self.increment_node(self.node)
-		if node != None and node.sbvalue.IsValid() and not(node.is_null):
+		if node is not None and node.sbvalue.IsValid() and not(node.is_null):
 			self.node = node
 			return self.value()
 		else:
@@ -242,7 +242,7 @@ class stdlist_SynthProvider:
 	def num_children(self):
 		global _list_capping_size
 		logger = lldb.formatters.Logger.Logger()
-		if self.count == None:
+		if self.count is None:
 			self.count = self.num_children_impl()
 			if self.count > _list_capping_size:
 				self.count = _list_capping_size
@@ -426,7 +426,7 @@ class stdmap_iterator:
 	def next(self):
 		logger = lldb.formatters.Logger.Logger()
 		node = self.increment_node(self.node)
-		if node != None and node.sbvalue.IsValid() and not(node.is_null):
+		if node is not None and node.sbvalue.IsValid() and not(node.is_null):
 			self.node = node
 			return self.value()
 		else:
@@ -441,7 +441,7 @@ class stdmap_iterator:
 		if N == 1:
 			return self.next()
 		while N > 0:
-			if self.next() == None:
+			if self.next() is None:
 				return None
 			N = N - 1
 		return self.value()
@@ -474,7 +474,7 @@ class stdmap_SynthProvider:
 	def num_children(self):
 		global _map_capping_size
 		logger = lldb.formatters.Logger.Logger()
-		if self.count == None:
+		if self.count is None:
 			self.count = self.num_children_impl()
 			if self.count > _map_capping_size:
 				self.count = _map_capping_size
@@ -492,7 +492,7 @@ class stdmap_SynthProvider:
 
 	def get_data_type(self):
 		logger = lldb.formatters.Logger.Logger()
-		if self.data_type == None or self.data_size == None:
+		if self.data_type is None or self.data_size is None:
 			if self.num_children() == 0:
 				return False
 			deref = self.root_node.Dereference()
@@ -510,7 +510,7 @@ class stdmap_SynthProvider:
 
 	def get_value_offset(self,node):
 		logger = lldb.formatters.Logger.Logger()
-		if self.skip_size == None:
+		if self.skip_size is None:
 			node_type = node.GetType()
 			fields_count = node_type.GetNumberOfFields()
 			for i in range(fields_count):
@@ -518,7 +518,7 @@ class stdmap_SynthProvider:
 				if field.GetName() == '__value_':
 					self.skip_size = field.GetOffsetInBytes()
 					break
-		return (self.skip_size != None)
+		return (self.skip_size is not None)
 
 	def get_child_index(self,name):
 		logger = lldb.formatters.Logger.Logger()
@@ -545,7 +545,7 @@ class stdmap_SynthProvider:
 			# hence, we need to know if we are at a node != 0, so that we can still get at the data
 			need_to_skip = (index > 0)
 			current = iterator.advance(index)
-			if current == None:
+			if current is None:
 				logger >> "Tree is garbage - returning None"
 				self.garbage = True
 				return None
@@ -560,7 +560,7 @@ class stdmap_SynthProvider:
 					return self.valobj.CreateValueFromData('[' + str(index) + ']',obj_data,self.data_type)
 				else:
 					# FIXME we need to have accessed item 0 before accessing any other item!
-					if self.skip_size == None:
+					if self.skip_size is None:
 						logger >> "You asked for item > 0 before asking for item == 0, I will fetch 0 now then retry"
 						if self.get_child_at_index(0):
 							return self.get_child_at_index(index)
@@ -738,7 +738,7 @@ class stdsharedptr_SynthProvider:
         if index == 0:
             return self.ptr
         if index == 1:
-            if self.cntrl == None:
+            if self.cntrl is None:
                 count = 0
             else:
                 count = 1 + self.cntrl.GetChildMemberWithName('__shared_owners_').GetValueAsSigned()
@@ -746,7 +746,7 @@ class stdsharedptr_SynthProvider:
                                                    lldb.SBData.CreateDataFromUInt64Array(self.endianness, self.pointer_size, [count]),
                                                    self.count_type)
         if index == 2:
-            if self.cntrl == None:
+            if self.cntrl is None:
                 count = 0
             else:
                 count = 1 + self.cntrl.GetChildMemberWithName('__shared_weak_owners_').GetValueAsSigned()

--- a/packages/Python/lldbsuite/test/attic/tester.py
+++ b/packages/Python/lldbsuite/test/attic/tester.py
@@ -39,7 +39,7 @@ def prettyTime(t):
 class ExecutionTimes:
   @classmethod
   def executionTimes(cls):
-    if cls.m_executionTimes == None:
+    if cls.m_executionTimes is None:
       cls.m_executionTimes = ExecutionTimes()
       for i in range(100):
         cls.m_executionTimes.start()

--- a/packages/Python/lldbsuite/test/driver/batch_mode/TestBatchMode.py
+++ b/packages/Python/lldbsuite/test/driver/batch_mode/TestBatchMode.py
@@ -101,7 +101,7 @@ class DriverBatchModeTest (TestBase):
         self.assertTrue(index == 0, "lldb didn't close on successful batch completion.")
 
     def closeVictim(self):
-        if self.victim != None:
+        if self.victim is not None:
             self.victim.close()
             self.victim = None
 
@@ -125,7 +125,7 @@ class DriverBatchModeTest (TestBase):
         # Start up the process by hand and wait for it to get to the wait loop.
 
         self.victim = pexpect.spawn('%s WAIT' %(exe))
-        if self.victim == None:
+        if self.victim is None:
             self.fail("Could not spawn ", exe, ".")
 
         self.addTearDownHook (self.closeVictim)
@@ -134,7 +134,7 @@ class DriverBatchModeTest (TestBase):
             self.victim.logfile_read = sys.stdout
 
         self.victim.expect("PID: ([0-9]+) END")
-        if self.victim.match == None:
+        if self.victim.match is None:
             self.fail("Couldn't get the target PID.")
 
         victim_pid = int(self.victim.match.group(1))

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/format-propagation/TestFormatPropagation.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/format-propagation/TestFormatPropagation.py
@@ -47,11 +47,11 @@ class FormatPropagationTestCase(TestBase):
         # extract the parent and the children
         frame = self.frame()
         parent = self.frame().FindVariable("f")
-        self.assertTrue(parent != None and parent.IsValid(),"could not find f")
+        self.assertTrue(parent is not None and parent.IsValid(),"could not find f")
         X = parent.GetChildMemberWithName("X")
-        self.assertTrue(X != None and X.IsValid(),"could not find X")
+        self.assertTrue(X is not None and X.IsValid(),"could not find X")
         Y = parent.GetChildMemberWithName("Y")
-        self.assertTrue(Y != None and Y.IsValid(),"could not find Y")
+        self.assertTrue(Y is not None and Y.IsValid(),"could not find Y")
         # check their values now
         self.assertTrue(X.GetValue() == "1", "X has an invalid value")
         self.assertTrue(Y.GetValue() == "2", "Y has an invalid value")

--- a/packages/Python/lldbsuite/test/functionalities/paths/TestPaths.py
+++ b/packages/Python/lldbsuite/test/functionalities/paths/TestPaths.py
@@ -29,7 +29,7 @@ class TestPaths(TestBase):
         for path_type in dir_path_types:
             f = lldb.SBHostOS.GetLLDBPath(path_type);
             # No directory path types should have the filename set
-            self.assertTrue (f.GetFilename() == None);
+            self.assertTrue (f.GetFilename() is None);
 
     @no_debug_info_test
     def test_directory_doesnt_end_with_slash(self):

--- a/packages/Python/lldbsuite/test/functionalities/plugins/python_os_plugin/operating_system.py
+++ b/packages/Python/lldbsuite/test/functionalities/plugins/python_os_plugin/operating_system.py
@@ -57,7 +57,7 @@ class OperatingSystemPlugIn(object):
         return self.threads
     
     def get_register_info(self):
-        if self.registers == None:
+        if self.registers is None:
             self.registers = dict()            
             self.registers['sets'] = ['GPR']
             self.registers['registers'] = [

--- a/packages/Python/lldbsuite/test/functionalities/plugins/python_os_plugin/operating_system2.py
+++ b/packages/Python/lldbsuite/test/functionalities/plugins/python_os_plugin/operating_system2.py
@@ -55,7 +55,7 @@ class OperatingSystemPlugIn(object):
         return self.threads
     
     def get_register_info(self):
-        if self.registers == None:
+        if self.registers is None:
             self.registers = dict()            
             self.registers['sets'] = ['GPR']
             self.registers['registers'] = [

--- a/packages/Python/lldbsuite/test/functionalities/thread/create_during_step/TestCreateDuringStep.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/create_during_step/TestCreateDuringStep.py
@@ -94,7 +94,7 @@ class CreateDuringStepTestCase(TestBase):
             if expected_bp_desc in thread.GetStopDescription(100):
                 stepping_thread = thread
                 break
-        self.assertTrue(stepping_thread != None, "unable to find thread stopped at %s" % expected_bp_desc)
+        self.assertTrue(stepping_thread is not None, "unable to find thread stopped at %s" % expected_bp_desc)
         current_line = self.breakpoint
         # Keep stepping until we've reached our designated continue point
         while current_line != self.continuepoint:

--- a/packages/Python/lldbsuite/test/functionalities/thread/exit_during_step/TestExitDuringStep.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/exit_during_step/TestExitDuringStep.py
@@ -102,7 +102,7 @@ class ExitDuringStepTestCase(TestBase):
             if stop_desc and (expected_bp_desc in stop_desc):
                 stepping_thread = thread
                 break
-        self.assertTrue(stepping_thread != None, "unable to find thread stopped at %s" % expected_bp_desc)
+        self.assertTrue(stepping_thread is not None, "unable to find thread stopped at %s" % expected_bp_desc)
 
         current_line = self.breakpoint
         stepping_frame = stepping_thread.GetFrameAtIndex(0)

--- a/packages/Python/lldbsuite/test/lang/objc/foundation/TestFoundationDisassembly.py
+++ b/packages/Python/lldbsuite/test/lang/objc/foundation/TestFoundationDisassembly.py
@@ -42,7 +42,7 @@ class FoundationDisassembleTestCase(TestBase):
                 foundation_framework = module.file.fullpath
                 break
 
-        self.assertTrue(foundation_framework != None, "Foundation.framework path located")
+        self.assertTrue(foundation_framework is not None, "Foundation.framework path located")
         self.runCmd("image dump symtab '%s'" % foundation_framework)
         raw_output = self.res.GetOutput()
         # Now, grab every 'Code' symbol and feed it into the command:

--- a/packages/Python/lldbsuite/test/lang/swift/variables/globals/TestSwiftGlobals.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/globals/TestSwiftGlobals.py
@@ -87,7 +87,7 @@ class TestSwiftGlobals(TestBase):
         self.assertTrue(my_large_dude.IsValid(), "my_large_dude returned a valid value object.")
         value = my_large_dude.GetValue()
         self.assertTrue(error.Success(), "Got a value for my_large_dude")
-        self.assertTrue(value == None, "my_large_dude value is the uninitialized one.")
+        self.assertTrue(value is None, "my_large_dude value is the uninitialized one.")
 
         # Now proceed to the breakpoint in our main function, make sure we can
         # still read these variables and they now have the right values.

--- a/packages/Python/lldbsuite/test/lldbinline.py
+++ b/packages/Python/lldbsuite/test/lldbinline.py
@@ -56,8 +56,8 @@ class CommandParser:
                 if new_breakpoint:
                     current_breakpoint = None
 
-                if command != None:
-                    if current_breakpoint == None:
+                if command is not None:
+                    if current_breakpoint is None:
                         current_breakpoint = {}
                         current_breakpoint['file_name'] = source_file
                         current_breakpoint['line_number'] = line_number

--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -298,20 +298,20 @@ class _LocalProcess(_BaseProcess):
                            stdin = PIPE)
 
     def terminate(self):
-        if self._proc.poll() == None:
+        if self._proc.poll() is None:
             # Terminate _proc like it does the pexpect
             signals_to_try = [sig for sig in ['SIGHUP', 'SIGCONT', 'SIGINT'] if sig in dir(signal)]
             for sig in signals_to_try:
                 try:
                     self._proc.send_signal(getattr(signal, sig))
                     time.sleep(self._delayafterterminate)
-                    if self._proc.poll() != None:
+                    if self._proc.poll() is not None:
                         return
                 except ValueError:
                     pass  # Windows says SIGINT is not a valid signal to send
             self._proc.terminate()
             time.sleep(self._delayafterterminate)
-            if self._proc.poll() != None:
+            if self._proc.poll() is not None:
                 return
             self._proc.kill()
             time.sleep(self._delayafterterminate)
@@ -1733,7 +1733,7 @@ class Base(unittest2.TestCase):
             # False because there's no need to write "expected failure" to the
             # stderr twice.
             # Once by the Python unittest framework, and a second time by us.
-            if bugnumber == None:
+            if bugnumber is None:
                 print("expected failure", file=sbuf)
             else:
                 print("expected failure (problem id:" + str(bugnumber) + ")", file=sbuf)
@@ -1754,7 +1754,7 @@ class Base(unittest2.TestCase):
             # False because there's no need to write "unexpected success" to the
             # stderr twice.
             # Once by the Python unittest framework, and a second time by us.
-            if bugnumber == None:
+            if bugnumber is None:
                 print("unexpected success", file=sbuf)
             else:
                 print("unexpected success (problem id:" + str(bugnumber) + ")", file=sbuf)
@@ -1976,12 +1976,12 @@ class Base(unittest2.TestCase):
            Any operator other than the following defaults to an equality test:
              '>', '>=', "=>", '<', '<=', '=<', '!=', "!" or 'not'
         """
-        if (compiler_version == None):
+        if (compiler_version is None):
             return True
         operator = str(compiler_version[0])
         version = compiler_version[1]
 
-        if (version == None):
+        if (version is None):
             return True
         if (operator == '>'):
             return self.getCompilerVersion() > version
@@ -1997,7 +1997,7 @@ class Base(unittest2.TestCase):
 
     def expectedCompiler(self, compilers):
         """Returns True iff any element of compilers is a sub-string of the current compiler."""
-        if (compilers == None):
+        if (compilers is None):
             return True
 
         for compiler in compilers:
@@ -2008,7 +2008,7 @@ class Base(unittest2.TestCase):
 
     def expectedArch(self, archs):
         """Returns True iff any element of archs is a sub-string of the current architecture."""
-        if (archs == None):
+        if (archs is None):
             return True
 
         for arch in archs:

--- a/packages/Python/lldbsuite/test/lldbutil.py
+++ b/packages/Python/lldbsuite/test/lldbutil.py
@@ -322,7 +322,7 @@ def run_break_set_by_file_and_line (test, file_name, line_number, extra_options 
 
     If loc_exact is true, we check that there is one location, and that location must be at the input file and line number."""
 
-    if file_name == None:
+    if file_name is None:
         command = 'breakpoint set -l %d'%(line_number)
     else:
         command = 'breakpoint set -f "%s" -l %d'%(file_name, line_number)
@@ -884,9 +884,9 @@ class BasicFormatter(object):
         # If there is a summary, it suffices.
         val = value.GetSummary()
         # Otherwise, get the value.
-        if val == None:
+        if val is None:
             val = value.GetValue()
-        if val == None and value.GetNumChildren() > 0:
+        if val is None and value.GetNumChildren() > 0:
             val = "%s (location)" % value.GetLocation()
         print("{indentation}({type}) {name} = {value}".format(
             indentation = ' ' * indent,
@@ -935,7 +935,7 @@ class RecursiveDecentFormatter(BasicFormatter):
         BasicFormatter.format(self, value, buffer=output, indent=self.lindent)
         new_indent = self.lindent + self.cindent
         for child in value:
-            if child.GetSummary() != None:
+            if child.GetSummary() is not None:
                 BasicFormatter.format(self, child, buffer=output, indent=new_indent)
             else:
                 if child.GetNumChildren() > 0:

--- a/packages/Python/lldbsuite/test/python_api/event/TestEvents.py
+++ b/packages/Python/lldbsuite/test/python_api/event/TestEvents.py
@@ -248,11 +248,11 @@ class EventAPITestCase(TestBase):
                         if match.group(1) == 'connected':
                             # When debugging remote targets with lldb-server, we
                             # first get the 'connected' event.
-                            self.context.assertTrue(self.context.state == None)
+                            self.context.assertTrue(self.context.state is None)
                             self.context.state = 'connected'
                             continue
                         elif match.group(1) == 'running':
-                            self.context.assertTrue(self.context.state == None or self.context.state == 'connected')
+                            self.context.assertTrue(self.context.state is None or self.context.state == 'connected')
                             self.context.state = 'running'
                             continue
                         elif match.group(1) == 'stopped':

--- a/packages/Python/lldbsuite/test/python_api/value/change_values/TestChangeValueAPI.py
+++ b/packages/Python/lldbsuite/test/python_api/value/change_values/TestChangeValueAPI.py
@@ -144,6 +144,6 @@ class ChangeValueAPITestCase(TestBase):
 
         self.assertTrue(process.GetState() == lldb.eStateStopped)
         thread = lldbutil.get_stopped_thread(process, lldb.eStopReasonBreakpoint)
-        self.assertTrue(thread == None, "We should not have managed to hit our second breakpoint with sp == 1")
+        self.assertTrue(thread is None, "We should not have managed to hit our second breakpoint with sp == 1")
         
         process.Kill()

--- a/packages/Python/lldbsuite/test/test_categories.py
+++ b/packages/Python/lldbsuite/test/test_categories.py
@@ -61,7 +61,7 @@ def validate(categories, exact_match):
         origCategory = category
         if category not in all_categories and not exact_match:
             category = unique_string_match(category, all_categories)
-        if (category not in all_categories) or category == None:
+        if (category not in all_categories) or category is None:
             print("fatal error: category '" + origCategory + "' is not a valid category")
             print("if you have added a new category, please edit test_categories.py, adding your new category to all_categories")
             print("else, please specify one or more of the following: " + str(list(all_categories.keys())))

--- a/packages/Python/lldbsuite/test/test_result.py
+++ b/packages/Python/lldbsuite/test/test_result.py
@@ -103,7 +103,7 @@ class LLDBTestResult(unittest2.TextTestResult):
         """
         test_categories = []
         test_method = getattr(test, test._testMethodName)
-        if test_method != None and hasattr(test_method, "categories"):
+        if test_method is not None and hasattr(test_method, "categories"):
             test_categories.extend(test_method.categories)
 
         test_categories.extend(test.getCategories())

--- a/packages/Python/lldbsuite/test/tracking.py
+++ b/packages/Python/lldbsuite/test/tracking.py
@@ -53,7 +53,7 @@ global_radar_client = None
 
 def get_radar_details(id):
     global global_radar_client
-    if global_radar_client == None:
+    if global_radar_client is None:
         authentication_strategy = AuthenticationStrategySPNego()
         system_identifier = ClientSystemIdentifier('lldb-test-tracker', '1.0')
         global_radar_client = RadarClient(authentication_strategy, system_identifier)
@@ -82,8 +82,8 @@ def process_xfail(path):
     m1 = re.search('rdar://([0-9]+)', xfail_line)
     m2 = re.search('rdar://problem/([0-9]+)', xfail_line)
     m3 = re.search('llvm.org/pr([0-9]+)', xfail_line)
-    if m1 == None and m2 == None:
-        if m3 == None:
+    if m1 is None and m2 is None:
+        if m3 is None:
             process_no_bug(name,xfail_line)
         else:
             process_llvm_bug(name,m3)

--- a/scripts/Python/modify-python-lldb.py
+++ b/scripts/Python/modify-python-lldb.py
@@ -291,7 +291,7 @@ class NewContent(StringIO.StringIO):
         self.prev_line = None
     def add_line(self, a_line):
         """Add a line to the content, if there is a previous line, commit it."""
-        if self.prev_line != None:
+        if self.prev_line is not None:
             self.write(self.prev_line + "\n")
         self.prev_line = a_line
     def del_line(self):
@@ -299,11 +299,11 @@ class NewContent(StringIO.StringIO):
         self.prev_line = None
     def del_blank_line(self):
         """Forget about the previous line if it is a blank line."""
-        if self.prev_line != None and not self.prev_line.strip():
+        if self.prev_line is not None and not self.prev_line.strip():
             self.prev_line = None
     def finish(self):
         """Call this when you're finished with populating content."""
-        if self.prev_line != None:
+        if self.prev_line is not None:
             self.write(self.prev_line + "\n")
         self.prev_line = None
 

--- a/scripts/Python/remote-build.py
+++ b/scripts/Python/remote-build.py
@@ -243,7 +243,7 @@ def run_remote_build_command(args, build_command_list):
                     print(display_line, file=sys.stderr)
 
         proc_retval = proc.poll()
-        if proc_retval != None:
+        if proc_retval is not None:
             # Process stopped.  Drain output before finishing up.
 
             # Drain stdout.

--- a/scripts/Python/static-binding/lldb.py
+++ b/scripts/Python/static-binding/lldb.py
@@ -2783,19 +2783,19 @@ class SBData(_object):
             lldbtarget = lldbdict['target']
         else:
             lldbtarget = None
-        if target == None and lldbtarget != None and lldbtarget.IsValid():
+        if target is None and lldbtarget is not None and lldbtarget.IsValid():
             target = lldbtarget
-        if ptr_size == None:
+        if ptr_size is None:
             if target and target.IsValid():
                 ptr_size = target.addr_size
             else:
                 ptr_size = 8
-        if endian == None:
+        if endian is None:
             if target and target.IsValid():
                 endian = target.byte_order
             else:
                 endian = lldbdict['eByteOrderLittle']
-        if size == None:
+        if size is None:
             if value > 2147483647:
                 size = 8
             elif value < -2147483648:

--- a/scripts/Xcode/build-swift-repl.py
+++ b/scripts/Xcode/build-swift-repl.py
@@ -49,14 +49,14 @@ def swiftc_path():
 
 def swift_target():
     deployment_target = macosx_deployment_target()
-    if deployment_target != None:
+    if deployment_target is not None:
         return arch()+"-apple-macosx"+deployment_target
     else:
         return None
 
 def target_arg_for_repl():
     target = swift_target()
-    if target != None:
+    if target is not None:
         return ["-target", target]
     else:
         return []

--- a/scripts/Xcode/package-clang-headers.py
+++ b/scripts/Xcode/package-clang-headers.py
@@ -59,7 +59,7 @@ for subdir in os.listdir(clang_dir):
         version_dir = os.path.join(clang_dir, subdir)
         break
 
-if version_dir == None:
+if version_dir is None:
     print "Couldn't find a subdirectory of the form #(.#)... in " + clang_dir
     sys.exit(1)
 

--- a/scripts/build-in-jenkins.py
+++ b/scripts/build-in-jenkins.py
@@ -9,7 +9,7 @@ print "Running lldb build test as user: ", pwd.getpwuid(os.getuid()).pw_name
 
 # We get everything from the workspace environment variable, so if it is not set we're toast:
 workspace = os.getenv("WORKSPACE")
-if workspace == None:
+if workspace is None:
     print "WORKSPACE environment variable is not set.  Exiting."
     exit(-1)
 
@@ -63,7 +63,7 @@ if not os.path.isdir (llvm_in_lldb_dir):
     os.symlink (llvm_dir, llvm_in_lldb_dir)
 
 lldb_configuration = os.getenv("LLDB_CONFIGURATION")
-if lldb_configuration == None:
+if lldb_configuration is None:
     lldb_configuration = "BuildAndIntegration"
 
 lldb_arch = "x86_64"

--- a/scripts/buildbot.py
+++ b/scripts/buildbot.py
@@ -51,7 +51,7 @@ class LLDBBuildBot:
         
         cmdline_prefix = []
         
-        if self.m_revision != None:
+        if self.m_revision is not None:
             cmdline_prefix = ["svn", "-r %s" % (self.m_revision), "co"]
         else:
             cmdline_prefix = ["svn", "co"]

--- a/third_party/Python/module/pexpect-2.4/examples/passmass.py
+++ b/third_party/Python/module/pexpect-2.4/examples/passmass.py
@@ -74,7 +74,7 @@ def main():
 
     for host in sys.argv[1:]:
         child = login(host, user, password)
-        if child == None:
+        if child is None:
             print 'Could not login to host:', host
             continue
         print 'Changing password on host:', host

--- a/utils/lui/lldbutil.py
+++ b/utils/lui/lldbutil.py
@@ -316,7 +316,7 @@ def run_break_set_by_file_and_line (test, file_name, line_number, extra_options 
 
     If loc_exact is true, we check that there is one location, and that location must be at the input file and line number."""
 
-    if file_name == None:
+    if file_name is None:
         command = 'breakpoint set -l %d'%(line_number)
     else:
         command = 'breakpoint set -f "%s" -l %d'%(file_name, line_number)
@@ -836,9 +836,9 @@ class BasicFormatter(object):
         # If there is a summary, it suffices.
         val = value.GetSummary()
         # Otherwise, get the value.
-        if val == None:
+        if val is None:
             val = value.GetValue()
-        if val == None and value.GetNumChildren() > 0:
+        if val is None and value.GetNumChildren() > 0:
             val = "%s (location)" % value.GetLocation()
         print >> output, "{indentation}({type}) {name} = {value}".format(
             indentation = ' ' * indent,
@@ -887,7 +887,7 @@ class RecursiveDecentFormatter(BasicFormatter):
         BasicFormatter.format(self, value, buffer=output, indent=self.lindent)
         new_indent = self.lindent + self.cindent
         for child in value:
-            if child.GetSummary() != None:
+            if child.GetSummary() is not None:
                 BasicFormatter.format(self, child, buffer=output, indent=new_indent)
             else:
                 if child.GetNumChildren() > 0:

--- a/utils/misc/grep-svn-log.py
+++ b/utils/misc/grep-svn-log.py
@@ -25,7 +25,7 @@ class Log(StringIO.StringIO):
     def add_line(self, a_line):
         """Add a line to the content, if there is a previous line, commit it."""
         global separator
-        if self.prev_line != None:
+        if self.prev_line is not None:
             print >> self, self.prev_line
         self.prev_line = a_line
         self.separator_added = (a_line == separator)
@@ -38,7 +38,7 @@ class Log(StringIO.StringIO):
         self.prev_line = None
     def finish(self):
         """Call this when you're finished with populating content."""
-        if self.prev_line != None:
+        if self.prev_line is not None:
             print >> self, self.prev_line
         self.prev_line = None
 

--- a/utils/vim-lldb/python-vim-lldb/vim_panes.py
+++ b/utils/vim-lldb/python-vim-lldb/vim_panes.py
@@ -235,7 +235,7 @@ class VimPane(object):
 
   def isPrepared(self):
     """ check window is OK """
-    if self.buffer == None or len(dir(self.buffer)) == 0 or bufwinnr(self.name) == -1:
+    if self.buffer is None or len(dir(self.buffer)) == 0 or bufwinnr(self.name) == -1:
       return False
     return True
 
@@ -249,7 +249,7 @@ class VimPane(object):
 
   def destroy(self):
     """ destroy window """
-    if self.buffer == None or len(dir(self.buffer)) == 0:
+    if self.buffer is None or len(dir(self.buffer)) == 0:
       return
     vim.command('bdelete ' + self.name)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:swift-lldb?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:swift-lldb?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
