### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/third_party/Python/module/pexpect-2.4/examples/rippy.py
+++ b/third_party/Python/module/pexpect-2.4/examples/rippy.py
@@ -376,7 +376,7 @@ def apply_smart (func, args):
     if hasattr(func,'im_func'): # Handle case when func is a class method.
         func = func.im_func
     argcount = func.func_code.co_argcount
-    required_args = dict([(k,args.get(k)) for k in func.func_code.co_varnames[:argcount]])
+    required_args = {k: args.get(k) for k in func.func_code.co_varnames[:argcount]}
     return func(**required_args)
 
 def count_unique (items):

--- a/third_party/Python/module/pexpect-2.4/examples/topip.py
+++ b/third_party/Python/module/pexpect-2.4/examples/topip.py
@@ -199,8 +199,8 @@ def main():
         pass
 
     # remove a few common, uninteresting addresses from the dictionary.
-    ip_list = dict([ (key,value) for key,value in ip_list.items() if '192.168.' not in key])
-    ip_list = dict([ (key,value) for key,value in ip_list.items() if '127.0.0.1' not in key])
+    ip_list = {key: value for key,value in ip_list.items() if '192.168.' not in key}
+    ip_list = {key: value for key,value in ip_list.items() if '127.0.0.1' not in key}
 
     # sort dict by value (count)
     #ip_list = sorted(ip_list.iteritems(),lambda x,y:cmp(x[1], y[1]),reverse=True)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:swift-lldb?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:runt18:swift-lldb?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
