### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/customization/bin-utils/binutils.py
+++ b/examples/customization/bin-utils/binutils.py
@@ -84,12 +84,12 @@ def utob(debugger, command_line, result, dict):
 
     bits = binary(n, width)
     if not bits:
-        print "insufficient width value: %d" % width
+        print "insufficient width value: {0:d}".format(width)
         return
     if verbose and width > 0:
         pos = positions(width)
         print ' '+' '.join(pos)
-    print ' %s' % str(bits)
+    print ' {0!s}'.format(str(bits))
 
 def itob(debugger, command_line, result, dict):
     """Convert the integer to print its two's complement representation.
@@ -113,10 +113,10 @@ def itob(debugger, command_line, result, dict):
 
     bits = twos_complement(n, width)
     if not bits:
-        print "insufficient width value: %d" % width
+        print "insufficient width value: {0:d}".format(width)
         return
     if verbose and width > 0:
         pos = positions(width)
         print ' '+' '.join(pos)
-    print ' %s' % str(bits)
+    print ' {0!s}'.format(str(bits))
 

--- a/examples/customization/pwd-cd-and-system/utils.py
+++ b/examples/customization/pwd-cd-and-system/utils.py
@@ -31,7 +31,7 @@ def chdir(debugger, args, result, dict):
 
     Holder.swap(os.getcwd())
     os.chdir(new_dir)
-    print "Current working directory: %s" % os.getcwd()
+    print "Current working directory: {0!s}".format(os.getcwd())
 
 def system(debugger, command_line, result, dict):
     """Execute the command (a string) in a subshell."""

--- a/examples/python/cmdtemplate.py
+++ b/examples/python/cmdtemplate.py
@@ -62,7 +62,7 @@ def the_framestats_command(debugger, command, result, dict):
         variable_type = variable.GetType()
         total_size = total_size + variable_type.GetByteSize()
     average_size = float(total_size) / variables_count
-    print >>result, "Your frame has %d variables. Their total size is %d bytes. The average size is %f bytes" % (variables_count,total_size,average_size)
+    print >>result, "Your frame has {0:d} variables. Their total size is {1:d} bytes. The average size is {2:f} bytes".format(variables_count, total_size, average_size)
     # not returning anything is akin to returning success
 
 def __lldb_init_module (debugger, dict):

--- a/examples/python/crashlog.py
+++ b/examples/python/crashlog.py
@@ -66,7 +66,7 @@ except ImportError:
                 except ImportError:
                     pass
                 else:
-                    print 'imported lldb from: "%s"' % (lldb_python_dir)
+                    print 'imported lldb from: "{0!s}"'.format((lldb_python_dir))
                     success = True
                     break
     if not success:
@@ -107,15 +107,15 @@ class CrashLog(symbolication.Symbolicator):
             if self.app_specific_backtrace:
                 print "%Application Specific Backtrace[%u] %s" % (prefix, self.index, self.reason)
             else:
-                print "%sThread[%u] %s" % (prefix, self.index, self.reason)
+                print "{0!s}Thread[{1:d}] {2!s}".format(prefix, self.index, self.reason)
             if self.frames:
-                print "%s  Frames:" % (prefix)
+                print "{0!s}  Frames:".format((prefix))
                 for frame in self.frames:
                     frame.dump(prefix + '    ')
             if self.registers:
-                print "%s  Registers:" % (prefix)
+                print "{0!s}  Registers:".format((prefix))
                 for reg in self.registers.keys():
-                    print "%s    %-5s = %#16.16x" % (prefix, reg, self.registers[reg])
+                    print "{0!s}    {1:<5!s} = {2:#16.16x}".format(prefix, reg, self.registers[reg])
         
         def dump_symbolicated (self, crash_log, options):
             this_thread_crashed = self.app_specific_backtrace
@@ -124,7 +124,7 @@ class CrashLog(symbolication.Symbolicator):
                 if options.crashed_only and this_thread_crashed == False:
                     return
 
-            print "%s" % self
+            print "{0!s}".format(self)
             #prev_frame_index = -1
             display_frame_idx = -1
             for frame_idx, frame in enumerate(self.frames):
@@ -139,7 +139,7 @@ class CrashLog(symbolication.Symbolicator):
                     symbolicated_frame_address_idx = 0
                     for symbolicated_frame_address in symbolicated_frame_addresses:
                         display_frame_idx += 1
-                        print '[%3u] %s' % (frame_idx, symbolicated_frame_address)
+                        print '[{0:3d}] {1!s}'.format(frame_idx, symbolicated_frame_address)
                         if (options.source_all or self.did_crash()) and display_frame_idx < options.source_frames and options.source_context:
                             source_context = options.source_context
                             line_entry = symbolicated_frame_address.get_symbol_context().line_entry
@@ -152,7 +152,7 @@ class CrashLog(symbolication.Symbolicator):
                                     # Indent the source a bit
                                     indent_str = '    '
                                     join_str = '\n' + indent_str
-                                    print '%s%s' % (indent_str, join_str.join(source_text.split('\n')))
+                                    print '{0!s}{1!s}'.format(indent_str, join_str.join(source_text.split('\n')))
                         if symbolicated_frame_address_idx == 0:
                             if disassemble:
                                 instructions = symbolicated_frame_address.get_instructions()
@@ -177,11 +177,11 @@ class CrashLog(symbolication.Symbolicator):
         
         def __str__(self):
             if self.app_specific_backtrace:
-                s = "Application Specific Backtrace[%u]" % self.index
+                s = "Application Specific Backtrace[{0:d}]".format(self.index)
             else:
-                s = "Thread[%u]" % self.index
+                s = "Thread[{0:d}]".format(self.index)
             if self.reason:
-                s += ' %s' % self.reason
+                s += ' {0!s}'.format(self.reason)
             return s
         
     
@@ -194,12 +194,12 @@ class CrashLog(symbolication.Symbolicator):
         
         def __str__(self):
             if self.description:
-                return "[%3u] 0x%16.16x %s" % (self.index, self.pc, self.description)
+                return "[{0:3d}] 0x{1:16.16x} {2!s}".format(self.index, self.pc, self.description)
             else:
-                return "[%3u] 0x%16.16x" % (self.index, self.pc)
+                return "[{0:3d}] 0x{1:16.16x}".format(self.index, self.pc)
 
         def dump(self, prefix):
-            print "%s%s" % (prefix, str(self))
+            print "{0!s}{1!s}".format(prefix, str(self))
     
     class DarwinImage(symbolication.Image):
         """Class that represents a binary images in a darwin crash log"""
@@ -222,9 +222,9 @@ class CrashLog(symbolication.Symbolicator):
             # Mark this as resolved so we don't keep trying
             self.resolved = True
             uuid_str = self.get_normalized_uuid_string()
-            print 'Getting symbols for %s %s...' % (uuid_str, self.path),
+            print 'Getting symbols for {0!s} {1!s}...'.format(uuid_str, self.path),
             if os.path.exists(self.dsymForUUIDBinary):
-                dsym_for_uuid_command = '%s %s' % (self.dsymForUUIDBinary, uuid_str)
+                dsym_for_uuid_command = '{0!s} {1!s}'.format(self.dsymForUUIDBinary, uuid_str)
                 s = commands.getoutput(dsym_for_uuid_command)
                 if s:
                     plist_root = plistlib.readPlistFromString (s)
@@ -239,7 +239,7 @@ class CrashLog(symbolication.Symbolicator):
                                 self.path = os.path.expanduser (plist['DBGSymbolRichExecutable'])
                                 self.resolved_path = self.path
             if not self.resolved_path and os.path.exists(self.path):
-                dwarfdump_cmd_output = commands.getoutput('dwarfdump --uuid "%s"' % self.path)
+                dwarfdump_cmd_output = commands.getoutput('dwarfdump --uuid "{0!s}"'.format(self.path))
                 self_uuid = self.get_uuid()
                 for line in dwarfdump_cmd_output.splitlines():
                     match = self.dwarfdump_uuid_regex.search (line)
@@ -252,7 +252,7 @@ class CrashLog(symbolication.Symbolicator):
                             break;
                 if not self.resolved_path:
                     self.unavailable = True
-                    print "error\n    error: unable to locate '%s' with UUID %s" % (self.path, uuid_str)
+                    print "error\n    error: unable to locate '{0!s}' with UUID {1!s}".format(self.path, uuid_str)
                     return False
             if (self.resolved_path and os.path.exists(self.resolved_path)) or (self.path and os.path.exists(self.path)):
                 print 'ok'
@@ -284,7 +284,7 @@ class CrashLog(symbolication.Symbolicator):
         try:
             f = open(self.path)
         except IOError:
-            self.error = 'error: cannot open "%s"' % self.path
+            self.error = 'error: cannot open "{0!s}"'.format(self.path)
             return
 
         self.file_lines = f.read().splitlines()
@@ -302,7 +302,7 @@ class CrashLog(symbolication.Symbolicator):
                             if self.thread_exception:
                                 thread.reason += self.thread_exception
                             if self.thread_exception_data:
-                                thread.reason += " (%s)" % self.thread_exception_data
+                                thread.reason += " ({0!s})".format(self.thread_exception_data)
                         if app_specific_backtrace:
                             self.backtraces.append(thread)
                         else:
@@ -397,7 +397,7 @@ class CrashLog(symbolication.Symbolicator):
                         self.idents.append(ident)
                     thread.frames.append (CrashLog.Frame(int(frame_match.group(1)), int(frame_match.group(3), 0), frame_match.group(4)))
                 else:
-                    print 'error: frame regex failed for line: "%s"' % line
+                    print 'error: frame regex failed for line: "{0!s}"'.format(line)
             elif parse_mode == PARSE_MODE_IMAGES:
                 image_match = self.image_regex_uuid.search (line)
                 if image_match:
@@ -419,7 +419,7 @@ class CrashLog(symbolication.Symbolicator):
                                                       image_match.group(5))
                         self.images.append (image)
                     else:
-                        print "error: image regex failed for: %s" % line
+                        print "error: image regex failed for: {0!s}".format(line)
 
             elif parse_mode == PARSE_MODE_THREGS:
                 stripped_line = line.strip()
@@ -436,7 +436,7 @@ class CrashLog(symbolication.Symbolicator):
         f.close()
     
     def dump(self):
-        print "Crash Log File: %s" % (self.path)
+        print "Crash Log File: {0!s}".format((self.path))
         if self.backtraces:
             print "\nApplication Specific Backtraces:"
             for thread in self.backtraces:
@@ -452,7 +452,7 @@ class CrashLog(symbolication.Symbolicator):
         for image in self.images:
             if image.identifier == identifier:
                 return image            
-        regex_text = '^.*\.%s$' % (identifier)
+        regex_text = '^.*\.{0!s}$'.format((identifier))
         regex = re.compile(regex_text)
         for image in self.images:
             if regex.match(image.identifier):
@@ -503,7 +503,7 @@ class Interactive(cmd.Cmd):
 
     def default(self, line):
         '''Catch all for unknown command, which will exit the interpreter.'''
-        print "uknown command: %s" % line
+        print "uknown command: {0!s}".format(line)
         return True
 
     def do_q(self, line):
@@ -532,7 +532,7 @@ class Interactive(cmd.Cmd):
                 if idx < len(self.crash_logs):
                     SymbolicateCrashLog (self.crash_logs[idx], options)
                 else:
-                    print 'error: crash log index %u is out of range' % (idx)
+                    print 'error: crash log index {0:d} is out of range'.format((idx))
         else:
             # No arguments, symbolicate all crash logs using the options provided
             for idx in range(len(self.crash_logs)):
@@ -542,9 +542,9 @@ class Interactive(cmd.Cmd):
         '''Dump a list of all crash logs that are currently loaded.
         
         USAGE: list'''
-        print '%u crash logs are loaded:' % len(self.crash_logs)
+        print '{0:d} crash logs are loaded:'.format(len(self.crash_logs))
         for (crash_log_idx, crash_log) in enumerate(self.crash_logs):
-            print '[%u] = %s' % (crash_log_idx, crash_log.path)
+            print '[{0:d}] = {1!s}'.format(crash_log_idx, crash_log.path)
 
     def do_image(self, line):
         '''Dump information about one or more binary images in the crash log given an image basename, or all images if no arguments are provided.'''
@@ -568,21 +568,21 @@ class Interactive(cmd.Cmd):
                         if fullpath_search:
                             if image.get_resolved_path() == image_path:
                                 matches_found += 1
-                                print '[%u] ' % (crash_log_idx), image
+                                print '[{0:d}] '.format((crash_log_idx)), image
                         else:
                             image_basename = image.get_resolved_path_basename()
                             if image_basename == image_path:
                                 matches_found += 1
-                                print '[%u] ' % (crash_log_idx), image
+                                print '[{0:d}] '.format((crash_log_idx)), image
                     if matches_found == 0:
                         for (image_idx, image) in enumerate(crash_log.images):
                             resolved_image_path = image.get_resolved_path()
                             if resolved_image_path and string.find(image.get_resolved_path(), image_path) >= 0:
-                                print '[%u] ' % (crash_log_idx), image
+                                print '[{0:d}] '.format((crash_log_idx)), image
         else:
             for crash_log in self.crash_logs:
                 for (image_idx, image) in enumerate(crash_log.images):
-                    print '[%u] %s' % (image_idx, image)            
+                    print '[{0:d}] {1!s}'.format(image_idx, image)            
         return False
 
 
@@ -602,7 +602,7 @@ def interactive_crashlogs(options, args):
         if options.debug:
             crash_log.dump()
         if not crash_log.images:
-            print 'error: no images in crash log "%s"' % (crash_log)
+            print 'error: no images in crash log "{0!s}"'.format((crash_log))
             continue
         else:
             crash_logs.append(crash_log)
@@ -636,15 +636,15 @@ def save_crashlog(debugger, command, result, dict):
         if lldb.process:
             pid = lldb.process.id
             if pid != lldb.LLDB_INVALID_PROCESS_ID:
-                out_file.write('Process:         %s [%u]\n' % (identifier, pid))
-        out_file.write('Path:            %s\n' % (target.executable.fullpath))
-        out_file.write('Identifier:      %s\n' % (identifier))
-        out_file.write('\nDate/Time:       %s\n' % (datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")))
-        out_file.write('OS Version:      Mac OS X %s (%s)\n' % (platform.mac_ver()[0], commands.getoutput('sysctl -n kern.osversion')));
+                out_file.write('Process:         {0!s} [{1:d}]\n'.format(identifier, pid))
+        out_file.write('Path:            {0!s}\n'.format((target.executable.fullpath)))
+        out_file.write('Identifier:      {0!s}\n'.format((identifier)))
+        out_file.write('\nDate/Time:       {0!s}\n'.format((datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))))
+        out_file.write('OS Version:      Mac OS X {0!s} ({1!s})\n'.format(platform.mac_ver()[0], commands.getoutput('sysctl -n kern.osversion')));
         out_file.write('Report Version:  9\n')
         for thread_idx in range(lldb.process.num_threads):
             thread = lldb.process.thread[thread_idx]
-            out_file.write('\nThread %u:\n' % (thread_idx))
+            out_file.write('\nThread {0:d}:\n'.format((thread_idx)))
             for (frame_idx, frame) in enumerate(thread.frames):
                 frame_pc = frame.pc
                 frame_offset = 0
@@ -658,19 +658,19 @@ def save_crashlog(debugger, command, result, dict):
                         frame_offset = frame_pc - frame.function.addr.load_addr
                 elif frame.symbol:
                     frame_offset = frame_pc - frame.symbol.addr.load_addr
-                out_file.write('%-3u %-32s 0x%16.16x %s' % (frame_idx, frame.module.file.basename, frame_pc, frame.name))
+                out_file.write('{0:<3d} {1:<32!s} 0x{2:16.16x} {3!s}'.format(frame_idx, frame.module.file.basename, frame_pc, frame.name))
                 if frame_offset > 0: 
-                    out_file.write(' + %u' % (frame_offset))
+                    out_file.write(' + {0:d}'.format((frame_offset)))
                 line_entry = frame.line_entry
                 if line_entry:
                     if options.verbose:
                         # This will output the fullpath + line + column
-                        out_file.write(' %s' % (line_entry))
+                        out_file.write(' {0!s}'.format((line_entry)))
                     else:
-                        out_file.write(' %s:%u' % (line_entry.file.basename, line_entry.line))
+                        out_file.write(' {0!s}:{1:d}'.format(line_entry.file.basename, line_entry.line))
                         column = line_entry.column
                         if column: 
-                            out_file.write(':%u' % (column))
+                            out_file.write(':{0:d}'.format((column)))
                 out_file.write('\n')
                 
         out_file.write('\nBinary Images:\n')
@@ -685,7 +685,7 @@ def save_crashlog(debugger, command, result, dict):
                     module_version_array = module.GetVersion()
                     if module_version_array:
                         module_version = '.'.join(map(str,module_version_array))
-                    out_file.write ('    0x%16.16x - 0x%16.16x  %s (%s - ???) <%s> %s\n' % (text_segment_load_addr, text_segment_end_load_addr, identifier, module_version, module.GetUUIDString(), module.file.fullpath))
+                    out_file.write ('    0x{0:16.16x} - 0x{1:16.16x}  {2!s} ({3!s} - ???) <{4!s}> {5!s}\n'.format(text_segment_load_addr, text_segment_end_load_addr, identifier, module_version, module.GetUUIDString(), module.file.fullpath))
         out_file.close()
     else:
         result.PutCString ("error: invalid target");
@@ -695,7 +695,7 @@ def Symbolicate(debugger, command, result, dict):
     try:
         SymbolicateCrashLogs (shlex.split(command))
     except:
-        result.PutCString ("error: python exception %s" % sys.exc_info()[0])
+        result.PutCString ("error: python exception {0!s}".format(sys.exc_info()[0]))
 
 def SymbolicateCrashLog(crash_log, options):
     if crash_log.error:
@@ -736,7 +736,7 @@ def SymbolicateCrashLog(crash_log, options):
                             for image in images:
                                 images_to_load.append(image)
                         else:
-                            print 'error: can\'t find image for identifier "%s"' % ident
+                            print 'error: can\'t find image for identifier "{0!s}"'.format(ident)
         else:
             for ident in crash_log.idents:
                 images = crash_log.find_images_with_identifier (ident)
@@ -744,7 +744,7 @@ def SymbolicateCrashLog(crash_log, options):
                     for image in images:
                         images_to_load.append(image)
                 else:
-                    print 'error: can\'t find image for identifier "%s"' % ident
+                    print 'error: can\'t find image for identifier "{0!s}"'.format(ident)
 
     for image in images_to_load:
         if not image in loaded_images:
@@ -801,12 +801,12 @@ be disassembled and lookups can be performed using the addresses found in the cr
         return
         
     if options.debug:
-        print 'command_args = %s' % command_args
+        print 'command_args = {0!s}'.format(command_args)
         print 'options', options
         print 'args', args
         
     if options.debug_delay > 0:
-        print "Waiting %u seconds for debugger to attach..." % options.debug_delay
+        print "Waiting {0:d} seconds for debugger to attach...".format(options.debug_delay)
         time.sleep(options.debug_delay)
     error = lldb.SBError()
         

--- a/examples/python/delta.py
+++ b/examples/python/delta.py
@@ -38,8 +38,8 @@ def start_gdb_log(debugger, command, result, dict):
             log_file = args[0]
 
         if log_file:
-            debugger.HandleCommand('log enable --threadsafe --timestamp --file "%s" gdb-remote packets' % log_file);
-            result.PutCString ("GDB packet logging enable with log file '%s'\nUse the 'stop_gdb_log' command to stop logging and show packet statistics." % log_file)
+            debugger.HandleCommand('log enable --threadsafe --timestamp --file "{0!s}" gdb-remote packets'.format(log_file));
+            result.PutCString ("GDB packet logging enable with log file '{0!s}'\nUse the 'stop_gdb_log' command to stop logging and show packet statistics.".format(log_file))
             return
 
         result.PutCString ('error: invalid log file path')
@@ -76,7 +76,7 @@ def parse_log_file(file, options):
     a long time during a preset set of debugger commands.'''
 
     print '#----------------------------------------------------------------------'
-    print "# Log file: '%s'" % file
+    print "# Log file: '{0!s}'".format(file)
     print '#----------------------------------------------------------------------'
 
     timestamp_regex = re.compile('(\s*)([1-9][0-9]+\.[0-9]+)([^0-9].*)$')
@@ -95,7 +95,7 @@ def parse_log_file(file, options):
             else:
                 base_time = curr_time
 
-            print '%s%.6f %+.6f%s' % (match.group(1), curr_time - base_time, delta, match.group(3))
+            print '{0!s}{1:.6f} {2:+.6f}{3!s}'.format(match.group(1), curr_time - base_time, delta, match.group(3))
             last_time = curr_time
         else:
             print line

--- a/examples/python/diagnose_nsstring.py
+++ b/examples/python/diagnose_nsstring.py
@@ -11,10 +11,10 @@ def read_memory(process,location,size):
 	for x in range(0,size-1):
 		byte = process.ReadUnsignedFromMemory(x+location,1,error)
 		if error.fail:
-			data = data + "err%s" % "" if x == size-2 else ":"
+			data = data + "err{0!s}".format("") if x == size-2 else ":"
 		else:
 			try:
-				data = data + "0x%x" % byte
+				data = data + "0x{0:x}".format(byte)
 				if byte == 0:
 					data = data + "(\\0)"
 				elif byte == 0xa:
@@ -26,7 +26,7 @@ def read_memory(process,location,size):
 				elif byte == '\n':
 					data = data + "(\\n)"
 				else:
-					data = data + "(%s)" % chr(byte)
+					data = data + "({0!s})".format(chr(byte))
 				if x < size-2:
 					data = data + ":"
 			except Exception as e:
@@ -97,7 +97,7 @@ struct $__lldb__CFString {\
 };\
 "
 
-	expression = expression + "*(($__lldb__CFString*) %d)" % nsstring_address
+	expression = expression + "*(($__lldb__CFString*) {0:d})".format(nsstring_address)
 	# print expression
 	dumped = target.EvaluateExpression(expression,options)
 	print >>result, str(dumped)
@@ -113,8 +113,7 @@ struct $__lldb__CFString {\
 	is_special = (nsstring.GetDynamicValue(lldb.eDynamicCanRunTarget).GetTypeName() == "NSPathStore2")
 	has_null = (info_bits & 8) == 8
     
-	print >>result,"\nInfo=%d\nMutable=%s\nInline=%s\nExplicit=%s\nUnicode=%s\nSpecial=%s\nNull=%s\n" % \
-		(info_bits, "yes" if is_mutable else "no","yes" if is_inline else "no","yes" if has_explicit_length else "no","yes" if is_unicode else "no","yes" if is_special else "no","yes" if has_null else "no")
+	print >>result,"\nInfo={0:d}\nMutable={1!s}\nInline={2!s}\nExplicit={3!s}\nUnicode={4!s}\nSpecial={5!s}\nNull={6!s}\n".format(info_bits, "yes" if is_mutable else "no", "yes" if is_inline else "no", "yes" if has_explicit_length else "no", "yes" if is_unicode else "no", "yes" if is_special else "no", "yes" if has_null else "no")
 
 
 	explicit_length_offset = 0
@@ -134,7 +133,7 @@ struct $__lldb__CFString {\
 	else:
 		explicit_length_offset = nsstring_address + explicit_length_offset
 		explicit_length = process.ReadUnsignedFromMemory(explicit_length_offset, 4, error)
-		print >>result,"Explicit length location is at 0x%x - read value is %d\n" % (explicit_length_offset,explicit_length)
+		print >>result,"Explicit length location is at 0x{0:x} - read value is {1:d}\n".format(explicit_length_offset, explicit_length)
 
 	if is_mutable:
 		location = 2 * ptr_size + nsstring_address
@@ -159,12 +158,12 @@ struct $__lldb__CFString {\
 	else:
 		location = 2 * ptr_size + nsstring_address
 		location = process.ReadPointerFromMemory(location,error)
-	print >>result,"Expected data location: 0x%x\n" % (location)
-	print >>result,"1K of data around location: %s\n" % read_memory(process,location,1024)
-	print >>result,"5K of data around string pointer: %s\n" % read_memory(process,nsstring_address,1024*5)
+	print >>result,"Expected data location: 0x{0:x}\n".format((location))
+	print >>result,"1K of data around location: {0!s}\n".format(read_memory(process,location,1024))
+	print >>result,"5K of data around string pointer: {0!s}\n".format(read_memory(process,nsstring_address,1024*5))
 
 def __lldb_init_module(debugger, internal_dict):
-	debugger.HandleCommand("command script add -f %s.diagnose_nsstring_Command_Impl diagnose-nsstring" % __name__)
+	debugger.HandleCommand("command script add -f {0!s}.diagnose_nsstring_Command_Impl diagnose-nsstring".format(__name__))
 	print 'The "diagnose-nsstring" command has been installed, type "help diagnose-nsstring" for detailed help.'
 
 __lldb_init_module(lldb.debugger,None)

--- a/examples/python/diagnose_unwind.py
+++ b/examples/python/diagnose_unwind.py
@@ -34,7 +34,7 @@ def backtrace_print_frame (target, frame_num, addr, fp):
         if module_filename == None:
           module_filename = ""
       if module_uuid_str != "" or module_filename != "":
-        module_description = '%s %s' % (module_filename, module_uuid_str)
+        module_description = '{0!s} {1!s}'.format(module_filename, module_uuid_str)
   except Exception:
     print '%2d: pc==0x%-*x fp==0x%-*x' % (frame_num, addr_width, addr_for_printing, addr_width, fp)
     return
@@ -117,12 +117,12 @@ def print_stack_frame(process, fp):
   addr_size = process.GetAddressByteSize()
   addr = fp - (2 * addr_size)
   i = 0
-  outline = "Stack frame from $fp-%d: " % (2 * addr_size)
+  outline = "Stack frame from $fp-{0:d}: ".format((2 * addr_size))
   error = lldb.SBError()
   try:
     while i < 5 and error.Success():
       address = process.ReadPointerFromMemory(addr + (i * addr_size), error)
-      outline += " 0x%x" % address
+      outline += " 0x{0:x}".format(address)
       i += 1
     print outline
   except Exception:
@@ -160,8 +160,8 @@ to be helpful when reporting the problem.
         modules_seen = []
         addresses_seen = []
 
-        print 'LLDB version %s' % debugger.GetVersionString()
-        print 'Unwind diagnostics for thread %d' % thread.GetIndexID()
+        print 'LLDB version {0!s}'.format(debugger.GetVersionString())
+        print 'Unwind diagnostics for thread {0:d}'.format(thread.GetIndexID())
         print ""
         print "============================================================================================="
         print ""
@@ -207,7 +207,7 @@ to be helpful when reporting the problem.
         for module in modules_seen:
           if module != None and module.GetFileSpec().GetFilename() != None:
             if not module.GetFileSpec().GetFilename() in modules_already_seen:
-              debugger.HandleCommand('image list %s' % module.GetFileSpec().GetFilename())
+              debugger.HandleCommand('image list {0!s}'.format(module.GetFileSpec().GetFilename()))
               modules_already_seen.add(module.GetFileSpec().GetFilename())
 
         print ""
@@ -220,24 +220,24 @@ to be helpful when reporting the problem.
           if not frame.IsInlined():
             print "--------------------------------------------------------------------------------------"
             print ""
-            print "Disassembly of %s, frame %d, address 0x%x" % (frame.GetFunctionName(), frame.GetFrameID(), frame.GetPC())
+            print "Disassembly of {0!s}, frame {1:d}, address 0x{2:x}".format(frame.GetFunctionName(), frame.GetFrameID(), frame.GetPC())
             print ""
             if target.triple[0:6] == "x86_64" or target.triple[0:4] == "i386":
-              debugger.HandleCommand('disassemble -F att -a 0x%x' % frame.GetPC())
+              debugger.HandleCommand('disassemble -F att -a 0x{0:x}'.format(frame.GetPC()))
             else:
-              debugger.HandleCommand('disassemble -a 0x%x' % frame.GetPC())
+              debugger.HandleCommand('disassemble -a 0x{0:x}'.format(frame.GetPC()))
             if frame.GetPC() in additional_addresses_to_disassemble:
               additional_addresses_to_disassemble.remove (frame.GetPC())
 
         for address in list(additional_addresses_to_disassemble):
           print "--------------------------------------------------------------------------------------"
           print ""
-          print "Disassembly of 0x%x" % address
+          print "Disassembly of 0x{0:x}".format(address)
           print ""
           if target.triple[0:6] == "x86_64" or target.triple[0:4] == "i386":
-            debugger.HandleCommand('disassemble -F att -a 0x%x' % address)
+            debugger.HandleCommand('disassemble -F att -a 0x{0:x}'.format(address))
           else:
-            debugger.HandleCommand('disassemble -a 0x%x' % address)
+            debugger.HandleCommand('disassemble -a 0x{0:x}'.format(address))
 
         print ""
         print "============================================================================================="
@@ -247,18 +247,18 @@ to be helpful when reporting the problem.
           if not frame.IsInlined():
             print "--------------------------------------------------------------------------------------"
             print ""
-            print "Unwind instructions for %s, frame %d" % (frame.GetFunctionName(), frame.GetFrameID())
+            print "Unwind instructions for {0!s}, frame {1:d}".format(frame.GetFunctionName(), frame.GetFrameID())
             print ""
-            debugger.HandleCommand('image show-unwind -a "0x%x"' % frame.GetPC())
+            debugger.HandleCommand('image show-unwind -a "0x{0:x}"'.format(frame.GetPC()))
             if frame.GetPC() in additional_addresses_to_show_unwind:
               additional_addresses_to_show_unwind.remove (frame.GetPC())
 
         for address in list(additional_addresses_to_show_unwind):
           print "--------------------------------------------------------------------------------------"
           print ""
-          print "Unwind instructions for 0x%x" % address
+          print "Unwind instructions for 0x{0:x}".format(address)
           print ""
-          debugger.HandleCommand('image show-unwind -a "0x%x"' % address)
+          debugger.HandleCommand('image show-unwind -a "0x{0:x}"'.format(address))
 
 def create_diagnose_unwind_options():
   usage = "usage: %prog"
@@ -266,5 +266,5 @@ def create_diagnose_unwind_options():
   parser = optparse.OptionParser(description=description, prog='diagnose_unwind',usage=usage)
   return parser
 
-lldb.debugger.HandleCommand('command script add -f %s.diagnose_unwind diagnose-unwind' % __name__)
+lldb.debugger.HandleCommand('command script add -f {0!s}.diagnose_unwind diagnose-unwind'.format(__name__))
 print 'The "diagnose-unwind" command has been installed, type "help diagnose-unwind" for detailed help.'

--- a/examples/python/dict_utils.py
+++ b/examples/python/dict_utils.py
@@ -54,7 +54,7 @@ class Enum(LookupDictionary):
     def __str__(self):
         s = self.get_first_key_for_value (self.value, None)
         if s == None:
-            s = "%#8.8x" % self.value
+            s = "{0:#8.8x}".format(self.value)
         return s
     
     def __repr__(self):

--- a/examples/python/disasm.py
+++ b/examples/python/disasm.py
@@ -41,7 +41,7 @@ debugger = lldb.SBDebugger.Create()
 debugger.SetAsync (False)
 
 # Create a target from a file and arch
-print "Creating a target for '%s'" % exe
+print "Creating a target for '{0!s}'".format(exe)
 
 target = debugger.CreateTargetWithFileAndArch (exe, lldb.LLDB_ARCH_DEFAULT)
 
@@ -90,10 +90,10 @@ if target:
                             disassemble_instructions (insts)
 
                     registerList = frame.GetRegisters()
-                    print "Frame registers (size of register set = %d):" % registerList.GetSize()
+                    print "Frame registers (size of register set = {0:d}):".format(registerList.GetSize())
                     for value in registerList:
                         #print value
-                        print "%s (number of children = %d):" % (value.GetName(), value.GetNumChildren())
+                        print "{0!s} (number of children = {1:d}):".format(value.GetName(), value.GetNumChildren())
                         for child in value:
                             print "Name: ", child.GetName(), " Value: ", child.GetValue()
 
@@ -111,7 +111,7 @@ if target:
         elif state == lldb.eStateExited:
             print "Didn't hit the breakpoint at main, program has exited..."
         else:
-            print "Unexpected process state: %s, killing process..." % debugger.StateAsCString (state)
+            print "Unexpected process state: {0!s}, killing process...".format(debugger.StateAsCString (state))
             process.Kill()
 
         

--- a/examples/python/file_extract.py
+++ b/examples/python/file_extract.py
@@ -28,7 +28,7 @@ class FileExtract:
         elif b == '<' or b == '>' or b == '@' or b == '=':
             self.byte_order = b
         else:
-            print "error: invalid byte order specified: '%s'" % b
+            print "error: invalid byte order specified: '{0!s}'".format(b)
 
     def is_in_memory(self):
         return False
@@ -135,7 +135,7 @@ class FileExtract:
         '''Extract a single fixed length C string from the binary file at the current file position, returns a single C string'''
         s = self.read_size(n)
         if s:
-            cstr, = struct.unpack(self.byte_order + ("%i" % n) + 's', s)
+            cstr, = struct.unpack(self.byte_order + ("{0:d}".format(n)) + 's', s)
             # Strip trialing NULLs
             cstr = string.strip(cstr, "\0")
             if isprint_only_with_space_padding:
@@ -160,7 +160,7 @@ class FileExtract:
         '''Extract "n" int8_t integers from the binary file at the current file position, returns a list of integers'''
         s = self.read_size(n)
         if s:
-            return struct.unpack(self.byte_order + ("%u" % n) + 'b', s)
+            return struct.unpack(self.byte_order + ("{0:d}".format(n)) + 'b', s)
         else:
             return (fail_value,) * n
 
@@ -168,7 +168,7 @@ class FileExtract:
         '''Extract "n" uint8_t integers from the binary file at the current file position, returns a list of integers'''
         s = self.read_size(n)
         if s:
-            return struct.unpack(self.byte_order + ("%u" % n) + 'B', s)
+            return struct.unpack(self.byte_order + ("{0:d}".format(n)) + 'B', s)
         else:
             return (fail_value,) * n
 
@@ -176,7 +176,7 @@ class FileExtract:
         '''Extract "n" int16_t integers from the binary file at the current file position, returns a list of integers'''
         s = self.read_size(2*n)
         if s:
-            return struct.unpack(self.byte_order + ("%u" % n) + 'h', s)
+            return struct.unpack(self.byte_order + ("{0:d}".format(n)) + 'h', s)
         else:
             return (fail_value,) * n
 
@@ -184,7 +184,7 @@ class FileExtract:
         '''Extract "n" uint16_t integers from the binary file at the current file position, returns a list of integers'''
         s = self.read_size(2*n)
         if s:
-            return struct.unpack(self.byte_order + ("%u" % n) + 'H', s)
+            return struct.unpack(self.byte_order + ("{0:d}".format(n)) + 'H', s)
         else:
             return (fail_value,) * n
 
@@ -192,7 +192,7 @@ class FileExtract:
         '''Extract "n" int32_t integers from the binary file at the current file position, returns a list of integers'''
         s = self.read_size(4*n)
         if s:
-            return struct.unpack(self.byte_order + ("%u" % n) + 'i', s)
+            return struct.unpack(self.byte_order + ("{0:d}".format(n)) + 'i', s)
         else:
             return (fail_value,) * n
 
@@ -200,7 +200,7 @@ class FileExtract:
         '''Extract "n" uint32_t integers from the binary file at the current file position, returns a list of integers'''
         s = self.read_size(4*n)
         if s:
-            return struct.unpack(self.byte_order + ("%u" % n) + 'I', s)
+            return struct.unpack(self.byte_order + ("{0:d}".format(n)) + 'I', s)
         else:
             return (fail_value,) * n
 
@@ -208,7 +208,7 @@ class FileExtract:
         '''Extract "n" int64_t integers from the binary file at the current file position, returns a list of integers'''
         s = self.read_size(8*n)
         if s:
-            return struct.unpack(self.byte_order + ("%u" % n) + 'q', s)
+            return struct.unpack(self.byte_order + ("{0:d}".format(n)) + 'q', s)
         else:
             return (fail_value,) * n
 
@@ -216,6 +216,6 @@ class FileExtract:
         '''Extract "n" uint64_t integers from the binary file at the current file position, returns a list of integers'''
         s = self.read_size(8*n)
         if s:
-            return struct.unpack(self.byte_order + ("%u" % n) + 'Q', s)
+            return struct.unpack(self.byte_order + ("{0:d}".format(n)) + 'Q', s)
         else:
             return (fail_value,) * n

--- a/examples/python/gdb_disassemble.py
+++ b/examples/python/gdb_disassemble.py
@@ -15,9 +15,9 @@ def disassemble(debugger, command, result, dict):
         inst_offset = inst_addr - start_addr
         comment = inst.comment
         if comment:
-            print "<%s + %-4u> 0x%x %8s  %s ; %s" % (name, inst_offset, inst_addr, inst.mnemonic, inst.operands, comment)
+            print "<{0!s} + {1:<4d}> 0x{2:x} {3:8!s}  {4!s} ; {5!s}".format(name, inst_offset, inst_addr, inst.mnemonic, inst.operands, comment)
         else:
-            print "<%s + %-4u> 0x%x %8s  %s" % (name, inst_offset, inst_addr, inst.mnemonic, inst.operands)
+            print "<{0!s} + {1:<4d}> 0x{2:x} {3:8!s}  {4!s}".format(name, inst_offset, inst_addr, inst.mnemonic, inst.operands)
             
 # Install the command when the module gets imported
 lldb.debugger.HandleCommand('command script add -f gdb_disassemble.disassemble gdb-disassemble')

--- a/examples/python/gdbremote.py
+++ b/examples/python/gdbremote.py
@@ -203,7 +203,7 @@ def start_gdb_log(debugger, command, result, dict):
         return
 
     if g_log_file:
-        result.PutCString ('error: logging is already in progress with file "%s"' % g_log_file)
+        result.PutCString ('error: logging is already in progress with file "{0!s}"'.format(g_log_file))
     else:
         args_len = len(args)
         if args_len == 0:
@@ -212,8 +212,8 @@ def start_gdb_log(debugger, command, result, dict):
             g_log_file = args[0]
 
         if g_log_file:
-            debugger.HandleCommand('log enable --threadsafe --timestamp --file "%s" gdb-remote packets' % g_log_file);
-            result.PutCString ("GDB packet logging enable with log file '%s'\nUse the 'stop_gdb_log' command to stop logging and show packet statistics." % g_log_file)
+            debugger.HandleCommand('log enable --threadsafe --timestamp --file "{0!s}" gdb-remote packets'.format(g_log_file));
+            result.PutCString ("GDB packet logging enable with log file '{0!s}'\nUse the 'stop_gdb_log' command to stop logging and show packet statistics.".format(g_log_file))
             return
 
         result.PutCString ('error: invalid log file path')
@@ -255,12 +255,12 @@ def stop_gdb_log(debugger, command, result, dict):
     elif os.path.exists (g_log_file):
         if len(args) == 0:
             debugger.HandleCommand('log disable gdb-remote packets');
-            result.PutCString ("GDB packet logging disabled. Logged packets are in '%s'" % g_log_file)
+            result.PutCString ("GDB packet logging disabled. Logged packets are in '{0!s}'".format(g_log_file))
             parse_gdb_log_file (g_log_file, options)
         else:
             result.PutCString (usage)
     else:
-        print 'error: the GDB packet log file "%s" does not exist' % g_log_file
+        print 'error: the GDB packet log file "{0!s}" does not exist'.format(g_log_file)
 
 def is_hex_byte(str):
     if len(str) == 2:
@@ -303,13 +303,13 @@ class RegisterInfo:
         if encoding == 'uint':
             uval = packet.get_hex_uint(g_byte_order)
             if bit_size == 8:
-                return '0x%2.2x' % (uval)
+                return '0x{0:2.2x}'.format((uval))
             elif bit_size == 16:
-                return '0x%4.4x' % (uval)
+                return '0x{0:4.4x}'.format((uval))
             elif bit_size == 32:
-                return '0x%8.8x' % (uval)
+                return '0x{0:8.8x}'.format((uval))
             elif bit_size == 64:
-                return '0x%16.16x' % (uval)
+                return '0x{0:16.16x}'.format((uval))
         bytes = list();
         uval = packet.get_hex_uint8()
         while uval != None:
@@ -319,8 +319,8 @@ class RegisterInfo:
         if g_byte_order == 'little':
             bytes.reverse()
         for byte in bytes:
-            value_str += '%2.2x' % byte
-        return '%s' % (value_str)
+            value_str += '{0:2.2x}'.format(byte)
+        return '{0!s}'.format((value_str))
     
     def __str__(self):
         '''Dump the register info key/value pairs'''
@@ -328,7 +328,7 @@ class RegisterInfo:
         for key in self.info.keys():
             if s:
                 s += ', '
-            s += "%s=%s " % (key, self.info[key])
+            s += "{0!s}={1!s} ".format(key, self.info[key])
         return s
     
 class Packet:
@@ -512,7 +512,7 @@ def get_thread_from_thread_suffix(str):
 def cmd_qThreadStopInfo(options, cmd, args):
     packet = Packet(args)
     tid = packet.get_hex_uint('big')
-    print "get_thread_stop_info  (tid = 0x%x)" % (tid)
+    print "get_thread_stop_info  (tid = 0x{0:x})".format((tid))
     
 def cmd_stop_reply(options, cmd, args):
     print "get_last_stop_info()"
@@ -540,9 +540,9 @@ def rsp_stop_reply(options, cmd, cmd_args, rsp):
         dump_key_value_pairs (key_value_pairs)
     elif stop_type == 'W':
         exit_status = packet.get_hex_uint8()
-        print 'stop_reply(): exit (status=%i)' % exit_status
+        print 'stop_reply(): exit (status={0:d})'.format(exit_status)
     elif stop_type == 'O':
-        print 'stop_reply(): stdout = "%s"' % packet.str
+        print 'stop_reply(): stdout = "{0!s}"'.format(packet.str)
         
 
 def cmd_unknown_packet(options, cmd, args):
@@ -561,13 +561,13 @@ def cmd_qSymbol(options, cmd, args):
         if symbol_addr is None:
             if packet.skip_exact_string(':'):
                 symbol_name = packet.get_hex_ascii_str()
-                print 'lookup_symbol("%s") -> symbol not available yet' % (symbol_name)
+                print 'lookup_symbol("{0!s}") -> symbol not available yet'.format((symbol_name))
             else:
                 print 'error: bad command format'
         else:
             if packet.skip_exact_string(':'):
                 symbol_name = packet.get_hex_ascii_str()
-                print 'lookup_symbol("%s") -> 0x%x' % (symbol_name, symbol_addr)
+                print 'lookup_symbol("{0!s}") -> 0x{1:x}'.format(symbol_name, symbol_addr)
             else:
                 print 'error: bad command format'
 
@@ -581,13 +581,13 @@ def rsp_qSymbol(options, cmd, cmd_args, rsp):
             packet = Packet(rsp)
             if packet.skip_exact_string("qSymbol:"):
                 symbol_name = packet.get_hex_ascii_str()
-                print 'lookup_symbol("%s")' % (symbol_name)
+                print 'lookup_symbol("{0!s}")'.format((symbol_name))
             else:
-                print 'error: response string should start with "qSymbol:": respnse is "%s"' % (rsp)
+                print 'error: response string should start with "qSymbol:": respnse is "{0!s}"'.format((rsp))
 
 def cmd_qXfer(options, cmd, args):
     # $qXfer:features:read:target.xml:0,1ffff#14
-    print "read target special data %s" % (args)
+    print "read target special data {0!s}".format((args))
     return True
 
 def rsp_qXfer(options, cmd, cmd_args, rsp):
@@ -618,7 +618,7 @@ def rsp_qXfer(options, cmd, cmd_args, rsp):
                             if 'bitsize' in reg_element.attrib:
                                 reg_info.info['bitsize'] = reg_element.attrib['bitsize']
                             g_register_infos.append(reg_info)
-                    print 'XML for "%s":' % (data[2])
+                    print 'XML for "{0!s}":'.format((data[2]))
                     ET.dump(xml_root)
 
 def cmd_A(options, cmd, args):
@@ -636,7 +636,7 @@ def cmd_A(options, cmd, args):
         if not packet.skip_exact_string(','):
             break;
         arg_value = packet.get_hex_ascii_str(arg_len)
-        print 'argv[%u] = "%s"' % (arg_idx, arg_value)
+        print 'argv[{0:d}] = "{1!s}"'.format(arg_idx, arg_value)
         
 def cmd_qC(options, cmd, args):
     print "query_current_thread_id()"
@@ -645,15 +645,15 @@ def rsp_qC(options, cmd, cmd_args, rsp):
     packet = Packet(rsp)
     if packet.skip_exact_string("QC"):
         tid = packet.get_thread_id()
-        print "current_thread_id = %#x" % (tid)
+        print "current_thread_id = {0:#x}".format((tid))
     else:
         print "current_thread_id = old thread ID"
 
 def cmd_query_packet(options, cmd, args):
     if args:
-        print "%s%s" % (cmd, args)
+        print "{0!s}{1!s}".format(cmd, args)
     else:
-        print "%s" % (cmd)
+        print "{0!s}".format((cmd))
     return False
     
 def rsp_ok_error(rsp):
@@ -661,19 +661,19 @@ def rsp_ok_error(rsp):
 
 def rsp_ok_means_supported(options, cmd, cmd_args, rsp):
     if rsp == 'OK':
-        print "%s%s is supported" % (cmd, cmd_args)
+        print "{0!s}{1!s} is supported".format(cmd, cmd_args)
     elif rsp == '':
-        print "%s%s is not supported" % (cmd, cmd_args)
+        print "{0!s}{1!s} is not supported".format(cmd, cmd_args)
     else:
-        print "%s%s -> %s" % (cmd, cmd_args, rsp)
+        print "{0!s}{1!s} -> {2!s}".format(cmd, cmd_args, rsp)
 
 def rsp_ok_means_success(options, cmd, cmd_args, rsp):
     if rsp == 'OK':
         print "success"
     elif rsp == '':
-        print "%s%s is not supported" % (cmd, cmd_args)
+        print "{0!s}{1!s} is not supported".format(cmd, cmd_args)
     else:
-        print "%s%s -> %s" % (cmd, cmd_args, rsp)
+        print "{0!s}{1!s} -> {2!s}".format(cmd, cmd_args, rsp)
 
 def dump_key_value_pairs(key_value_pairs):
     max_key_len = 0
@@ -688,7 +688,7 @@ def dump_key_value_pairs(key_value_pairs):
 
 def rsp_dump_key_value_pairs(options, cmd, cmd_args, rsp):
     if rsp:
-        print '%s response:' % (cmd)
+        print '{0!s} response:'.format((cmd))
         packet = Packet(rsp)
         key_value_pairs = packet.get_key_value_pairs()
         dump_key_value_pairs(key_value_pairs)
@@ -705,7 +705,7 @@ def cmd_s(options, cmd, args):
     
 def cmd_vCont(options, cmd, args):
     if args == '?':
-        print "%s: get supported extended continue modes" % (cmd)
+        print "{0!s}: get supported extended continue modes".format((cmd))
     else:
         got_other_threads = 0
         s = ''
@@ -717,9 +717,9 @@ def cmd_vCont(options, cmd, args):
             elif short_action == 's':
                 action = 'step'
             elif short_action[0] == 'C':
-                action = 'continue with signal 0x%s' % (short_action[1:])
+                action = 'continue with signal 0x{0!s}'.format((short_action[1:]))
             elif short_action == 'S':
-                action = 'step with signal 0x%s' % (short_action[1:])
+                action = 'step with signal 0x{0!s}'.format((short_action[1:]))
             else:
                 action = short_action
             if s:
@@ -728,11 +728,11 @@ def cmd_vCont(options, cmd, args):
                 got_other_threads = 1
                 s += 'other-threads:'
             else:
-                s += 'thread 0x%4.4x: %s' % (tid, action)
+                s += 'thread 0x{0:4.4x}: {1!s}'.format(tid, action)
         if got_other_threads:
-            print "extended_continue (%s)" % (s)
+            print "extended_continue ({0!s})".format((s))
         else:
-            print "extended_continue (%s, other-threads: suspend)" % (s)
+            print "extended_continue ({0!s}, other-threads: suspend)".format((s))
     return False
 
 def rsp_vCont(options, cmd, cmd_args, rsp):
@@ -740,7 +740,7 @@ def rsp_vCont(options, cmd, cmd_args, rsp):
         # Skip the leading 'vCont;'
         rsp = rsp[6:]
         modes = string.split(rsp, ';')
-        s = "%s: supported extended continue modes include: " % (cmd)
+        s = "{0!s}: supported extended continue modes include: ".format((cmd))
         
         for i, mode in enumerate(modes):
             if i: 
@@ -761,27 +761,27 @@ def rsp_vCont(options, cmd, cmd_args, rsp):
             rsp_stop_reply (options, cmd, cmd_args, rsp)
             return
         if rsp[0] == 'O':
-            print "stdout: %s" % (rsp)
+            print "stdout: {0!s}".format((rsp))
             return
     else:
-        print "not supported (cmd = '%s', args = '%s', rsp = '%s')" % (cmd, cmd_args, rsp)
+        print "not supported (cmd = '{0!s}', args = '{1!s}', rsp = '{2!s}')".format(cmd, cmd_args, rsp)
 
 def cmd_vAttach(options, cmd, args):
     (extra_command, args) = string.split(args, ';')
     if extra_command:
-        print "%s%s(%s)" % (cmd, extra_command, args)
+        print "{0!s}{1!s}({2!s})".format(cmd, extra_command, args)
     else:
-        print "attach(pid = %u)" % int(args, 16)
+        print "attach(pid = {0:d})".format(int(args, 16))
     return False
     
 
 def cmd_qRegisterInfo(options, cmd, args):
-    print 'query_register_info(reg_num=%i)' % (int(args, 16))
+    print 'query_register_info(reg_num={0:d})'.format((int(args, 16)))
     return False
 
 def rsp_qRegisterInfo(options, cmd, cmd_args, rsp):
     global g_max_register_info_name_len
-    print 'query_register_info(reg_num=%i):' % (int(cmd_args, 16)),
+    print 'query_register_info(reg_num={0:d}):'.format((int(cmd_args, 16))),
     if len(rsp) == 3 and rsp[0] == 'E':
         g_max_register_info_name_len = 0
         for reg_info in g_register_infos:
@@ -801,7 +801,7 @@ def cmd_qThreadInfo(options, cmd, args):
         query_type = 'first'
     else: 
         query_type = 'subsequent'
-    print 'get_current_thread_list(type=%s)' % (query_type)
+    print 'get_current_thread_list(type={0!s})'.format((query_type))
     return False
 
 def rsp_qThreadInfo(options, cmd, cmd_args, rsp):
@@ -812,7 +812,7 @@ def rsp_qThreadInfo(options, cmd, cmd_args, rsp):
         for i, tid in enumerate(tids):
             if i:
                 print ',',
-            print '0x%x' % (tid),
+            print '0x{0:x}'.format((tid)),
         print
     elif response_type == 'l':
         print 'END'
@@ -820,7 +820,7 @@ def rsp_qThreadInfo(options, cmd, cmd_args, rsp):
 def rsp_hex_big_endian(options, cmd, cmd_args, rsp):
     packet = Packet(rsp)
     uval = packet.get_hex_uint('big')
-    print '%s: 0x%x' % (cmd, uval)
+    print '{0!s}: 0x{1:x}'.format(cmd, uval)
 
 def cmd_read_mem_bin(options, cmd, args):
     # x0x7fff5fc39200,0x200
@@ -828,7 +828,7 @@ def cmd_read_mem_bin(options, cmd, args):
     addr = packet.get_number()
     comma = packet.get_char()
     size = packet.get_number()
-    print 'binary_read_memory (addr = 0x%16.16x, size = %u)' % (addr, size)
+    print 'binary_read_memory (addr = 0x{0:16.16x}, size = {1:d})'.format(addr, size)
     return False
 
 def rsp_mem_bin_bytes(options, cmd, cmd_args, rsp):
@@ -845,7 +845,7 @@ def cmd_read_memory(options, cmd, args):
     addr = packet.get_hex_uint('big')
     comma = packet.get_char()
     size = packet.get_hex_uint('big')
-    print 'read_memory (addr = 0x%16.16x, size = %u)' % (addr, size)
+    print 'read_memory (addr = 0x{0:16.16x}, size = {1:d})'.format(addr, size)
     return False
 
 def dump_hex_memory_buffer(addr, hex_byte_str):
@@ -858,8 +858,8 @@ def dump_hex_memory_buffer(addr, hex_byte_str):
             if ascii:
                 print '  ', ascii
                 ascii = ''
-            print '0x%x:' % (addr + idx),
-        print '%2.2x' % (uval),
+            print '0x{0:x}:'.format((addr + idx)),
+        print '{0:2.2x}'.format((uval)),
         if 0x20 <= uval and uval < 0x7f:
             ascii += '%c' % uval
         else:
@@ -880,7 +880,7 @@ def cmd_write_memory(options, cmd, args):
     if packet.get_char() != ':':
         print 'error: invalid write memory command (missing colon after size)'
         return
-    print 'write_memory (addr = 0x%16.16x, size = %u, data:' % (addr, size)
+    print 'write_memory (addr = 0x{0:16.16x}, size = {1:d}, data:'.format(addr, size)
     dump_hex_memory_buffer (addr, packet.str) 
     return False
 
@@ -890,13 +890,13 @@ def cmd_alloc_memory(options, cmd, args):
     if packet.get_char() != ',':
         print 'error: invalid allocate memory command (missing comma after address)'
         return
-    print 'allocate_memory (byte-size = %u (0x%x), permissions = %s)' % (byte_size, byte_size, packet.str)
+    print 'allocate_memory (byte-size = {0:d} (0x{1:x}), permissions = {2!s})'.format(byte_size, byte_size, packet.str)
     return False
 
 def rsp_alloc_memory(options, cmd, cmd_args, rsp):
     packet = Packet(rsp)
     addr = packet.get_hex_uint('big')
-    print 'addr = 0x%x' % addr
+    print 'addr = 0x{0:x}'.format(addr)
 
 def cmd_dealloc_memory(options, cmd, args):
     packet = Packet(args)
@@ -904,7 +904,7 @@ def cmd_dealloc_memory(options, cmd, args):
     if packet.get_char() != ',':
         print 'error: invalid allocate memory command (missing comma after address)'
     else:
-        print 'deallocate_memory (addr = 0x%x, permissions = %s)' % (addr, packet.str)
+        print 'deallocate_memory (addr = 0x{0:x}, permissions = {1!s})'.format(addr, packet.str)
     return False
 def rsp_memory_bytes(options, cmd, cmd_args, rsp):
     addr = Packet(cmd_args).get_hex_uint('big')
@@ -919,14 +919,14 @@ def get_register_name_equal_value(options, reg_num, hex_value_str):
             symbolicated_addresses = options.symbolicator.symbolicate (int(value_str, 0))
             if symbolicated_addresses:
                 s += options.colors.magenta()
-                s += '%s' % symbolicated_addresses[0]
+                s += '{0!s}'.format(symbolicated_addresses[0])
                 s += options.colors.reset()
                 return s
         s += value_str
         return s
     else:
         reg_value = Packet(hex_value_str).get_hex_uint(g_byte_order)
-        return 'reg(%u) = 0x%x' % (reg_num, reg_value)
+        return 'reg({0:d}) = 0x{1:x}'.format(reg_num, reg_value)
 
 def cmd_read_one_reg(options, cmd, args):
     packet = Packet(args)
@@ -939,11 +939,11 @@ def cmd_read_one_reg(options, cmd, args):
         packet.get_char() # skip ;
         thread_info = packet.get_key_value_pairs()
         tid = int(thread_info[0][1], 16)
-    s = 'read_register (reg_num=%u' % reg_num
+    s = 'read_register (reg_num={0:d}'.format(reg_num)
     if name:
-        s += ' (%s)' % (name)
+        s += ' ({0!s})'.format((name))
     if tid != None:
-        s += ', tid = 0x%4.4x' % (tid)
+        s += ', tid = 0x{0:4.4x}'.format((tid))
     s += ')'
     print s
     return False
@@ -962,13 +962,13 @@ def cmd_write_one_reg(options, cmd, args):
         name = None
         hex_value_str = packet.get_hex_chars()
         tid = get_thread_from_thread_suffix (packet.str)
-        s = 'write_register (reg_num=%u' % reg_num
+        s = 'write_register (reg_num={0:d}'.format(reg_num)
         if name:
-            s += ' (%s)' % (name)
+            s += ' ({0!s})'.format((name))
         s += ', value = '
         s += get_register_name_equal_value(options, reg_num, hex_value_str)
         if tid != None:
-            s += ', tid = 0x%4.4x' % (tid)
+            s += ', tid = 0x{0:4.4x}'.format((tid))
         s += ')'
         print s
     return False
@@ -988,7 +988,7 @@ def cmd_read_all_regs(cmd, cmd_args):
     packet.get_char() # toss the 'g' command character
     tid = get_thread_from_thread_suffix (packet.str)
     if tid != None:
-        print 'read_all_register(thread = 0x%4.4x)' % tid
+        print 'read_all_register(thread = 0x{0:4.4x})'.format(tid)
     else:
         print 'read_all_register()'
     return False
@@ -1017,7 +1017,7 @@ def cmd_bp(options, cmd, args):
     packet.get_char() # Skip ,
     bp_size = packet.get_hex_uint('big')
     s += g_bp_types[bp_type]
-    s += " (addr = 0x%x, size = %u)" % (bp_addr, bp_size)
+    s += " (addr = 0x{0:x}, size = {1:d})".format(bp_addr, bp_size)
     print s
     return False
 
@@ -1025,7 +1025,7 @@ def cmd_mem_rgn_info(options, cmd, args):
     packet = Packet(args)
     packet.get_char() # skip ':' character
     addr = packet.get_hex_uint('big')
-    print 'get_memory_region_info (addr=0x%x)' % (addr)
+    print 'get_memory_region_info (addr=0x{0:x})'.format((addr))
     return False
 
 def cmd_kill(options, cmd, args):
@@ -1057,7 +1057,7 @@ def decode_packet(s, start_index = 0):
         return normal_s
 
 def rsp_json(options, cmd, cmd_args, rsp):
-    print '%s() reply:' % (cmd)
+    print '{0!s}() reply:'.format((cmd))
     json_tree = json.loads(rsp)
     print json.dumps(json_tree, indent=4, separators=(',', ': '))
     
@@ -1275,13 +1275,13 @@ def parse_gdb_log(file, options):
                 packet_name = None
 
             if not options or not options.quiet:
-                print '%s%.6f %+.6f%s' % (match.group(1), curr_time - base_time, delta, match.group(3))
+                print '{0!s}{1:.6f} {2:+.6f}{3!s}'.format(match.group(1), curr_time - base_time, delta, match.group(3))
             last_time = curr_time
         # else:
         #     print line
     (average, std_dev) = calculate_mean_and_standard_deviation(packet_times)
     if average and std_dev:
-        print '%u packets with average packet time of %f and standard deviation of %f' % (len(packet_times), average, std_dev)
+        print '{0:d} packets with average packet time of {1:f} and standard deviation of {2:f}'.format(len(packet_times), average, std_dev)
     if packet_total_times:
         total_packet_time = 0.0
         total_packet_count = 0
@@ -1295,7 +1295,7 @@ def parse_gdb_log(file, options):
 
         print '#---------------------------------------------------'
         print '# Packet timing summary:'
-        print '# Totals: time = %6f, count = %6d' % (total_packet_time, total_packet_count)
+        print '# Totals: time = {0:6f}, count = {1:6d}'.format(total_packet_time, total_packet_count)
         print '#---------------------------------------------------'
         print '# Packet                   Time (sec) Percent Count '
         print '#------------------------- ---------- ------- ------'
@@ -1309,9 +1309,9 @@ def parse_gdb_log(file, options):
                 packet_total_time = packet_total_times[item]
                 packet_percent = (packet_total_time / total_packet_time)*100.0
                 if packet_percent >= 10.0:
-                    print "  %24s %.6f   %.2f%% %6d" % (item, packet_total_time, packet_percent, packet_count[item])
+                    print "  {0:24!s} {1:.6f}   {2:.2f}% {3:6d}".format(item, packet_total_time, packet_percent, packet_count[item])
                 else:
-                    print "  %24s %.6f   %.2f%%  %6d" % (item, packet_total_time, packet_percent, packet_count[item])
+                    print "  {0:24!s} {1:.6f}   {2:.2f}%  {3:6d}".format(item, packet_total_time, packet_percent, packet_count[item])
                     
     
     
@@ -1337,18 +1337,18 @@ if __name__ == '__main__':
         lldb.debugger = lldb.SBDebugger.Create()
         import lldb.macosx.crashlog
         options.symbolicator = lldb.macosx.crashlog.CrashLog(options.crashlog)
-        print '%s' % (options.symbolicator)
+        print '{0!s}'.format((options.symbolicator))
 
     # This script is being run from the command line, create a debugger in case we are
     # going to use any debugger functions in our function.
     if len(args):
         for file in args:
             print '#----------------------------------------------------------------------'
-            print "# GDB remote log file: '%s'" % file
+            print "# GDB remote log file: '{0!s}'".format(file)
             print '#----------------------------------------------------------------------'
             parse_gdb_log_file (file, options)
         if options.symbolicator:
-            print '%s' % (options.symbolicator)
+            print '{0!s}'.format((options.symbolicator))
     else:
         parse_gdb_log(sys.stdin, options)
         

--- a/examples/python/globals.py
+++ b/examples/python/globals.py
@@ -41,13 +41,13 @@ def get_globals(raw_path, options):
                         if global_variable_list:
                             # Print results for anything that matched
                             for global_variable in global_variable_list:
-                                print 'name = %s' % global_variable.name    # returns the global variable name as a string
-                                print 'value = %s' % global_variable.value  # Returns the variable value as a string
-                                print 'type = %s' % global_variable.type    # Returns an lldb.SBType object
-                                print 'addr = %s' % global_variable.addr    # Returns an lldb.SBAddress (section offset address) for this global
-                                print 'file_addr = 0x%x' % global_variable.addr.file_addr    # Returns the file virtual address for this global
-                                print 'location = %s' % global_variable.location    # returns the global variable value as a string
-                                print 'size = %s' % global_variable.size    # Returns the size in bytes of this global variable
+                                print 'name = {0!s}'.format(global_variable.name)    # returns the global variable name as a string
+                                print 'value = {0!s}'.format(global_variable.value)  # Returns the variable value as a string
+                                print 'type = {0!s}'.format(global_variable.type)    # Returns an lldb.SBType object
+                                print 'addr = {0!s}'.format(global_variable.addr)    # Returns an lldb.SBAddress (section offset address) for this global
+                                print 'file_addr = 0x{0:x}'.format(global_variable.addr.file_addr)    # Returns the file virtual address for this global
+                                print 'location = {0!s}'.format(global_variable.location)    # returns the global variable value as a string
+                                print 'size = {0!s}'.format(global_variable.size)    # Returns the size in bytes of this global variable
                                 print
 
 def globals(command_args):

--- a/examples/python/lldb_module_utils.py
+++ b/examples/python/lldb_module_utils.py
@@ -26,13 +26,13 @@ def dump_module_line_tables(debugger, command, result, dict):
         target = debugger.GetSelectedTarget()
         lldb.target = target
         for module_name in command_args:
-            result.PutCString('Searching for module "%s"' % (module_name,))
+            result.PutCString('Searching for module "{0!s}"'.format(module_name))
             module_fspec = lldb.SBFileSpec (module_name, False)
             module = target.FindModule (module_fspec);
             if module:
                 for cu_idx in range (module.GetNumCompileUnits()):
                     cu = module.GetCompileUnitAtIndex(cu_idx)
-                    result.PutCString("\n%s:" % (cu.file))
+                    result.PutCString("\n{0!s}:".format((cu.file)))
                     for line_idx in range(cu.GetNumLineEntries()):
                         line_entry = cu.GetLineEntryAtIndex(line_idx)
                         start_file_addr = line_entry.addr.file_addr
@@ -40,20 +40,20 @@ def dump_module_line_tables(debugger, command, result, dict):
                         # If the two addresses are equal, this line table entry is a termination entry
                         if options.verbose:
                             if start_file_addr != end_file_addr:
-                                result.PutCString('[%#x - %#x): %s' % (start_file_addr, end_file_addr, line_entry))
+                                result.PutCString('[{0:#x} - {1:#x}): {2!s}'.format(start_file_addr, end_file_addr, line_entry))
                         else:
                             if start_file_addr == end_file_addr:
-                                result.PutCString('%#x: END' % (start_file_addr))
+                                result.PutCString('{0:#x}: END'.format((start_file_addr)))
                             else:
-                                result.PutCString('%#x: %s' % (start_file_addr, line_entry))
+                                result.PutCString('{0:#x}: {1!s}'.format(start_file_addr, line_entry))
                         if start_file_addr == end_file_addr:
                             result.Printf("\n")
             else:
-                result.PutCString ("no module for '%s'" % module)
+                result.PutCString ("no module for '{0!s}'".format(module))
     else:
         result.PutCString ("error: invalid target")
 
 parser = create_dump_module_line_tables_options ()
 dump_module_line_tables.__doc__ = parser.format_help()
-lldb.debugger.HandleCommand('command script add -f %s.dump_module_line_tables dump_module_line_tables' % __name__)
+lldb.debugger.HandleCommand('command script add -f {0!s}.dump_module_line_tables dump_module_line_tables'.format(__name__))
 print 'Installed "dump_module_line_tables" command'

--- a/examples/python/lldbtk.py
+++ b/examples/python/lldbtk.py
@@ -44,8 +44,8 @@ class FrameTreeItemDelegate(object):
 
     def get_item_dictionary(self):
         id = self.frame.GetFrameID()
-        name = 'frame #%u' % (id);
-        value = '0x%16.16x' % (self.frame.GetPC())
+        name = 'frame #{0:d}'.format((id));
+        value = '0x{0:16.16x}'.format((self.frame.GetPC()))
         stream = lldb.SBStream()
         self.frame.GetDescription(stream)
         summary = stream.GetData().split("`")[1]
@@ -70,9 +70,9 @@ class ThreadTreeItemDelegate(object):
 
    def get_item_dictionary(self):
        num_frames = self.thread.GetNumFrames()
-       name = 'thread #%u' % (self.thread.GetIndexID())
-       value = '0x%x' % (self.thread.GetThreadID())
-       summary = '%u frames' % (num_frames)
+       name = 'thread #{0:d}'.format((self.thread.GetIndexID()))
+       value = '0x{0:x}'.format((self.thread.GetThreadID()))
+       summary = '{0:d} frames'.format((num_frames))
        return { '#0' : name,
                 'value': value, 
                 'summary': summary,
@@ -137,7 +137,7 @@ class TargetImagesTreeItemDelegate(object):
         num_modules = self.target.GetNumModules()
         return { '#0' : 'images',
                  'value': '', 
-                 'summary': '%u images' % num_modules,
+                 'summary': '{0:d} images'.format(num_modules),
                  'children' : num_modules > 0,
                  'tree-item-delegate' : self }
 
@@ -156,7 +156,7 @@ class ModuleTreeItemDelegate(object):
         self.index = index
 
     def get_item_dictionary(self):
-        name = 'module %u' % (self.index)
+        name = 'module {0:d}'.format((self.index))
         value = self.module.file.basename
         summary = self.module.file.dirname
         return { '#0' : name,
@@ -185,7 +185,7 @@ class ModuleSectionsTreeItemDelegate(object):
     def get_item_dictionary(self):
         name = 'sections'
         value = ''
-        summary = '%u sections' % (self.module.GetNumSections())
+        summary = '{0:d} sections'.format((self.module.GetNumSections()))
         return { '#0' : name,
                  'value': value, 
                  'summary': summary,
@@ -210,9 +210,9 @@ class SectionTreeItemDelegate(object):
         name = self.section.name
         section_load_addr = self.section.GetLoadAddress(self.target)
         if section_load_addr != lldb.LLDB_INVALID_ADDRESS:
-            value = '0x%16.16x' % (section_load_addr)
+            value = '0x{0:16.16x}'.format((section_load_addr))
         else:
-            value = '0x%16.16x *' % (self.section.file_addr)
+            value = '0x{0:16.16x} *'.format((self.section.file_addr))
         summary = ''
         return { '#0' : name,
                  'value': value, 
@@ -237,7 +237,7 @@ class ModuleCompileUnitsTreeItemDelegate(object):
     def get_item_dictionary(self):
         name = 'compile units'
         value = ''
-        summary = '%u compile units' % (self.module.GetNumSections())
+        summary = '{0:d} compile units'.format((self.module.GetNumSections()))
         return { '#0' : name,
                  'value': value, 
                  'summary': summary,
@@ -284,7 +284,7 @@ class LineTableTreeItemDelegate(object):
         name = 'line table'
         value = ''
         num_lines = self.cu.GetNumLineEntries()
-        summary = '%u line entries' % (num_lines)
+        summary = '{0:d} line entries'.format((num_lines))
         return { '#0' : name,
                  'value': value, 
                  'summary': summary,
@@ -311,9 +311,9 @@ class LineEntryTreeItemDelegate(object):
         address = self.line_entry.GetStartAddress()
         load_addr = address.GetLoadAddress(self.target)
         if load_addr != lldb.LLDB_INVALID_ADDRESS:
-            value = '0x%16.16x' % (load_addr)
+            value = '0x{0:16.16x}'.format((load_addr))
         else:
-            value = '0x%16.16x *' % (address.file_addr)
+            value = '0x{0:16.16x} *'.format((address.file_addr))
         summary = self.line_entry.GetFileSpec().fullpath + ':' + str(self.line_entry.line)
         return { '#0' : name,
                  'value': value, 
@@ -334,9 +334,9 @@ class InstructionTreeItemDelegate(object):
         address = self.instr.GetAddress()
         load_addr = address.GetLoadAddress(self.target)
         if load_addr != lldb.LLDB_INVALID_ADDRESS:
-            name = '0x%16.16x' % (load_addr)
+            name = '0x{0:16.16x}'.format((load_addr))
         else:
-            name = '0x%16.16x *' % (address.file_addr)
+            name = '0x{0:16.16x} *'.format((address.file_addr))
         value = self.instr.GetMnemonic(self.target) + ' ' + self.instr.GetOperands(self.target)
         summary = self.instr.GetComment(self.target)
         return { '#0' : name,
@@ -353,7 +353,7 @@ class ModuleSymbolsTreeItemDelegate(object):
     def get_item_dictionary(self):
         name = 'symbols'
         value = ''
-        summary = '%u symbols' % (self.module.GetNumSymbols())
+        summary = '{0:d} symbols'.format((self.module.GetNumSymbols()))
         return { '#0' : name,
                  'value': value, 
                  'summary': summary,
@@ -377,12 +377,12 @@ class SymbolTreeItemDelegate(object):
 
     def get_item_dictionary(self):
         address = self.symbol.GetStartAddress()
-        name = '[%u]' % self.index
+        name = '[{0:d}]'.format(self.index)
         symbol_load_addr = address.GetLoadAddress(self.target)
         if symbol_load_addr != lldb.LLDB_INVALID_ADDRESS:
-            value = '0x%16.16x' % (symbol_load_addr)
+            value = '0x{0:16.16x}'.format((symbol_load_addr))
         else:
-            value = '0x%16.16x *' % (address.file_addr)
+            value = '0x{0:16.16x} *'.format((address.file_addr))
         summary = self.symbol.name
         return { '#0' : name,
                  'value': value, 

--- a/examples/python/mach_o.py
+++ b/examples/python/mach_o.py
@@ -186,9 +186,9 @@ def dump_memory(base_addr, data, hex_bytes_len, num_per_line):
     while i < hex_bytes_len:
         if ((i/2) % num_per_line) == 0:
             if i > 0:
-                print ' %s' % (ascii_str)
+                print ' {0!s}'.format((ascii_str))
                 ascii_str = ''
-            print '0x%8.8x:' % (addr+i),
+            print '0x{0:8.8x}:'.format((addr+i)),
         hex_byte = hex_bytes[i:i+2]
         print hex_byte,
         int_byte = int (hex_byte, 16)
@@ -369,8 +369,8 @@ def dump_hex_bytes(addr, s, bytes_per_line=16):
         if (i % bytes_per_line) == 0:
             if line:
                 print line
-            line = '%#8.8x: ' % (addr + i)
-        line += "%02X " % ord(ch)
+            line = '{0:#8.8x}: '.format((addr + i))
+        line += "{0:02X} ".format(ord(ch))
         i += 1
     print line
 
@@ -401,9 +401,9 @@ def dump_hex_byte_string_diff(addr, a, b, bytes_per_line=16):
         if (i % bytes_per_line) == 0:
             if line:
                 print line
-            line = '%#8.8x: ' % (addr + i)
+            line = '{0:#8.8x}: '.format((addr + i))
         if mismatch: line += tty_colors.red()
-        line += "%02X " % ord(ch)
+        line += "{0:02X} ".format(ord(ch))
         if mismatch: line += tty_colors.default()
         i += 1
     
@@ -583,12 +583,12 @@ class Mach:
             self.archs      = list()
 
         def description(self):
-            s = '%#8.8x: %s (' % (self.file_off, self.path)
+            s = '{0:#8.8x}: {1!s} ('.format(self.file_off, self.path)
             archs_string = ''
             for arch in self.archs:
                 if len(archs_string):
                     archs_string += ', '
-                archs_string += '%s' % arch.arch
+                archs_string += '{0!s}'.format(arch.arch)
             s += archs_string
             s += ')'
             return s
@@ -621,7 +621,7 @@ class Mach:
         def dump(self, options):
             if options.dump_header:
                 print
-                print "Universal Mach File: magic = %s, nfat_arch = %u" % (self.magic, self.nfat_arch)
+                print "Universal Mach File: magic = {0!s}, nfat_arch = {1:d}".format(self.magic, self.nfat_arch)
                 print
             if self.nfat_arch > 0:
                 if options.dump_header:
@@ -693,19 +693,19 @@ class Mach:
                     print "---------- ---------- ---------- ----------"
             def dump_flat(self, options):
                 if options.verbose:
-                    print "%#8.8x %#8.8x %#8.8x %#8.8x %#8.8x" % (self.arch.cpu, self.arch.sub, self.offset, self.size, self.align)
+                    print "{0:#8.8x} {1:#8.8x} {2:#8.8x} {3:#8.8x} {4:#8.8x}".format(self.arch.cpu, self.arch.sub, self.offset, self.size, self.align)
                 else:
-                    print "%-10s %#8.8x %#8.8x %#8.8x" % (self.arch, self.offset, self.size, self.align)
+                    print "{0:<10!s} {1:#8.8x} {2:#8.8x} {3:#8.8x}".format(self.arch, self.offset, self.size, self.align)
             def dump(self):
-                print "   cputype: %#8.8x" % self.arch.cpu
-                print "cpusubtype: %#8.8x" % self.arch.sub
-                print "    offset: %#8.8x" % self.offset
-                print "      size: %#8.8x" % self.size
-                print "     align: %#8.8x" % self.align
+                print "   cputype: {0:#8.8x}".format(self.arch.cpu)
+                print "cpusubtype: {0:#8.8x}".format(self.arch.sub)
+                print "    offset: {0:#8.8x}".format(self.offset)
+                print "      size: {0:#8.8x}".format(self.size)
+                print "     align: {0:#8.8x}".format(self.align)
             def __str__(self):
-                return "Mach.Universal.ArchInfo: %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x" % (self.arch.cpu, self.arch.sub, self.offset, self.size, self.align)
+                return "Mach.Universal.ArchInfo: {0:#8.8x} {1:#8.8x} {2:#8.8x} {3:#8.8x} {4:#8.8x}".format(self.arch.cpu, self.arch.sub, self.offset, self.size, self.align)
             def __repr__(self):
-                return "Mach.Universal.ArchInfo: %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x" % (self.arch.cpu, self.arch.sub, self.offset, self.size, self.align)
+                return "Mach.Universal.ArchInfo: {0:#8.8x} {1:#8.8x} {2:#8.8x} {3:#8.8x} {4:#8.8x}".format(self.arch.cpu, self.arch.sub, self.offset, self.size, self.align)
                 
     class Flags:
 
@@ -809,7 +809,7 @@ class Mach:
             self.sections.append(Mach.Section())
 
         def description(self):
-            return '%#8.8x: %s (%s)' % (self.file_off, self.path, self.arch)
+            return '{0:#8.8x}: {1!s} ({2!s})'.format(self.file_off, self.path, self.arch)
             
         def unpack(self, data, magic = None):
             self.data = data
@@ -888,14 +888,14 @@ class Mach:
         
         def compare(self, rhs):
             print "\nComparing:"
-            print "a) %s %s" % (self.arch, self.path)
-            print "b) %s %s" % (rhs.arch, rhs.path)
+            print "a) {0!s} {1!s}".format(self.arch, self.path)
+            print "b) {0!s} {1!s}".format(rhs.arch, rhs.path)
             result = True
             if self.type == rhs.type:
                 for lhs_section in self.sections[1:]:
                     rhs_section = rhs.get_section_by_section(lhs_section)
                     if rhs_section:
-                        print 'comparing %s.%s...' % (lhs_section.segname, lhs_section.sectname),
+                        print 'comparing {0!s}.{1!s}...'.format(lhs_section.segname, lhs_section.sectname),
                         sys.stdout.flush()
                         lhs_data = lhs_section.get_contents (self)
                         rhs_data = rhs_section.get_contents (rhs)
@@ -926,26 +926,26 @@ class Mach:
                                 # dump_hex_byte_string_diff(0, rhs_data, lhs_data)
                         elif lhs_data and not rhs_data:
                             print 'error: section data missing from b:'
-                            print 'a) %s' % (lhs_section)
-                            print 'b) %s' % (rhs_section)
+                            print 'a) {0!s}'.format((lhs_section))
+                            print 'b) {0!s}'.format((rhs_section))
                             result = False
                         elif not lhs_data and rhs_data:
                             print 'error: section data missing from a:'
-                            print 'a) %s' % (lhs_section)
-                            print 'b) %s' % (rhs_section)
+                            print 'a) {0!s}'.format((lhs_section))
+                            print 'b) {0!s}'.format((rhs_section))
                             result = False
                         elif lhs_section.offset or rhs_section.offset:
                             print 'error: section data missing for both a and b:'
-                            print 'a) %s' % (lhs_section)
-                            print 'b) %s' % (rhs_section)
+                            print 'a) {0!s}'.format((lhs_section))
+                            print 'b) {0!s}'.format((rhs_section))
                             result = False
                         else:
                             print 'ok'
                     else:
                         result = False
-                        print 'error: section %s is missing in %s' % (lhs_section.sectname, rhs.path)
+                        print 'error: section {0!s} is missing in {1!s}'.format(lhs_section.sectname, rhs.path)
             else:
-                print 'error: comaparing a %s mach-o file with a %s mach-o file is not supported' % (self.type, rhs.type)
+                print 'error: comaparing a {0!s} mach-o file with a {1!s} mach-o file is not supported'.format(self.type, rhs.type)
                 result = False
             if not result:
                 print 'error: mach files differ'
@@ -960,9 +960,9 @@ class Mach:
 
         def dump_flat(self, options):
             if options.verbose:
-                print "%#8.8x %#8.8x %#8.8x %#8.8x %#8u %#8.8x %#8.8x" % (self.magic, self.arch.cpu , self.arch.sub, self.filetype.value, self.ncmds, self.sizeofcmds, self.flags.bits)
+                print "{0:#8.8x} {1:#8.8x} {2:#8.8x} {3:#8.8x} {4:8d} {5:#8.8x} {6:#8.8x}".format(self.magic, self.arch.cpu , self.arch.sub, self.filetype.value, self.ncmds, self.sizeofcmds, self.flags.bits)
             else:
-                print "%-12s %-10s %-14s %#8u %#8.8x %s" % (self.magic, self.arch, self.filetype, self.ncmds, self.sizeofcmds, self.flags)
+                print "{0:<12!s} {1:<10!s} {2:<14!s} {3:8d} {4:#8.8x} {5!s}".format(self.magic, self.arch, self.filetype, self.ncmds, self.sizeofcmds, self.flags)
 
         def dump(self, options):
             if options.dump_header:
@@ -986,13 +986,13 @@ class Mach:
             if dump_description:
                 print self.description()
             print "Mach Header"
-            print "       magic: %#8.8x %s" % (self.magic.value, self.magic)
-            print "     cputype: %#8.8x %s" % (self.arch.cpu, self.arch)
-            print "  cpusubtype: %#8.8x" % self.arch.sub
-            print "    filetype: %#8.8x %s" % (self.filetype.get_enum_value(), self.filetype.get_enum_name())
-            print "       ncmds: %#8.8x %u" % (self.ncmds, self.ncmds)
-            print "  sizeofcmds: %#8.8x" % self.sizeofcmds
-            print "       flags: %#8.8x %s" % (self.flags.bits, self.flags)
+            print "       magic: {0:#8.8x} {1!s}".format(self.magic.value, self.magic)
+            print "     cputype: {0:#8.8x} {1!s}".format(self.arch.cpu, self.arch)
+            print "  cpusubtype: {0:#8.8x}".format(self.arch.sub)
+            print "    filetype: {0:#8.8x} {1!s}".format(self.filetype.get_enum_value(), self.filetype.get_enum_name())
+            print "       ncmds: {0:#8.8x} {1:d}".format(self.ncmds, self.ncmds)
+            print "  sizeofcmds: {0:#8.8x}".format(self.sizeofcmds)
+            print "       flags: {0:#8.8x} {1!s}".format(self.flags.bits, self.flags)
             
         def dump_load_commands(self, dump_description = True, options = None):
             if dump_description:
@@ -1019,7 +1019,7 @@ class Mach:
             if num_sections > 1:
                 self.sections[1].dump_header()
                 for sect_idx in range(1,num_sections):
-                    print "%s" % self.sections[sect_idx]
+                    print "{0!s}".format(self.sections[sect_idx])
 
         def dump_section_contents(self, options):
             saved_section_to_disk = False
@@ -1048,19 +1048,19 @@ class Mach:
                                     data.seek (data_offset)
                                     outfile.write(data.read_size (data_size))
                             else:
-                                print "Saving section %s to '%s'" % (sectname, options.outfile)
+                                print "Saving section {0!s} to '{1!s}'".format(sectname, options.outfile)
                                 outfile.write(sect_bytes)
                             outfile.close()
                             saved_section_to_disk = True
                         else:
-                            print "error: you can only save a single section to disk at a time, skipping section '%s'" % (sectname)
+                            print "error: you can only save a single section to disk at a time, skipping section '{0!s}'".format((sectname))
                     else:
-                        print 'section %s:\n' % (sectname)
+                        print 'section {0!s}:\n'.format((sectname))
                         section.dump_header()
-                        print '%s\n' % (section)
+                        print '{0!s}\n'.format((section))
                         dump_memory (0, sect_bytes, options.max_count, 16)
                 else:
-                    print 'error: no section named "%s" was found' % (sectname)
+                    print 'error: no section named "{0!s}" was found'.format((sectname))
 
         def get_segment(self, segname):
             if len(self.segments) == 1 and self.segments[0].segname == '':
@@ -1105,7 +1105,7 @@ class Mach:
             if dump_description:
                 print self.description()
             for i, symbol in enumerate(self.symbols):
-                print '[%5u] %s' % (i, symbol)
+                print '[{0:5d}] {1!s}'.format(i, symbol)
         
         def dump_symbol_names_matching_regex(self, regex, file=None):
             self.get_symtab()
@@ -1113,7 +1113,7 @@ class Mach:
                 if symbol.name and regex.search (symbol.name):
                     print symbol.name
                     if file:
-                        file.write('%s\n' % (symbol.name))
+                        file.write('{0!s}\n'.format((symbol.name)))
         
         def is_64_bit(self):
             return self.magic.is_64_bit()
@@ -1184,7 +1184,7 @@ class Mach:
 
         def __str__(self):
             lc_name = self.command.get_enum_name()
-            return '%#8.8x: <%#4.4x> %-24s' % (self.file_off, self.length, lc_name)
+            return '{0:#8.8x}: <{1:#4.4x}> {2:<24!s}'.format(self.file_off, self.length, lc_name)
 
     class Section:
 
@@ -1225,9 +1225,9 @@ class Mach:
 
         def __str__(self):
             if self.is_64:
-                return "[%3u] %#16.16x %#16.16x %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %s.%s" % (self.index, self.addr, self.size, self.offset, self.align, self.reloff, self.nreloc, self.flags, self.reserved1, self.reserved2, self.reserved3, self.segname, self.sectname)
+                return "[{0:3d}] {1:#16.16x} {2:#16.16x} {3:#8.8x} {4:#8.8x} {5:#8.8x} {6:#8.8x} {7:#8.8x} {8:#8.8x} {9:#8.8x} {10:#8.8x} {11!s}.{12!s}".format(self.index, self.addr, self.size, self.offset, self.align, self.reloff, self.nreloc, self.flags, self.reserved1, self.reserved2, self.reserved3, self.segname, self.sectname)
             else:
-                return "[%3u] %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %#8.8x %s.%s" % (self.index, self.addr, self.size, self.offset, self.align, self.reloff, self.nreloc, self.flags, self.reserved1, self.reserved2, self.segname, self.sectname)
+                return "[{0:3d}] {1:#8.8x} {2:#8.8x} {3:#8.8x} {4:#8.8x} {5:#8.8x} {6:#8.8x} {7:#8.8x} {8:#8.8x} {9:#8.8x} {10!s}.{11!s}".format(self.index, self.addr, self.size, self.offset, self.align, self.reloff, self.nreloc, self.flags, self.reserved1, self.reserved2, self.segname, self.sectname)
 
         def get_contents(self, mach_file):
             '''Get the section contents as a python string'''
@@ -1258,7 +1258,7 @@ class Mach:
 
         def __str__(self):
             s = Mach.LoadCommand.__str__(self);
-            s += "%#8.8x %#8.8x %#8.8x " % (self.timestamp, self.current_version, self.compatibility_version)
+            s += "{0:#8.8x} {1:#8.8x} {2:#8.8x} ".format(self.timestamp, self.current_version, self.compatibility_version)
             s += self.name
             return s
     
@@ -1273,7 +1273,7 @@ class Mach:
 
         def __str__(self):
             s = Mach.LoadCommand.__str__(self);
-            s += "%s" % self.name
+            s += "{0!s}".format(self.name)
             return s
 
     class UnixThreadLoadCommand(LoadCommand):
@@ -1288,12 +1288,12 @@ class Mach:
                 self.register_values = data.get_n_uint32(self.count)
             
             def __str__(self):
-                s = "flavor = %u, count = %u, regs =" % (self.flavor, self.count)
+                s = "flavor = {0:d}, count = {1:d}, regs =".format(self.flavor, self.count)
                 i = 0
                 for register_value in self.register_values:
                     if i % 8 == 0:
                         s += "\n                                            "
-                    s += " %#8.8x" % register_value
+                    s += " {0:#8.8x}".format(register_value)
                     i += 1
                 return s
             
@@ -1309,7 +1309,7 @@ class Mach:
         def __str__(self):
             s = Mach.LoadCommand.__str__(self);
             for reg_set in self.reg_sets:
-                s += "%s" % reg_set
+                s += "{0!s}".format(reg_set)
             return s
 
     class DYLDInfoOnlyLoadCommand(LoadCommand):
@@ -1332,11 +1332,11 @@ class Mach:
 
         def __str__(self):
             s = Mach.LoadCommand.__str__(self);
-            s += "rebase_off = %#8.8x, rebase_size = %u, " % (self.rebase_off, self.rebase_size)
-            s += "bind_off = %#8.8x, bind_size = %u, " % (self.bind_off, self.bind_size)
-            s += "weak_bind_off = %#8.8x, weak_bind_size = %u, " % (self.weak_bind_off, self.weak_bind_size)
-            s += "lazy_bind_off = %#8.8x, lazy_bind_size = %u, " % (self.lazy_bind_off, self.lazy_bind_size)
-            s += "export_off = %#8.8x, export_size = %u, " % (self.export_off, self.export_size)
+            s += "rebase_off = {0:#8.8x}, rebase_size = {1:d}, ".format(self.rebase_off, self.rebase_size)
+            s += "bind_off = {0:#8.8x}, bind_size = {1:d}, ".format(self.bind_off, self.bind_size)
+            s += "weak_bind_off = {0:#8.8x}, weak_bind_size = {1:d}, ".format(self.weak_bind_off, self.weak_bind_size)
+            s += "lazy_bind_off = {0:#8.8x}, lazy_bind_size = {1:d}, ".format(self.lazy_bind_off, self.lazy_bind_size)
+            s += "export_off = {0:#8.8x}, export_size = {1:d}, ".format(self.export_off, self.export_size)
             return s
 
     class DYLDSymtabLoadCommand(LoadCommand):
@@ -1376,15 +1376,15 @@ class Mach:
             # s += "indirectsymoff = %#8.8x, nindirectsyms = %u, " % (self.indirectsymoff, self.nindirectsyms)
             # s += "extreloff = %#8.8x, nextrel = %u, " % (self.extreloff, self.nextrel)
             # s += "locreloff = %#8.8x, nlocrel = %u" % (self.locreloff, self.nlocrel)
-            s += "ilocalsym      = %-10u, nlocalsym     = %u\n" % (self.ilocalsym, self.nlocalsym)
-            s += "                                             iextdefsym     = %-10u, nextdefsym    = %u\n" % (self.iextdefsym, self.nextdefsym)
-            s += "                                             iundefsym      = %-10u, nundefsym     = %u\n" % (self.iundefsym, self.nundefsym)
-            s += "                                             tocoff         = %#8.8x, ntoc          = %u\n" % (self.tocoff, self.ntoc)
-            s += "                                             modtaboff      = %#8.8x, nmodtab       = %u\n" % (self.modtaboff, self.nmodtab)
-            s += "                                             extrefsymoff   = %#8.8x, nextrefsyms   = %u\n" % (self.extrefsymoff, self.nextrefsyms)
-            s += "                                             indirectsymoff = %#8.8x, nindirectsyms = %u\n" % (self.indirectsymoff, self.nindirectsyms)
-            s += "                                             extreloff      = %#8.8x, nextrel       = %u\n" % (self.extreloff, self.nextrel)
-            s += "                                             locreloff      = %#8.8x, nlocrel       = %u" % (self.locreloff, self.nlocrel)
+            s += "ilocalsym      = {0:<10d}, nlocalsym     = {1:d}\n".format(self.ilocalsym, self.nlocalsym)
+            s += "                                             iextdefsym     = {0:<10d}, nextdefsym    = {1:d}\n".format(self.iextdefsym, self.nextdefsym)
+            s += "                                             iundefsym      = {0:<10d}, nundefsym     = {1:d}\n".format(self.iundefsym, self.nundefsym)
+            s += "                                             tocoff         = {0:#8.8x}, ntoc          = {1:d}\n".format(self.tocoff, self.ntoc)
+            s += "                                             modtaboff      = {0:#8.8x}, nmodtab       = {1:d}\n".format(self.modtaboff, self.nmodtab)
+            s += "                                             extrefsymoff   = {0:#8.8x}, nextrefsyms   = {1:d}\n".format(self.extrefsymoff, self.nextrefsyms)
+            s += "                                             indirectsymoff = {0:#8.8x}, nindirectsyms = {1:d}\n".format(self.indirectsymoff, self.nindirectsyms)
+            s += "                                             extreloff      = {0:#8.8x}, nextrel       = {1:d}\n".format(self.extreloff, self.nextrel)
+            s += "                                             locreloff      = {0:#8.8x}, nlocrel       = {1:d}".format(self.locreloff, self.nlocrel)
             return s
 
     class SymtabLoadCommand(LoadCommand):                
@@ -1401,7 +1401,7 @@ class Mach:
                 
         def __str__(self):
             s = Mach.LoadCommand.__str__(self);
-            s += "symoff = %#8.8x, nsyms = %u, stroff = %#8.8x, strsize = %u" % (self.symoff, self.nsyms, self.stroff, self.strsize)
+            s += "symoff = {0:#8.8x}, nsyms = {1:d}, stroff = {2:#8.8x}, strsize = {3:d}".format(self.symoff, self.nsyms, self.stroff, self.strsize)
             return s
 
 
@@ -1414,7 +1414,7 @@ class Mach:
             uuid_data = data.get_n_uint8(16)
             uuid_str = ''
             for byte in uuid_data:
-                uuid_str += '%2.2x' % byte
+                uuid_str += '{0:2.2x}'.format(byte)
             self.uuid = uuid.UUID(uuid_str)
             mach_file.uuid = self.uuid
 
@@ -1435,7 +1435,7 @@ class Mach:
 
         def __str__(self):
             s = Mach.LoadCommand.__str__(self);
-            s += "dataoff = %#8.8x, datasize = %u" % (self.dataoff, self.datasize)
+            s += "dataoff = {0:#8.8x}, datasize = {1:d}".format(self.dataoff, self.datasize)
             return s
 
     class EncryptionInfoLoadCommand(LoadCommand):
@@ -1451,7 +1451,7 @@ class Mach:
 
         def __str__(self):
             s = Mach.LoadCommand.__str__(self);
-            s += "file-range = [%#8.8x - %#8.8x), cryptsize = %u, cryptid = %u" % (self.cryptoff, self.cryptoff + self.cryptsize, self.cryptsize, self.cryptid)
+            s += "file-range = [{0:#8.8x} - {1:#8.8x}), cryptsize = {2:d}, cryptid = {3:d}".format(self.cryptoff, self.cryptoff + self.cryptsize, self.cryptsize, self.cryptid)
             return s
 
     class SegmentLoadCommand(LoadCommand):
@@ -1487,10 +1487,10 @@ class Mach:
         def __str__(self):
             s = Mach.LoadCommand.__str__(self);
             if self.command.get_enum_value() == LC_SEGMENT:
-                s += "%#8.8x %#8.8x %#8.8x %#8.8x " % (self.vmaddr, self.vmsize, self.fileoff, self.filesize)
+                s += "{0:#8.8x} {1:#8.8x} {2:#8.8x} {3:#8.8x} ".format(self.vmaddr, self.vmsize, self.fileoff, self.filesize)
             else:
-                s += "%#16.16x %#16.16x %#16.16x %#16.16x " % (self.vmaddr, self.vmsize, self.fileoff, self.filesize)
-            s += "%s %s %3u %#8.8x" % (vm_prot_names[self.maxprot], vm_prot_names[self.initprot], self.nsects, self.flags)
+                s += "{0:#16.16x} {1:#16.16x} {2:#16.16x} {3:#16.16x} ".format(self.vmaddr, self.vmsize, self.fileoff, self.filesize)
+            s += "{0!s} {1!s} {2:3d} {3:#8.8x}".format(vm_prot_names[self.maxprot], vm_prot_names[self.initprot], self.nsects, self.flags)
             s += ' ' + self.segname
             return s
 
@@ -1539,7 +1539,7 @@ class Mach:
                 n_type = self.value
                 if n_type & N_STAB:
                     stab = Mach.NList.Type.Stab(self.value)
-                    return '%s' % stab
+                    return '{0!s}'.format(stab)
                 else:
                     type = self.value & N_TYPE
                     type_str = ''
@@ -1554,7 +1554,7 @@ class Mach:
                     elif type == N_INDR:
                         type_str = 'N_INDR'
                     else:
-                        type_str = "??? (%#2.2x)" % type
+                        type_str = "??? ({0:#2.2x})".format(type)
                     if n_type & N_PEXT:
                         type_str += ' | PEXT'
                     if n_type & N_EXT:
@@ -1588,8 +1588,8 @@ class Mach:
         def __str__(self):
             name_display = ''
             if len(self.name):
-                name_display = ' "%s"' % self.name
-            return '%#8.8x %#2.2x (%-20s) %#2.2x %#4.4x %16.16x%s' % (self.name_offset, self.type.value, self.type, self.sect_idx, self.desc, self.value, name_display)
+                name_display = ' "{0!s}"'.format(self.name)
+            return '{0:#8.8x} {1:#2.2x} ({2:<20!s}) {3:#2.2x} {4:#4.4x} {5:16.16x}{6!s}'.format(self.name_offset, self.type.value, self.type, self.sect_idx, self.desc, self.value, name_display)
 
 
     class Interactive(cmd.Cmd):
@@ -1598,13 +1598,13 @@ class Mach:
         def __init__(self, mach, options):
             cmd.Cmd.__init__(self)
             self.intro = 'Interactive mach-o command interpreter'
-            self.prompt = 'mach-o: %s %% ' % mach.path
+            self.prompt = 'mach-o: {0!s} % '.format(mach.path)
             self.mach = mach
             self.options = options
 
         def default(self, line):
             '''Catch all for unknown command, which will exit the interpreter.'''
-            print "uknown command: %s" % line
+            print "uknown command: {0!s}".format(line)
             return True
 
         def do_q(self, line):

--- a/examples/python/memory.py
+++ b/examples/python/memory.py
@@ -39,7 +39,7 @@ except ImportError:
                 except ImportError:
                     pass
                 else:
-                    print 'imported lldb from: "%s"' % (lldb_python_dir)
+                    print 'imported lldb from: "{0!s}"'.format((lldb_python_dir))
                     success = True
                     break
     if not success:
@@ -133,7 +133,7 @@ def memfind (target, options, args, result):
         start_addr = int(args[0], 0)
         end_addr = int(args[1], 0)
         if start_addr >= end_addr:
-            print_error ("error: inavlid memory range [%#x - %#x)" % (start_addr, end_addr), True, result)
+            print_error ("error: inavlid memory range [{0:#x} - {1:#x})".format(start_addr, end_addr), True, result)
             return
         options.size = end_addr - start_addr
     else:
@@ -156,21 +156,21 @@ def memfind (target, options, args, result):
     bytes = process.ReadMemory (start_addr, options.size, error)
     if error.Success():
         num_matches = 0
-        print >>result, "Searching memory range [%#x - %#x) for" % (start_addr, end_addr),
+        print >>result, "Searching memory range [{0:#x} - {1:#x}) for".format(start_addr, end_addr),
         for byte in options.data:
-            print >>result, '%2.2x' % ord(byte),
+            print >>result, '{0:2.2x}'.format(ord(byte)),
         print >>result
         
         match_index = string.find(bytes, options.data)
         while match_index != -1:
             num_matches = num_matches + 1
-            print >>result, '%#x: %#x + %u' % (start_addr + match_index, start_addr, match_index)
+            print >>result, '{0:#x}: {1:#x} + {2:d}'.format(start_addr + match_index, start_addr, match_index)
             match_index = string.find(bytes, options.data, match_index + 1)
             
         if num_matches == 0:
             print >>result, "error: no matches found"
     else:
-        print >>result, 'error: %s' % (error.GetCString())
+        print >>result, 'error: {0!s}'.format((error.GetCString()))
         
 
 if __name__ == '__main__':

--- a/examples/python/performance.py
+++ b/examples/python/performance.py
@@ -45,7 +45,7 @@ except ImportError:
                 except ImportError:
                     pass
                 else:
-                    print 'imported lldb from: "%s"' % (lldb_python_dir)
+                    print 'imported lldb from: "{0!s}"'.format((lldb_python_dir))
                     success = True
                     break
     if not success:
@@ -149,7 +149,7 @@ class TestCase:
             error = lldb.SBError()
             self.process = self.target.Launch (self.launch_info, error)
             if not error.Success():
-                print "error: %s" % error.GetCString()
+                print "error: {0!s}".format(error.GetCString())
             if self.process:
                 self.process.GetBroadcaster().AddListener(self.listener, lldb.SBProcess.eBroadcastBitStateChanged | lldb.SBProcess.eBroadcastBitInterrupt)
                 return True
@@ -163,7 +163,7 @@ class TestCase:
                 if self.listener.WaitForEvent (lldb.UINT32_MAX, process_event):
                     state = lldb.SBProcess.GetStateFromEvent (process_event)
                     if self.verbose:
-                        print "event = %s" % (lldb.SBDebugger.StateAsCString(state))
+                        print "event = {0!s}".format((lldb.SBDebugger.StateAsCString(state)))
                     if lldb.SBProcess.GetRestartedFromEvent(process_event):
                         continue
                     if state == lldb.eStateInvalid or state == lldb.eStateDetached or state == lldb.eStateCrashed or  state == lldb.eStateUnloaded or state == lldb.eStateExited:
@@ -182,7 +182,7 @@ class TestCase:
                             
                             stop_reason = thread.GetStopReason()
                             if self.verbose:
-                                print "tid = %#x pc = %#x " % (thread.GetThreadID(),frame.GetPC()),
+                                print "tid = {0:#x} pc = {1:#x} ".format(thread.GetThreadID(), frame.GetPC()),
                             if stop_reason == lldb.eStopReasonNone:
                                 if self.verbose:
                                     print "none"
@@ -213,15 +213,15 @@ class TestCase:
                                 bp_id = thread.GetStopReasonDataAtIndex(0)
                                 bp_loc_id = thread.GetStopReasonDataAtIndex(1)
                                 if self.verbose:
-                                    print "breakpoint id = %d.%d" % (bp_id, bp_loc_id)
+                                    print "breakpoint id = {0:d}.{1:d}".format(bp_id, bp_loc_id)
                             elif stop_reason == lldb.eStopReasonWatchpoint:
                                 select_thread = True
                                 if self.verbose:
-                                    print "watchpoint id = %d" % (thread.GetStopReasonDataAtIndex(0))
+                                    print "watchpoint id = {0:d}".format((thread.GetStopReasonDataAtIndex(0)))
                             elif stop_reason == lldb.eStopReasonSignal:
                                 select_thread = True
                                 if self.verbose:
-                                    print "signal %d" % (thread.GetStopReasonDataAtIndex(0))
+                                    print "signal {0:d}".format((thread.GetStopReasonDataAtIndex(0)))
                             
                             if select_thread and not selected_thread:
                                 self.thread = thread
@@ -250,7 +250,7 @@ class MemoryMeasurement(Measurement):
         Measurement.__init__(self)
         self.pid = pid
         self.stats = ["rprvt","rshrd","rsize","vsize","vprvt","kprvt","kshrd","faults","cow","pageins"]
-        self.command = "top -l 1 -pid %u -stats %s" % (self.pid, ",".join(self.stats))
+        self.command = "top -l 1 -pid {0:d} -stats {1!s}".format(self.pid, ",".join(self.stats))
         self.value = dict()
     
     def Measure(self):
@@ -278,7 +278,7 @@ class MemoryMeasurement(Measurement):
         for key in self.value.keys():
             if s:
                 s += "\n"
-            s += "%8s = %s" % (key, self.value[key])
+            s += "{0:8!s} = {1!s}".format(key, self.value[key])
         return s
 
 
@@ -291,7 +291,7 @@ class TesterTestCase(TestCase):
     def BreakpointHit (self, thread):
         bp_id = thread.GetStopReasonDataAtIndex(0)
         loc_id = thread.GetStopReasonDataAtIndex(1)
-        print "Breakpoint %i.%i hit: %s" % (bp_id, loc_id, thread.process.target.FindBreakpointByID(bp_id))
+        print "Breakpoint {0:d}.{1:d} hit: {2!s}".format(bp_id, loc_id, thread.process.target.FindBreakpointByID(bp_id))
         thread.StepOver()
     
     def PlanComplete (self, thread):
@@ -308,7 +308,7 @@ class TesterTestCase(TestCase):
             if self.target:
                 with Timer() as breakpoint_timer:
                     bp = self.target.BreakpointCreateByName("main")
-                print('Breakpoint time = %.03f sec.' % breakpoint_timer.interval)
+                print('Breakpoint time = {0:.03f} sec.'.format(breakpoint_timer.interval))
                 
                 self.user_actions.append (BreakpointAction(breakpoint=bp, callback=TesterTestCase.BreakpointHit, callback_owner=self))
                 self.user_actions.append (PlanCompleteAction(callback=TesterTestCase.PlanComplete, callback_owner=self))
@@ -319,8 +319,8 @@ class TesterTestCase(TestCase):
                 else:
                     print "error: failed to launch process"
             else:
-                print "error: failed to create target with '%s'" % (args[0])
-        print('Total time = %.03f sec.' % total_time.interval)
+                print "error: failed to create target with '{0!s}'".format((args[0]))
+        print('Total time = {0:.03f} sec.'.format(total_time.interval))
         
 
 if __name__ == '__main__':

--- a/examples/python/process_events.py
+++ b/examples/python/process_events.py
@@ -41,7 +41,7 @@ except ImportError:
                 except ImportError:
                     pass
                 else:
-                    print 'imported lldb from: "%s"' % (lldb_python_dir)
+                    print 'imported lldb from: "{0!s}"'.format((lldb_python_dir))
                     success = True
                     break
     if not success:
@@ -51,7 +51,7 @@ except ImportError:
 def print_threads(process, options):
     if options.show_threads:
         for thread in process:
-            print '%s %s' % (thread, thread.GetFrameAtIndex(0))
+            print '{0!s} {1!s}'.format(thread, thread.GetFrameAtIndex(0))
 
 def run_commands(command_interpreter, commands):
     return_obj = lldb.SBCommandReturnObject()
@@ -134,7 +134,7 @@ def main(argv):
     # Create a target from a file and arch
     
     if exe:
-        print "Creating a target for '%s'" % exe
+        print "Creating a target for '{0!s}'".format(exe)
     error = lldb.SBError()
     target = debugger.CreateTarget (exe, options.arch, options.platform, True, error)
     
@@ -144,7 +144,7 @@ def main(argv):
         # command line command to take advantage of the shorthand breakpoint creation
         if launch_info and options.breakpoints:
             for bp in options.breakpoints:
-                debugger.HandleCommand( "_regexp-break %s" % (bp))
+                debugger.HandleCommand( "_regexp-break {0!s}".format((bp)))
             run_commands(command_interpreter, ['breakpoint list'])
         
         for run_idx in range(options.run_count):
@@ -154,26 +154,26 @@ def main(argv):
             
             if launch_info:
                 if options.run_count == 1:
-                    print 'Launching "%s"...' % (exe)
+                    print 'Launching "{0!s}"...'.format((exe))
                 else:
-                    print 'Launching "%s"... (launch %u of %u)' % (exe, run_idx + 1, options.run_count)
+                    print 'Launching "{0!s}"... (launch {1:d} of {2:d})'.format(exe, run_idx + 1, options.run_count)
             
                 process = target.Launch (launch_info, error)
             else:
                 if options.attach_pid != -1:
-                    print 'Attaching to process %i...' % (options.attach_pid)
+                    print 'Attaching to process {0:d}...'.format((options.attach_pid))
                 else:
                     if options.attach_wait:
-                        print 'Waiting for next to process named "%s" to launch...' % (options.attach_name)
+                        print 'Waiting for next to process named "{0!s}" to launch...'.format((options.attach_name))
                     else:
-                        print 'Attaching to existing process named "%s"...' % (options.attach_name)
+                        print 'Attaching to existing process named "{0!s}"...'.format((options.attach_name))
                 process = target.Attach (attach_info, error)
             
             # Make sure the launch went ok
             if process and process.GetProcessID() != lldb.LLDB_INVALID_PROCESS_ID:
                 
                 pid = process.GetProcessID()
-                print 'Process is %i' % (pid)
+                print 'Process is {0:d}'.format((pid))
                 if attach_info:
                     # continue process if we attached as we won't get an initial event
                     process.Continue()
@@ -189,53 +189,53 @@ def main(argv):
                             state = lldb.SBProcess.GetStateFromEvent (event)
                             if state == lldb.eStateInvalid:
                                 # Not a state event
-                                print 'process event = %s' % (event)
+                                print 'process event = {0!s}'.format((event))
                             else:
-                                print "process state changed event: %s" % (lldb.SBDebugger.StateAsCString(state))
+                                print "process state changed event: {0!s}".format((lldb.SBDebugger.StateAsCString(state)))
                                 if state == lldb.eStateStopped:
                                     if stop_idx == 0:
                                         if launch_info:
-                                            print "process %u launched" % (pid)
+                                            print "process {0:d} launched".format((pid))
                                             run_commands(command_interpreter, ['breakpoint list'])
                                         else:
-                                            print "attached to process %u" % (pid)
+                                            print "attached to process {0:d}".format((pid))
                                             for m in target.modules:
                                                 print m
                                             if options.breakpoints:
                                                 for bp in options.breakpoints:
-                                                    debugger.HandleCommand( "_regexp-break %s" % (bp))
+                                                    debugger.HandleCommand( "_regexp-break {0!s}".format((bp)))
                                                 run_commands(command_interpreter, ['breakpoint list'])
                                         run_commands (command_interpreter, options.launch_commands)
                                     else:
                                         if options.verbose:
-                                            print "process %u stopped" % (pid)
+                                            print "process {0:d} stopped".format((pid))
                                         run_commands (command_interpreter, options.stop_commands)
                                     stop_idx += 1
                                     print_threads (process, options)
-                                    print "continuing process %u" % (pid)
+                                    print "continuing process {0:d}".format((pid))
                                     process.Continue()
                                 elif state == lldb.eStateExited:
                                     exit_desc = process.GetExitDescription()
                                     if exit_desc:
-                                        print "process %u exited with status %u: %s" % (pid, process.GetExitStatus (), exit_desc)
+                                        print "process {0:d} exited with status {1:d}: {2!s}".format(pid, process.GetExitStatus (), exit_desc)
                                     else:
-                                        print "process %u exited with status %u" % (pid, process.GetExitStatus ())
+                                        print "process {0:d} exited with status {1:d}".format(pid, process.GetExitStatus ())
                                     run_commands (command_interpreter, options.exit_commands)
                                     done = True
                                 elif state == lldb.eStateCrashed:
-                                    print "process %u crashed" % (pid)
+                                    print "process {0:d} crashed".format((pid))
                                     print_threads (process, options)
                                     run_commands (command_interpreter, options.crash_commands)
                                     done = True
                                 elif state == lldb.eStateDetached:
-                                    print "process %u detached" % (pid)
+                                    print "process {0:d} detached".format((pid))
                                     done = True
                                 elif state == lldb.eStateRunning:
                                     # process is running, don't say anything, we will always get one of these after resuming
                                     if options.verbose:
-                                        print "process %u resumed" % (pid)
+                                        print "process {0:d} resumed".format((pid))
                                 elif state == lldb.eStateUnloaded:
-                                    print "process %u unloaded, this shouldn't happen" % (pid)
+                                    print "process {0:d} unloaded, this shouldn't happen".format((pid))
                                     done = True
                                 elif state == lldb.eStateConnected:
                                     print "process connected"
@@ -244,21 +244,21 @@ def main(argv):
                                 elif state == lldb.eStateLaunching:
                                     print "process launching"
                         else:
-                            print 'event = %s' % (event)
+                            print 'event = {0!s}'.format((event))
                     else:
                         # timeout waiting for an event
-                        print "no process event for %u seconds, killing the process..." % (options.event_timeout)
+                        print "no process event for {0:d} seconds, killing the process...".format((options.event_timeout))
                         done = True
                 # Now that we are done dump the stdout and stderr
                 process_stdout = process.GetSTDOUT(1024)
                 if process_stdout:
-                    print "Process STDOUT:\n%s" % (process_stdout)
+                    print "Process STDOUT:\n{0!s}".format((process_stdout))
                     while process_stdout:
                         process_stdout = process.GetSTDOUT(1024)
                         print process_stdout
                 process_stderr = process.GetSTDERR(1024)
                 if process_stderr:
-                    print "Process STDERR:\n%s" % (process_stderr)
+                    print "Process STDERR:\n{0!s}".format((process_stderr))
                     while process_stderr:
                         process_stderr = process.GetSTDERR(1024)
                         print process_stderr

--- a/examples/python/pytracer.py
+++ b/examples/python/pytracer.py
@@ -18,7 +18,7 @@ class TracebackFancy:
 	def __str__(self):
 		if self.t == None:
 			return ""
-		str_self = "%s @ %s" % (self.getFrame().getName(), self.getLineNumber())
+		str_self = "{0!s} @ {1!s}".format(self.getFrame().getName(), self.getLineNumber())
 		return str_self + "\n" + self.getNext().__str__()
 
 class ExceptionFancy:
@@ -74,7 +74,7 @@ class ArgsFancy:
 		count = 0
 		size = len(args)
 		for arg in args:
-			ret = ret + ("%s = %s" % (arg, args[arg]))
+			ret = ret + ("{0!s} = {1!s}".format(arg, args[arg]))
 			count = count + 1
 			if count < size:
 				ret = ret + ", "
@@ -218,7 +218,7 @@ class LoggingTracer:
 		print "return from " + frame.getName() + " value is " + str(retval) + " locals are " + str(frame.getLocals())
 
 	def exceptionEvent(self,frame,exception):
-		print "exception %s %s raised from %s @ %s" %  (exception.getType(), str(exception.getValue()), frame.getName(), frame.getLineNumber())
+		print "exception {0!s} {1!s} raised from {2!s} @ {3!s}".format(exception.getType(), str(exception.getValue()), frame.getName(), frame.getLineNumber())
 		print "tb: " + str(exception.getTraceback())
 
 # the same functionality as LoggingTracer, but with a little more lldb-specific smarts
@@ -227,7 +227,7 @@ class LLDBAwareTracer:
 		if frame.getName() == "<module>":
 			return
 		if frame.getName() == "run_one_line":
-			print "call run_one_line(%s)" % (frame.getArgumentInfo().getArgs()["input_string"])
+			print "call run_one_line({0!s})".format((frame.getArgumentInfo().getArgs()["input_string"]))
 			return
 		if "Python.framework" in frame.getFileName():
 			print "call into Python at " + frame.getName()
@@ -241,7 +241,7 @@ class LLDBAwareTracer:
 			for arg in args:
 				if arg == "dict" or arg == "internal_dict":
 					continue
-				strout = strout + ("%s = %s " % (arg,args[arg]))
+				strout = strout + ("{0!s} = {1!s} ".format(arg, args[arg]))
 		else:
 			strout += " from " + frame.getCaller().getName() + " @ " + str(frame.getCaller().getLineNumber()) + " args are " + str(frame.getArgumentInfo())
 		print strout
@@ -250,7 +250,7 @@ class LLDBAwareTracer:
 		if frame.getName() == "<module>":
 			return
 		if frame.getName() == "run_one_line":
-			print "running run_one_line(%s) @ %s" % (frame.getArgumentInfo().getArgs()["input_string"],frame.getLineNumber())
+			print "running run_one_line({0!s}) @ {1!s}".format(frame.getArgumentInfo().getArgs()["input_string"], frame.getLineNumber())
 			return
 		if "Python.framework" in frame.getFileName():
 			print "running into Python at " + frame.getName() + " @ " + str(frame.getLineNumber())
@@ -261,7 +261,7 @@ class LLDBAwareTracer:
 			for local in locals:
 				if local == "dict" or local == "internal_dict":
 					continue
-				strout = strout + ("%s = %s " % (local,locals[local]))
+				strout = strout + ("{0!s} = {1!s} ".format(local, locals[local]))
 		else:
 			strout = strout + str(frame.getLocals())
 		strout = strout + " in " + frame.getFileName()
@@ -271,7 +271,7 @@ class LLDBAwareTracer:
 		if frame.getName() == "<module>":
 			return
 		if frame.getName() == "run_one_line":
-			print "return from run_one_line(%s) return value is %s" % (frame.getArgumentInfo().getArgs()["input_string"],retval)
+			print "return from run_one_line({0!s}) return value is {1!s}".format(frame.getArgumentInfo().getArgs()["input_string"], retval)
 			return
 		if "Python.framework" in frame.getFileName():
 			print "return from Python at " + frame.getName() + " return value is " + str(retval)
@@ -282,7 +282,7 @@ class LLDBAwareTracer:
 			for local in locals:
 				if local == "dict" or local == "internal_dict":
 					continue
-				strout = strout + ("%s = %s " % (local,locals[local]))
+				strout = strout + ("{0!s} = {1!s} ".format(local, locals[local]))
 		else:
 			strout = strout + str(frame.getLocals())
 		strout = strout + " in " + frame.getFileName()
@@ -291,7 +291,7 @@ class LLDBAwareTracer:
 	def exceptionEvent(self,frame,exception):
 		if frame.getName() == "<module>":
 			return
-		print "exception %s %s raised from %s @ %s" %  (exception.getType(), str(exception.getValue()), frame.getName(), frame.getLineNumber())
+		print "exception {0!s} {1!s} raised from {2!s} @ {3!s}".format(exception.getType(), str(exception.getValue()), frame.getName(), frame.getLineNumber())
 		print "tb: " + str(exception.getTraceback())
 
 def f(x,y=None):
@@ -305,7 +305,7 @@ def g(x):
 def print_keyword_args(**kwargs):
      # kwargs is a dict of the keyword args passed to the function
      for key, value in kwargs.iteritems():
-         print "%s = %s" % (key, value)
+         print "{0!s} = {1!s}".format(key, value)
 
 def total(initial=5, *numbers, **keywords):
     count = initial

--- a/examples/python/sbvalue.py
+++ b/examples/python/sbvalue.py
@@ -102,7 +102,7 @@ class variable(object):
     def __getitem__(self, key):
         # Allow array access if this value has children...
         if type(key) is int:
-            return variable(self.sbvalue.GetValueForExpressionPath("[%i]" % key))
+            return variable(self.sbvalue.GetValueForExpressionPath("[{0:d}]".format(key)))
         raise TypeError
 
     def __getattr__(self, name):
@@ -248,8 +248,8 @@ class variable(object):
         return float (self.sbvalue.GetValueAsSigned())
         
     def __oct__(self):
-        return '0%o' % self.sbvalue.GetValueAsSigned()
+        return '0{0:o}'.format(self.sbvalue.GetValueAsSigned())
         
     def __hex__(self):
-        return '0x%x' % self.sbvalue.GetValueAsSigned()
+        return '0x{0:x}'.format(self.sbvalue.GetValueAsSigned())
     

--- a/examples/python/sources.py
+++ b/examples/python/sources.py
@@ -5,10 +5,10 @@ import shlex
 
 def dump_module_sources(module, result):
     if module:
-        print >> result, "Module: %s" % (module.file)
+        print >> result, "Module: {0!s}".format((module.file))
         for compile_unit in module.compile_units:
             if compile_unit.file:
-                print >> result, "  %s" % (compile_unit.file)
+                print >> result, "  {0!s}".format((compile_unit.file))
     
 def info_sources(debugger, command, result, dict):
     description='''This command will dump all compile units in any modules that are listed as arguments, or for all modules if no arguments are supplied.'''

--- a/examples/python/stacks.py
+++ b/examples/python/stacks.py
@@ -22,7 +22,7 @@ def stack_frames(debugger, command, result, dict):
     frame_info = {}
     for thread in process:
         last_frame = None
-        print "thread %u" % (thread.id)
+        print "thread {0:d}".format((thread.id))
         for frame in thread.frames:
             if last_frame:
                 frame_size = 0
@@ -34,7 +34,7 @@ def stack_frames(debugger, command, result, dict):
                     else:
                         # First frame that has a valid size
                         first_frame_size = last_frame.fp - last_frame.sp 
-                    print "<%#7x> %s" % (first_frame_size, last_frame)
+                    print "<{0:#7x}> {1!s}".format(first_frame_size, last_frame)
                     if first_frame_size:
                         name = last_frame.name
                         if name not in frame_info:
@@ -44,7 +44,7 @@ def stack_frames(debugger, command, result, dict):
                 else:
                     # Second or higher frame
                     frame_size = frame.fp - last_frame.fp 
-                print "<%#7x> %s" % (frame_size, frame)
+                print "<{0:#7x}> {1!s}".format(frame_size, frame)
                 if frame_size > 0:
                     name = frame.name
                     if name not in frame_info:

--- a/examples/python/symbolication.py
+++ b/examples/python/symbolication.py
@@ -48,13 +48,13 @@ class Address:
         self.symbolication = None # The cached symbolicated string that describes this address
         self.inlined = False
     def __str__(self):
-        s = "%#16.16x" % (self.load_addr)
+        s = "{0:#16.16x}".format((self.load_addr))
         if self.symbolication:
-            s += " %s" % (self.symbolication)
+            s += " {0!s}".format((self.symbolication))
         elif self.description:
-            s += " %s" % (self.description)
+            s += " {0!s}".format((self.description))
         elif self.so_addr:
-            s += " %s" % (self.so_addr)
+            s += " {0!s}".format((self.so_addr))
         return s
 
     def resolve_addr(self):
@@ -124,21 +124,21 @@ class Address:
                     # Dump the offset from the current function or symbol if it is non zero
                     function_offset = self.load_addr - function_start_load_addr
                     if function_offset > 0:
-                        self.symbolication += " + %u" % (function_offset)
+                        self.symbolication += " + {0:d}".format((function_offset))
                     elif function_offset < 0:
-                        self.symbolication += " %i (invalid negative offset, file a bug) " % function_offset
+                        self.symbolication += " {0:d} (invalid negative offset, file a bug) ".format(function_offset)
 
                     # Print out any line information if any is available
                     if line_entry.GetFileSpec():
                         # Print full source file path in verbose mode
                         if verbose:
-                            self.symbolication += ' at %s' % line_entry.GetFileSpec()
+                            self.symbolication += ' at {0!s}'.format(line_entry.GetFileSpec())
                         else:
-                            self.symbolication += ' at %s' % line_entry.GetFileSpec().GetFilename()
-                        self.symbolication += ':%u' % line_entry.GetLine ()
+                            self.symbolication += ' at {0!s}'.format(line_entry.GetFileSpec().GetFilename())
+                        self.symbolication += ':{0:d}'.format(line_entry.GetLine ())
                         column = line_entry.GetColumn()
                         if column > 0:
-                            self.symbolication += ':%u' % column
+                            self.symbolication += ':{0:d}'.format(column)
                     return True
         return False
 
@@ -184,7 +184,7 @@ class Section:
                 if op == '+':
                     self.end_addr += self.start_addr
                 return True
-        print 'error: invalid section info string "%s"' % s
+        print 'error: invalid section info string "{0!s}"'.format(s)
         print 'Valid section info formats are:'
         print 'Format                Example                    Description'
         print '--------------------- -----------------------------------------------'
@@ -197,10 +197,10 @@ class Section:
         if self.name:
             if self.end_addr != None:
                 if self.start_addr != None:
-                    return "%s=[0x%16.16x - 0x%16.16x)" % (self.name, self.start_addr, self.end_addr)
+                    return "{0!s}=[0x{1:16.16x} - 0x{2:16.16x})".format(self.name, self.start_addr, self.end_addr)
             else:
                 if self.start_addr != None:
-                    return "%s=0x%16.16x" % (self.name, self.start_addr)
+                    return "{0!s}=0x{1:16.16x}".format(self.name, self.start_addr)
             return self.name
         return "<invalid>"
             
@@ -239,37 +239,37 @@ class Image:
         return obj
         
     def dump(self, prefix):
-        print "%s%s" % (prefix, self)
+        print "{0!s}{1!s}".format(prefix, self)
 
     def debug_dump(self):
-        print 'path = "%s"' % (self.path)
-        print 'resolved_path = "%s"' % (self.resolved_path)
-        print 'resolved = %i' % (self.resolved)
-        print 'unavailable = %i' % (self.unavailable)
-        print 'uuid = %s' % (self.uuid)
-        print 'section_infos = %s' % (self.section_infos)
-        print 'identifier = "%s"' % (self.identifier)
-        print 'version = %s' % (self.version)
-        print 'arch = %s' % (self.arch)
-        print 'module = %s' % (self.module)
-        print 'symfile = "%s"' % (self.symfile)
-        print 'slide = %i (0x%x)' % (self.slide, self.slide)
+        print 'path = "{0!s}"'.format((self.path))
+        print 'resolved_path = "{0!s}"'.format((self.resolved_path))
+        print 'resolved = {0:d}'.format((self.resolved))
+        print 'unavailable = {0:d}'.format((self.unavailable))
+        print 'uuid = {0!s}'.format((self.uuid))
+        print 'section_infos = {0!s}'.format((self.section_infos))
+        print 'identifier = "{0!s}"'.format((self.identifier))
+        print 'version = {0!s}'.format((self.version))
+        print 'arch = {0!s}'.format((self.arch))
+        print 'module = {0!s}'.format((self.module))
+        print 'symfile = "{0!s}"'.format((self.symfile))
+        print 'slide = {0:d} (0x{1:x})'.format(self.slide, self.slide)
         
     def __str__(self):
         s = ''
         if self.uuid:
-            s += "%s " % (self.get_uuid())
+            s += "{0!s} ".format((self.get_uuid()))
         if self.arch:
-            s += "%s " % (self.arch)
+            s += "{0!s} ".format((self.arch))
         if self.version:
-            s += "%s " % (self.version)
+            s += "{0!s} ".format((self.version))
         resolved_path = self.get_resolved_path()
         if resolved_path:
-            s += "%s " % (resolved_path)
+            s += "{0!s} ".format((resolved_path))
         for section_info in self.section_infos:
-            s += ", %s" % (section_info)
+            s += ", {0!s}".format((section_info))
         if self.slide != None:
-            s += ', slide = 0x%16.16x' % self.slide
+            s += ', slide = 0x{0:16.16x}'.format(self.slide)
         return s        
     
     def add_section(self, section):
@@ -321,11 +321,11 @@ class Image:
                                     if error.Success():
                                         num_sections_loaded += 1
                                     else:
-                                        return 'error: %s' % error.GetCString()
+                                        return 'error: {0!s}'.format(error.GetCString())
                                 else:
-                                    return 'error: unable to find the section named "%s"' % section_info.name
+                                    return 'error: unable to find the section named "{0!s}"'.format(section_info.name)
                             else:
-                                return 'error: unable to find "%s" section in "%s"' % (range.name, self.get_resolved_path())
+                                return 'error: unable to find "{0!s}" section in "{1!s}"'.format(range.name, self.get_resolved_path())
                         if num_sections_loaded == 0:
                             return 'error: no sections were successfully loaded'
                     else:
@@ -354,7 +354,7 @@ class Image:
                 resolved_path = self.get_resolved_path()
                 self.module = target.AddModule (resolved_path, self.arch, uuid_str, self.symfile)
             if not self.module:
-                return 'error: unable to get module for (%s) "%s"' % (self.arch, self.get_resolved_path())
+                return 'error: unable to get module for ({0!s}) "{1!s}"'.format(self.arch, self.get_resolved_path())
             if self.has_section_load_info():
                 return self.load_module(target)
             else:
@@ -401,9 +401,9 @@ class Image:
                         print 'ERROR: ', err
                 return target
             else:
-                print 'error: unable to create a valid target for (%s) "%s"' % (self.arch, self.path)
+                print 'error: unable to create a valid target for ({0!s}) "{1!s}"'.format(self.arch, self.path)
         else:
-            print 'error: unable to locate main executable (%s) "%s"' % (self.arch, self.path)
+            print 'error: unable to locate main executable ({0!s}) "{1!s}"'.format(self.arch, self.path)
         return None
     
 class Symbolicator:
@@ -433,13 +433,13 @@ class Symbolicator:
     def __str__(self):
         s = "Symbolicator:\n"
         if self.target:
-            s += "Target = '%s'\n" % (self.target)
+            s += "Target = '{0!s}'\n".format((self.target))
             s += "Target modules:\n"
             for m in self.target.modules:
                 s += str(m) + "\n"
         s += "Images:\n"
         for image in self.images:
-            s += '    %s\n' % (image)
+            s += '    {0!s}\n'.format((image))
         return s
     
     def find_images_with_identifier(self, identifier):
@@ -448,7 +448,7 @@ class Symbolicator:
             if image.identifier == identifier:
                 images.append(image)
         if len(images) == 0:
-            regex_text = '^.*\.%s$' % (identifier)
+            regex_text = '^.*\.{0!s}$'.format((identifier))
             regex = re.compile(regex_text)
             for image in self.images:
                 if regex.match(image.identifier):
@@ -537,12 +537,12 @@ def disassemble_instructions (target, instructions, pc, insts_before_pc, insts_a
         operands =  inst.GetOperands (target)
         comment =  inst.GetComment (target)
         #data = inst.GetData (target)
-        lines.append ("%#16.16x: %8s %s" % (inst_pc, mnemonic, operands))
+        lines.append ("{0:#16.16x}: {1:8!s} {2!s}".format(inst_pc, mnemonic, operands))
         if comment:
             line_len = len(lines[-1])
             if line_len < comment_column:
                 lines[-1] += ' ' * (comment_column - line_len)
-                lines[-1] += "; %s" % comment
+                lines[-1] += "; {0!s}".format(comment)
 
     if pc_index >= 0:
         # If we are disassembling the non-zeroeth frame, we need to backup the PC by 1
@@ -632,7 +632,7 @@ def Symbolicate(command_args):
                 print symbolicated_addr
             print
     else:
-        print 'error: no target for %s' % (symbolicator)
+        print 'error: no target for {0!s}'.format((symbolicator))
         
 if __name__ == '__main__':
     # Create a new debugger instance

--- a/examples/python/types.py
+++ b/examples/python/types.py
@@ -40,7 +40,7 @@ except ImportError:
                 except ImportError:
                     pass
                 else:
-                    print 'imported lldb from: "%s"' % (lldb_python_dir)
+                    print 'imported lldb from: "{0!s}"'.format((lldb_python_dir))
                     success = True
                     break
     if not success:
@@ -99,10 +99,10 @@ def verify_type (target, options, type):
     #     last_member_padding = byte_size - end_offset
     #     print '%+4u <%u> padding' % (end_offset, last_member_padding)
     #     padding += last_member_padding
-    print 'Total byte size: %u' % (byte_size)
-    print 'Total pad bytes: %u' % (padding)
+    print 'Total byte size: {0:d}'.format((byte_size))
+    print 'Total pad bytes: {0:d}'.format((padding))
     if padding > 0:
-        print 'Padding percentage: %2.2f %%' % ((float(padding) / float(byte_size)) * 100.0)
+        print 'Padding percentage: {0:2.2f} %'.format(((float(padding) / float(byte_size)) * 100.0))
     print
 
 def verify_type_recursive (target, options, type, member_name, depth, base_offset, padding):
@@ -110,9 +110,9 @@ def verify_type_recursive (target, options, type, member_name, depth, base_offse
     typename = type.GetName()
     byte_size = type.GetByteSize()
     if member_name and member_name != typename:
-        print '%+4u <%3u> %s%s %s;' % (base_offset, byte_size, '    ' * depth, typename, member_name)
+        print '{0:+4d} <{1:3d}> {2!s}{3!s} {4!s};'.format(base_offset, byte_size, '    ' * depth, typename, member_name)
     else:
-        print '%+4u {%3u} %s%s' % (base_offset, byte_size, '    ' * depth, typename)
+        print '{0:+4d} {{{1:3d}}} {2!s}{3!s}'.format(base_offset, byte_size, '    ' * depth, typename)
     
     for type_regex in options.skip_type_regexes:
         match = type_regex.match (typename)
@@ -134,13 +134,13 @@ def verify_type_recursive (target, options, type, member_name, depth, base_offse
                 member_is_class_or_struct = True
             if member_idx == 0 and member_offset == target.GetAddressByteSize() and type.IsPolymorphicClass():
                 ptr_size = target.GetAddressByteSize()
-                print '%+4u <%3u> %s__vtbl_ptr_type * _vptr;' % (prev_end_offset, ptr_size, '    ' * (depth + 1))
+                print '{0:+4d} <{1:3d}> {2!s}__vtbl_ptr_type * _vptr;'.format(prev_end_offset, ptr_size, '    ' * (depth + 1))
                 prev_end_offset = ptr_size
             else:
                 if prev_end_offset < member_total_offset:
                     member_padding = member_total_offset - prev_end_offset
                     padding = padding + member_padding
-                    print '%+4u <%3u> %s<PADDING>' % (prev_end_offset, member_padding, '    ' * (depth + 1))
+                    print '{0:+4d} <{1:3d}> {2!s}<PADDING>'.format(prev_end_offset, member_padding, '    ' * (depth + 1))
         
             if member_is_class_or_struct:
                 (prev_end_offset, padding) = verify_type_recursive (target, options, member_canonical_type, member_name, depth + 1, member_total_offset, padding)
@@ -148,18 +148,18 @@ def verify_type_recursive (target, options, type, member_name, depth, base_offse
                 prev_end_offset = member_total_offset + member_byte_size
                 member_typename = member_type.GetName()
                 if member.IsBitfield():
-                    print '%+4u <%3u> %s%s:%u %s;' % (member_total_offset, member_byte_size, '    ' * (depth + 1), member_typename, member.GetBitfieldSizeInBits(), member_name)
+                    print '{0:+4d} <{1:3d}> {2!s}{3!s}:{4:d} {5!s};'.format(member_total_offset, member_byte_size, '    ' * (depth + 1), member_typename, member.GetBitfieldSizeInBits(), member_name)
                 else:
-                    print '%+4u <%3u> %s%s %s;' % (member_total_offset, member_byte_size, '    ' * (depth + 1), member_typename, member_name)
+                    print '{0:+4d} <{1:3d}> {2!s}{3!s} {4!s};'.format(member_total_offset, member_byte_size, '    ' * (depth + 1), member_typename, member_name)
     
         if prev_end_offset < byte_size:
             last_member_padding = byte_size - prev_end_offset
-            print '%+4u <%3u> %s<PADDING>' % (prev_end_offset, last_member_padding, '    ' * (depth + 1))
+            print '{0:+4d} <{1:3d}> {2!s}<PADDING>'.format(prev_end_offset, last_member_padding, '    ' * (depth + 1))
             padding += last_member_padding
     else:
         if type.IsPolymorphicClass():
             ptr_size = target.GetAddressByteSize()
-            print '%+4u <%3u> %s__vtbl_ptr_type * _vptr;' % (prev_end_offset, ptr_size, '    ' * (depth + 1))
+            print '{0:+4d} <{1:3d}> {2!s}__vtbl_ptr_type * _vptr;'.format(prev_end_offset, ptr_size, '    ' * (depth + 1))
             prev_end_offset = ptr_size
         prev_end_offset = base_offset + byte_size
     
@@ -186,7 +186,7 @@ def parse_all_struct_class_types (debugger, command, result, dict):
         error = lldb.SBError()
         target = debugger.CreateTarget (f, None, None, False, error)
         module = target.GetModuleAtIndex(0)
-        print "Parsing all types in '%s'" % (module)
+        print "Parsing all types in '{0!s}'".format((module))
         types = module.GetTypes(lldb.eTypeClassClass | lldb.eTypeClassStruct)
         for t in types:
             print t
@@ -213,19 +213,19 @@ def verify_types (target, options):
     
     if modules:
         for module in modules:
-            print 'module: %s' % (module.file)
+            print 'module: {0!s}'.format((module.file))
             if options.typenames:
                 for typename in options.typenames:
                     types = module.FindTypes(typename)
                     if types.GetSize():
-                        print 'Found %u types matching "%s" in "%s"' % (len(types), typename, module.file)
+                        print 'Found {0:d} types matching "{1!s}" in "{2!s}"'.format(len(types), typename, module.file)
                         for type in types:
                             verify_type (target, options, type)
                     else:
-                        print 'error: no type matches "%s" in "%s"' % (typename, module.file)
+                        print 'error: no type matches "{0!s}" in "{1!s}"'.format(typename, module.file)
             else:
                 types = module.GetTypes(lldb.eTypeClassClass | lldb.eTypeClassStruct)
-                print 'Found %u types in "%s"' % (len(types), module.file)
+                print 'Found {0:d} types in "{1!s}"'.format(len(types), module.file)
                 for type in types:
                     verify_type (target, options, type)
     else:
@@ -242,7 +242,7 @@ if __name__ == '__main__':
     #     sys.exit(1)
     
     if options.debug:
-        print "Waiting for debugger to attach to process %d" % os.getpid()
+        print "Waiting for debugger to attach to process {0:d}".format(os.getpid())
         os.kill(os.getpid(), signal.SIGSTOP)
         
     for path in args:

--- a/examples/summaries/cocoa/metrics.py
+++ b/examples/summaries/cocoa/metrics.py
@@ -78,8 +78,7 @@ class Metrics:
 			return MetricsPrinter_Compact(self)
 		if name == 'verbose':
 			return MetricsPrinter_Verbose(self)
-		raise AttributeError("%r object has no attribute %r" %
-			                         (type(self).__name__, name))
+		raise AttributeError("{0!r} object has no attribute {1!r}".format(type(self).__name__, name))
 
 	def __str__(self):
 		return str(self.verbose)

--- a/examples/summaries/pysummary.py
+++ b/examples/summaries/pysummary.py
@@ -4,10 +4,10 @@ def pyobj_summary (value,unused):
 	if value == None or value.IsValid() == False or value.GetValueAsUnsigned(0) == 0:
 		return "<invalid>"
 	refcnt = value.GetChildMemberWithName("ob_refcnt")
-	expr = "(char*)PyString_AsString( (PyObject*)PyObject_Str( (PyObject*)0x%x) )" % (value.GetValueAsUnsigned(0))
+	expr = "(char*)PyString_AsString( (PyObject*)PyObject_Str( (PyObject*)0x{0:x}) )".format((value.GetValueAsUnsigned(0)))
 	expr_summary = value.target.EvaluateExpression(expr,lldb.SBExpressionOptions()).GetSummary()
-	refcnt_value = "rc = %d" % (refcnt.GetValueAsUnsigned(0))
-	return "%s (%s)" % (expr_summary,refcnt_value)
+	refcnt_value = "rc = {0:d}".format((refcnt.GetValueAsUnsigned(0)))
+	return "{0!s} ({1!s})".format(expr_summary, refcnt_value)
 
 def __lldb_init_module(debugger, unused):
 	debugger.HandleCommand("type summary add PyObject --python-function pysummary.pyobj_summary")

--- a/examples/summaries/unicode_strings.py
+++ b/examples/summaries/unicode_strings.py
@@ -20,7 +20,7 @@ def utf8_summary(value,unused):
 		return '""'
 	error = lldb.SBError()
 	string_data = value.process.ReadMemory(pointer, length, error)
-	return '"%s"' % (string_data) # utf8 is safe to emit as-is on OSX
+	return '"{0!s}"'.format((string_data)) # utf8 is safe to emit as-is on OSX
 
 def utf16_summary(value,unused):
 	pointer = value.GetChildMemberWithName("first").GetValueAsUnsigned(0)
@@ -32,7 +32,7 @@ def utf16_summary(value,unused):
 		return '""'
 	error = lldb.SBError()
 	string_data = value.process.ReadMemory(pointer, length, error)
-	return '"%s"' % (string_data.decode('utf-16').encode('utf-8')) # utf8 is safe to emit as-is on OSX
+	return '"{0!s}"'.format((string_data.decode('utf-16').encode('utf-8'))) # utf8 is safe to emit as-is on OSX
 
 def utf32_summary(value,unused):
 	pointer = value.GetChildMemberWithName("first").GetValueAsUnsigned(0)
@@ -44,5 +44,5 @@ def utf32_summary(value,unused):
 		return '""'
 	error = lldb.SBError()
 	string_data = value.process.ReadMemory(pointer, length, error)
-	return '"%s"' % (string_data.decode('utf-32').encode('utf-8')) # utf8 is safe to emit as-is on OSX
+	return '"{0!s}"'.format((string_data.decode('utf-32').encode('utf-8'))) # utf8 is safe to emit as-is on OSX
 

--- a/examples/synthetic/gnu_libstdcpp.py
+++ b/examples/synthetic/gnu_libstdcpp.py
@@ -23,7 +23,7 @@ class StdListSynthProvider:
 		logger = lldb.formatters.Logger.Logger()
 		valid = self.value(self.next_node(node)) != self.node_address
 		if valid:
-			logger >> "%s is valid" % str(self.valobj.GetName())
+			logger >> "{0!s} is valid".format(str(self.valobj.GetName()))
 		else:
 			logger >> "synthetic value is not valid"
 		return valid
@@ -246,7 +246,7 @@ class StdVectorSynthProvider:
 				value_expr = "(bool)true"
 			else:
 				value_expr = "(bool)false"
-			return self.valobj.CreateValueFromExpression("[%d]" % index, value_expr)
+			return self.valobj.CreateValueFromExpression("[{0:d}]".format(index), value_expr)
 
 		def update(self):
 			try:

--- a/examples/synthetic/libcxx.py
+++ b/examples/synthetic/libcxx.py
@@ -592,7 +592,7 @@ class stddeque_SynthProvider:
         except:
             self.block_size = -1
             self.element_size = -1
-        logger.write("block_size=%d, element_size=%d" % (self.block_size, self.element_size))
+        logger.write("block_size={0:d}, element_size={1:d}".format(self.block_size, self.element_size))
 
     def find_block_size(self):
         # in order to use the deque we must have the block size, or else
@@ -636,7 +636,7 @@ class stddeque_SynthProvider:
         try:
             i, j = divmod(self.start+index, self.block_size)
             return self.first.CreateValueFromExpression('[' + str(index) + ']',
-                                                        '*(*(%s + %d) + %d)' % (self.first.get_expr_path(), i, j))
+                                                        '*(*({0!s} + {1:d}) + {2:d})'.format(self.first.get_expr_path(), i, j))
         except:
             return None
 
@@ -695,7 +695,7 @@ class stddeque_SynthProvider:
             elif not (end_row-1)*self.block_size <= start+count < end_row*self.block_size:
                 logger.write("nth element must be before the 'end' row")
                 return
-            logger.write("update success: count=%r, start=%r, first=%r" % (count,start,first))
+            logger.write("update success: count={0!r}, start={1!r}, first={2!r}".format(count, start, first))
             # if consistent, save all we really need:
             self.count = count
             self.start = start

--- a/examples/synthetic/unordered_multi.py
+++ b/examples/synthetic/unordered_multi.py
@@ -37,13 +37,13 @@ class libcxx_hash_table_SynthProvider:
 			bl_ptr = table.GetChildMemberWithName('__bucket_list_').GetChildMemberWithName('__ptr_')
 			self.bucket_array_ptr = bl_ptr.GetChildMemberWithName('__first_').GetValueAsUnsigned(0)
 			self.bucket_count = bl_ptr.GetChildMemberWithName('__second_').GetChildMemberWithName('__data_').GetChildMemberWithName('__first_').GetValueAsUnsigned(0)
-			logger >> "Bucket count = %r" % self.bucket_count
+			logger >> "Bucket count = {0!r}".format(self.bucket_count)
 
 			self.begin_ptr = table.GetChildMemberWithName('__p1_').GetChildMemberWithName('__first_').GetChildMemberWithName('__next_')
 
 			self.num_elements    = table.GetChildMemberWithName('__p2_').GetChildMemberWithName('__first_').GetValueAsUnsigned(0)
 			self.max_load_factor = table.GetChildMemberWithName('__p3_').GetChildMemberWithName('__first_').GetValueAsUnsigned(0)
-			logger >> "Num elements = %r" % self.num_elements
+			logger >> "Num elements = {0!r}".format(self.num_elements)
 
 			# save the pointers as we get them
 			#   -- don't access this first element if num_element==0!
@@ -53,7 +53,7 @@ class libcxx_hash_table_SynthProvider:
 			else:
 				self.next_element = None
 		except Exception as e:
-			logger >> "Caught exception: %r" % e
+			logger >> "Caught exception: {0!r}".format(e)
 			pass
 
 	def num_children(self):
@@ -83,7 +83,7 @@ class libcxx_hash_table_SynthProvider:
 			return None
 
 		# extend
-		logger >> " : cache size starts with %d elements" % len(self.elements_cache)
+		logger >> " : cache size starts with {0:d} elements".format(len(self.elements_cache))
 		while index >= len(self.elements_cache):
 			# if we hit the end before we get the index, give up:
 			if not self.next_element:
@@ -101,9 +101,9 @@ class libcxx_hash_table_SynthProvider:
 				self.next_element = None
 
 		# hit the index! so we have the value
-		logger >> " : cache size ends with %d elements" % len(self.elements_cache)
+		logger >> " : cache size ends with {0:d} elements".format(len(self.elements_cache))
 		value, hash_value = self.elements_cache[index]
-		return self.valobj.CreateValueFromData('[%d] <hash %d>'%(index,hash_value), value.GetData(), value.GetType())
+		return self.valobj.CreateValueFromData('[{0:d}] <hash {1:d}>'.format(index, hash_value), value.GetData(), value.GetType())
 
 
 def __lldb_init_module(debugger,dict):

--- a/packages/Python/lldbsuite/support/fs.py
+++ b/packages/Python/lldbsuite/support/fs.py
@@ -59,6 +59,6 @@ def find_executable(executable):
 
     if not result or len(result) < 1:
         raise os.OSError(
-            "failed to find exe='%s' in paths='%s'" % (executable, paths_to_check))
+            "failed to find exe='{0!s}' in paths='{1!s}'".format(executable, paths_to_check))
     return result
 

--- a/packages/Python/lldbsuite/test/api/check_public_api_headers/TestPublicAPIHeaders.py
+++ b/packages/Python/lldbsuite/test/api/check_public_api_headers/TestPublicAPIHeaders.py
@@ -66,15 +66,15 @@ class SBDirCheckerCase(TestBase):
     def sanity_check_executable(self, exe_name):
         """Sanity check executable compiled from the auto-generated program."""
         exe = os.path.join(os.getcwd(), exe_name)
-        self.runCmd("file %s" % exe, CURRENT_EXECUTABLE_SET)
+        self.runCmd("file {0!s}".format(exe), CURRENT_EXECUTABLE_SET)
 
         self.line_to_break = line_number(self.source, '// Set breakpoint here.')
 
-        env_cmd = "settings set target.env-vars %s=%s" %(self.dylibPath, self.getLLDBLibraryEnvVal())
+        env_cmd = "settings set target.env-vars {0!s}={1!s}".format(self.dylibPath, self.getLLDBLibraryEnvVal())
         if self.TraceOn():
             print("Set environment to: ", env_cmd)
         self.runCmd(env_cmd)
-        self.addTearDownHook(lambda: self.dbg.HandleCommand("settings remove target.env-vars %s" % self.dylibPath))
+        self.addTearDownHook(lambda: self.dbg.HandleCommand("settings remove target.env-vars {0!s}".format(self.dylibPath)))
 
         lldbutil.run_break_set_by_file_and_line (self, self.source, self.line_to_break, num_expected_locations = -1)
 

--- a/packages/Python/lldbsuite/test/api/multiple-debuggers/TestMultipleDebuggers.py
+++ b/packages/Python/lldbsuite/test/api/multiple-debuggers/TestMultipleDebuggers.py
@@ -37,7 +37,7 @@ class TestMultipleSimultaneousDebuggers(TestBase):
 # will recognize it as a test failure.
 
         if self.TraceOn():
-            print("Running test %s" % self.driver_exe)
+            print("Running test {0!s}".format(self.driver_exe))
             check_call([self.driver_exe, self.inferior_exe], env=env)
         else:
             with open(os.devnull, 'w') as fnull:

--- a/packages/Python/lldbsuite/test/api/multithreaded/TestMultithreaded.py
+++ b/packages/Python/lldbsuite/test/api/multithreaded/TestMultithreaded.py
@@ -83,7 +83,7 @@ class SBBreakpointCallbackCase(TestBase):
 
         env = {self.dylibPath : self.getLLDBLibraryEnvVal()}
         if self.TraceOn():
-            print("Running test %s" % " ".join(exe))
+            print("Running test {0!s}".format(" ".join(exe)))
             check_call(exe, env=env)
         else:
             with open(os.devnull, 'w') as fnull:

--- a/packages/Python/lldbsuite/test/attic/tester.py
+++ b/packages/Python/lldbsuite/test/attic/tester.py
@@ -29,11 +29,11 @@ def prettyTime(t):
   if t == 0.0:
     return "0s"
   if t < 0.000001:
-    return ("%.3f" % (t * 1000000000.0)) + "ns"
+    return ("{0:.3f}".format((t * 1000000000.0))) + "ns"
   if t < 0.001:
-    return ("%.3f" % (t * 1000000.0)) + "µs"
+    return ("{0:.3f}".format((t * 1000000.0))) + "µs"
   if t < 1:
-    return ("%.3f" % (t * 1000.0)) + "ms"
+    return ("{0:.3f}".format((t * 1000.0))) + "ms"
   return str(t) + "s"
 
 class ExecutionTimes:

--- a/packages/Python/lldbsuite/test/bench.py
+++ b/packages/Python/lldbsuite/test/bench.py
@@ -62,10 +62,10 @@ Run the standard benchmarks defined in the list named 'benches'.\
 
     for item in benches:
         command = item.replace('%E',
-                               '-e "%s"' % opts.exe if opts.exe else '')
+                               '-e "{0!s}"'.format(opts.exe) if opts.exe else '')
         command = command.replace('%X',
-                               '-x "%s"' % opts.break_spec if opts.break_spec else '')
-        print("Running %s" % (command))
+                               '-x "{0!s}"'.format(opts.break_spec) if opts.break_spec else '')
+        print("Running {0!s}".format((command)))
         os.system(command)
 
     print("Bench runner done.")

--- a/packages/Python/lldbsuite/test/benchmarks/continue/TestBenchmarkContinue.py
+++ b/packages/Python/lldbsuite/test/benchmarks/continue/TestBenchmarkContinue.py
@@ -63,4 +63,4 @@ class TestBenchmarkContinue(BenchBase):
             lldbutil.continue_to_breakpoint(self.process(), bkpt)
             lldbutil_sw.stop()
             
-        print("runCmd: %s\nlldbutil: %s" % (runCmd_sw,lldbutil_sw))
+        print("runCmd: {0!s}\nlldbutil: {1!s}".format(runCmd_sw, lldbutil_sw))

--- a/packages/Python/lldbsuite/test/benchmarks/disassembly/TestDisassembly.py
+++ b/packages/Python/lldbsuite/test/benchmarks/disassembly/TestDisassembly.py
@@ -44,15 +44,15 @@ class DisassembleDriverMainLoop(BenchBase):
     def test_run_lldb_then_gdb(self):
         """Test disassembly on a large function with lldb vs. gdb."""
         print()
-        print("lldb path: %s" % lldbtest_config.lldbExec)
-        print("gdb path: %s" % self.gdbExec)
+        print("lldb path: {0!s}".format(lldbtest_config.lldbExec))
+        print("gdb path: {0!s}".format(self.gdbExec))
 
         print()
         self.run_lldb_disassembly(self.exe, self.function, self.count)
         print("lldb benchmark:", self.stopwatch)
         self.run_gdb_disassembly(self.exe, self.function, self.count)
         print("gdb benchmark:", self.stopwatch)
-        print("lldb_avg/gdb_avg: %f" % (self.lldb_avg/self.gdb_avg))
+        print("lldb_avg/gdb_avg: {0:f}".format((self.lldb_avg/self.gdb_avg)))
 
     @benchmarks_test
     @no_debug_info_test
@@ -60,15 +60,15 @@ class DisassembleDriverMainLoop(BenchBase):
     def test_run_gdb_then_lldb(self):
         """Test disassembly on a large function with lldb vs. gdb."""
         print()
-        print("lldb path: %s" % lldbtest_config.lldbExec)
-        print("gdb path: %s" % self.gdbExec)
+        print("lldb path: {0!s}".format(lldbtest_config.lldbExec))
+        print("gdb path: {0!s}".format(self.gdbExec))
 
         print()
         self.run_gdb_disassembly(self.exe, self.function, self.count)
         print("gdb benchmark:", self.stopwatch)
         self.run_lldb_disassembly(self.exe, self.function, self.count)
         print("lldb benchmark:", self.stopwatch)
-        print("lldb_avg/gdb_avg: %f" % (self.lldb_avg/self.gdb_avg))
+        print("lldb_avg/gdb_avg: {0:f}".format((self.lldb_avg/self.gdb_avg)))
 
     def run_lldb_disassembly(self, exe, function, count):
         import pexpect
@@ -77,7 +77,7 @@ class DisassembleDriverMainLoop(BenchBase):
         prompt = self.child_prompt
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s %s %s' % (lldbtest_config.lldbExec, self.lldbOption, exe))
+        self.child = pexpect.spawn('{0!s} {1!s} {2!s}'.format(lldbtest_config.lldbExec, self.lldbOption, exe))
         child = self.child
 
         # Turn on logging for what the child sends back.
@@ -85,7 +85,7 @@ class DisassembleDriverMainLoop(BenchBase):
             child.logfile_read = sys.stdout
 
         child.expect_exact(prompt)
-        child.sendline('breakpoint set -F %s' % function)
+        child.sendline('breakpoint set -F {0!s}'.format(function))
         child.expect_exact(prompt)
         child.sendline('run')
         child.expect_exact(prompt)
@@ -118,7 +118,7 @@ class DisassembleDriverMainLoop(BenchBase):
         prompt = self.child_prompt
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s --nx %s' % (self.gdbExec, exe))
+        self.child = pexpect.spawn('{0!s} --nx {1!s}'.format(self.gdbExec, exe))
         child = self.child
 
         # Turn on logging for what the child sends back.
@@ -126,7 +126,7 @@ class DisassembleDriverMainLoop(BenchBase):
             child.logfile_read = sys.stdout
 
         child.expect_exact(prompt)
-        child.sendline('break %s' % function)
+        child.sendline('break {0!s}'.format(function))
         child.expect_exact(prompt)
         child.sendline('run')
         child.expect_exact(prompt)

--- a/packages/Python/lldbsuite/test/benchmarks/disassembly/TestDoAttachThenDisassembly.py
+++ b/packages/Python/lldbsuite/test/benchmarks/disassembly/TestDoAttachThenDisassembly.py
@@ -36,7 +36,7 @@ class AttachThenDisassemblyBench(BenchBase):
         popen = subprocess.Popen([exe, self.lldbOption],
                                  stdout = open(os.devnull, 'w') if not self.TraceOn() else None)
         if self.TraceOn():
-            print("pid of spawned process: %d" % popen.pid)
+            print("pid of spawned process: {0:d}".format(popen.pid))
 
         # Attach to the launched lldb process.
         listener = lldb.SBListener("my.attach.listener")
@@ -55,7 +55,7 @@ class AttachThenDisassemblyBench(BenchBase):
                 found = True
                 thread0.SetSelectedFrame(i)
                 if self.TraceOn():
-                    print("Found frame#%d for function 'MainLoop'" % i)
+                    print("Found frame#{0:d} for function 'MainLoop'".format(i))
                 break
             i += 1
             

--- a/packages/Python/lldbsuite/test/benchmarks/disassembly/TestXcode41Vs42GDBDisassembly.py
+++ b/packages/Python/lldbsuite/test/benchmarks/disassembly/TestXcode41Vs42GDBDisassembly.py
@@ -35,7 +35,7 @@ class XCode41Vs42GDBDisassembly(BenchBase):
         self.run_gdb_disassembly(self.gdb_42_exe, self.exe, self.function, self.count)
         print("4.2 gdb benchmark:", self.stopwatch)
         self.gdb_42_avg = self.stopwatch.avg()
-        print("gdb_42_avg/gdb_41_avg: %f" % (self.gdb_42_avg/self.gdb_41_avg))
+        print("gdb_42_avg/gdb_41_avg: {0:f}".format((self.gdb_42_avg/self.gdb_41_avg)))
 
     @benchmarks_test
     @no_debug_info_test
@@ -49,7 +49,7 @@ class XCode41Vs42GDBDisassembly(BenchBase):
         self.run_gdb_disassembly(self.gdb_41_exe, self.exe, self.function, self.count)
         print("4.1 gdb benchmark:", self.stopwatch)
         self.gdb_41_avg = self.stopwatch.avg()
-        print("gdb_42_avg/gdb_41_avg: %f" % (self.gdb_42_avg/self.gdb_41_avg))
+        print("gdb_42_avg/gdb_41_avg: {0:f}".format((self.gdb_42_avg/self.gdb_41_avg)))
 
     def run_gdb_disassembly(self, gdb_exe_path, exe, function, count):
         import pexpect
@@ -58,7 +58,7 @@ class XCode41Vs42GDBDisassembly(BenchBase):
         prompt = self.child_prompt
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s --nx %s' % (gdb_exe_path, exe))
+        self.child = pexpect.spawn('{0!s} --nx {1!s}'.format(gdb_exe_path, exe))
         child = self.child
 
         # Turn on logging for what the child sends back.
@@ -66,7 +66,7 @@ class XCode41Vs42GDBDisassembly(BenchBase):
             child.logfile_read = sys.stdout
 
         child.expect_exact(prompt)
-        child.sendline('break %s' % function)
+        child.sendline('break {0!s}'.format(function))
         child.expect_exact(prompt)
         child.sendline('run')
         child.expect_exact(prompt)

--- a/packages/Python/lldbsuite/test/benchmarks/expression/TestExpressionCmd.py
+++ b/packages/Python/lldbsuite/test/benchmarks/expression/TestExpressionCmd.py
@@ -42,7 +42,7 @@ class ExpressionEvaluationCase(BenchBase):
         self.stopwatch.reset()
         for i in range(count):
             # So that the child gets torn down after the test.
-            self.child = pexpect.spawn('%s %s %s' % (lldbtest_config.lldbExec, self.lldbOption, exe))
+            self.child = pexpect.spawn('{0!s} {1!s} {2!s}'.format(lldbtest_config.lldbExec, self.lldbOption, exe))
             child = self.child
 
             # Turn on logging for what the child sends back.
@@ -50,7 +50,7 @@ class ExpressionEvaluationCase(BenchBase):
                 child.logfile_read = sys.stdout
 
             child.expect_exact(prompt)
-            child.sendline('breakpoint set -f %s -l %d' % (self.source, self.line_to_break))
+            child.sendline('breakpoint set -f {0!s} -l {1:d}'.format(self.source, self.line_to_break))
             child.expect_exact(prompt)
             child.sendline('run')
             child.expect_exact(prompt)

--- a/packages/Python/lldbsuite/test/benchmarks/expression/TestRepeatedExprs.py
+++ b/packages/Python/lldbsuite/test/benchmarks/expression/TestRepeatedExprs.py
@@ -33,7 +33,7 @@ class RepeatedExprsCase(BenchBase):
         print("lldb benchmark:", self.stopwatch)
         self.run_gdb_repeated_exprs(self.exe_name, self.count)
         print("gdb benchmark:", self.stopwatch)
-        print("lldb_avg/gdb_avg: %f" % (self.lldb_avg/self.gdb_avg))
+        print("lldb_avg/gdb_avg: {0:f}".format((self.lldb_avg/self.gdb_avg)))
 
     def run_lldb_repeated_exprs(self, exe_name, count):
         import pexpect
@@ -44,7 +44,7 @@ class RepeatedExprsCase(BenchBase):
         prompt = self.child_prompt
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s %s %s' % (lldbtest_config.lldbExec, self.lldbOption, exe))
+        self.child = pexpect.spawn('{0!s} {1!s} {2!s}'.format(lldbtest_config.lldbExec, self.lldbOption, exe))
         child = self.child
 
         # Turn on logging for what the child sends back.
@@ -52,7 +52,7 @@ class RepeatedExprsCase(BenchBase):
             child.logfile_read = sys.stdout
 
         child.expect_exact(prompt)
-        child.sendline('breakpoint set -f %s -l %d' % (self.source, self.line_to_break))
+        child.sendline('breakpoint set -f {0!s} -l {1:d}'.format(self.source, self.line_to_break))
         child.expect_exact(prompt)
         child.sendline('run')
         child.expect_exact(prompt)
@@ -90,7 +90,7 @@ class RepeatedExprsCase(BenchBase):
         prompt = self.child_prompt
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('gdb --nx %s' % exe)
+        self.child = pexpect.spawn('gdb --nx {0!s}'.format(exe))
         child = self.child
 
         # Turn on logging for what the child sends back.
@@ -98,7 +98,7 @@ class RepeatedExprsCase(BenchBase):
             child.logfile_read = sys.stdout
 
         child.expect_exact(prompt)
-        child.sendline('break %s:%d' % (self.source, self.line_to_break))
+        child.sendline('break {0!s}:{1:d}'.format(self.source, self.line_to_break))
         child.expect_exact(prompt)
         child.sendline('run')
         child.expect_exact(prompt)

--- a/packages/Python/lldbsuite/test/benchmarks/frame_variable/TestFrameVariableResponse.py
+++ b/packages/Python/lldbsuite/test/benchmarks/frame_variable/TestFrameVariableResponse.py
@@ -39,7 +39,7 @@ class FrameVariableResponseBench(BenchBase):
         self.stopwatch.reset()
         for i in range(count):
             # So that the child gets torn down after the test.
-            self.child = pexpect.spawn('%s %s %s' % (lldbtest_config.lldbExec, self.lldbOption, exe))
+            self.child = pexpect.spawn('{0!s} {1!s} {2!s}'.format(lldbtest_config.lldbExec, self.lldbOption, exe))
             child = self.child
 
             # Turn on logging for what the child sends back.
@@ -47,7 +47,7 @@ class FrameVariableResponseBench(BenchBase):
                 child.logfile_read = sys.stdout
 
             # Set our breakpoint.
-            child.sendline('breakpoint set %s' % break_spec)
+            child.sendline('breakpoint set {0!s}'.format(break_spec))
             child.expect_exact(prompt)
 
             # Run the target and expect it to be stopped due to breakpoint.

--- a/packages/Python/lldbsuite/test/benchmarks/libcxxlist/TestBenchmarkLibcxxList.py
+++ b/packages/Python/lldbsuite/test/benchmarks/libcxxlist/TestBenchmarkLibcxxList.py
@@ -56,4 +56,4 @@ class TestBenchmarkLibcxxList(BenchBase):
         self.expect('frame variable -A list', substrs=['[300]', '300'])
         sw.stop()
             
-        print("time to print: %s" % (sw))
+        print("time to print: {0!s}".format((sw)))

--- a/packages/Python/lldbsuite/test/benchmarks/libcxxmap/TestBenchmarkLibcxxMap.py
+++ b/packages/Python/lldbsuite/test/benchmarks/libcxxmap/TestBenchmarkLibcxxMap.py
@@ -56,4 +56,4 @@ class TestBenchmarkLibcxxMap(BenchBase):
         self.expect('frame variable -A map', substrs=['[300]', '300'])
         sw.stop()
             
-        print("time to print: %s" % (sw))
+        print("time to print: {0!s}".format((sw)))

--- a/packages/Python/lldbsuite/test/benchmarks/startup/TestStartupDelays.py
+++ b/packages/Python/lldbsuite/test/benchmarks/startup/TestStartupDelays.py
@@ -47,7 +47,7 @@ class StartupDelaysBench(BenchBase):
         self.stopwatch2.reset()
         for i in range(count):
             # So that the child gets torn down after the test.
-            self.child = pexpect.spawn('%s %s' % (lldbtest_config.lldbExec, self.lldbOption))
+            self.child = pexpect.spawn('{0!s} {1!s}'.format(lldbtest_config.lldbExec, self.lldbOption))
             child = self.child
 
             # Turn on logging for what the child sends back.
@@ -56,12 +56,12 @@ class StartupDelaysBench(BenchBase):
 
             with self.stopwatch:
                 # Create a fresh target.
-                child.sendline('file %s' % exe) # Aka 'target create'.
+                child.sendline('file {0!s}'.format(exe)) # Aka 'target create'.
                 child.expect_exact(prompt)
 
             with self.stopwatch2:
                 # Read debug info and set the first breakpoint.
-                child.sendline('breakpoint set %s' % break_spec)
+                child.sendline('breakpoint set {0!s}'.format(break_spec))
                 child.expect_exact(prompt)
 
             with self.stopwatch3:

--- a/packages/Python/lldbsuite/test/benchmarks/stepping/TestSteppingSpeed.py
+++ b/packages/Python/lldbsuite/test/benchmarks/stepping/TestSteppingSpeed.py
@@ -37,7 +37,7 @@ class SteppingSpeedBench(BenchBase):
         prompt = self.child_prompt
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s %s %s' % (lldbtest_config.lldbExec, self.lldbOption, exe))
+        self.child = pexpect.spawn('{0!s} {1!s} {2!s}'.format(lldbtest_config.lldbExec, self.lldbOption, exe))
         child = self.child
 
         # Turn on logging for what the child sends back.
@@ -45,7 +45,7 @@ class SteppingSpeedBench(BenchBase):
             child.logfile_read = sys.stdout
 
         child.expect_exact(prompt)
-        child.sendline('breakpoint set %s' % break_spec)
+        child.sendline('breakpoint set {0!s}'.format(break_spec))
         child.expect_exact(prompt)
         child.sendline('run')
         child.expect_exact(prompt)

--- a/packages/Python/lldbsuite/test/benchmarks/swiftdictionary/TestBenchmarkSwiftDictionary.py
+++ b/packages/Python/lldbsuite/test/benchmarks/swiftdictionary/TestBenchmarkSwiftDictionary.py
@@ -70,4 +70,4 @@ class TestBenchmarkSwiftDictionary(BenchBase):
         self.expect('frame variable -A dict', substrs=['[300]', '300'])
         sw.stop()
             
-        print("time to print: %s" % (sw))
+        print("time to print: {0!s}".format((sw)))

--- a/packages/Python/lldbsuite/test/benchmarks/turnaround/TestCompileRunToBreakpointTurnaround.py
+++ b/packages/Python/lldbsuite/test/benchmarks/turnaround/TestCompileRunToBreakpointTurnaround.py
@@ -32,7 +32,7 @@ class CompileRunToBreakpointBench(BenchBase):
         print("lldb turnaround benchmark:", self.stopwatch)
         self.run_gdb_turnaround(self.exe, self.function, self.count)
         print("gdb turnaround benchmark:", self.stopwatch)
-        print("lldb_avg/gdb_avg: %f" % (self.lldb_avg/self.gdb_avg))
+        print("lldb_avg/gdb_avg: {0:f}".format((self.lldb_avg/self.gdb_avg)))
 
     def run_lldb_turnaround(self, exe, function, count):
         import pexpect
@@ -40,7 +40,7 @@ class CompileRunToBreakpointBench(BenchBase):
             prompt = self.child_prompt
 
             # So that the child gets torn down after the test.
-            self.child = pexpect.spawn('%s %s %s' % (lldbtest_config.lldbExec, self.lldbOption, exe))
+            self.child = pexpect.spawn('{0!s} {1!s} {2!s}'.format(lldbtest_config.lldbExec, self.lldbOption, exe))
             child = self.child
 
             # Turn on logging for what the child sends back.
@@ -48,7 +48,7 @@ class CompileRunToBreakpointBench(BenchBase):
                 child.logfile_read = sys.stdout
 
             child.expect_exact(prompt)
-            child.sendline('breakpoint set -F %s' % function)
+            child.sendline('breakpoint set -F {0!s}'.format(function))
             child.expect_exact(prompt)
             child.sendline('run')
             child.expect_exact(prompt)
@@ -81,7 +81,7 @@ class CompileRunToBreakpointBench(BenchBase):
             prompt = self.child_prompt
 
             # So that the child gets torn down after the test.
-            self.child = pexpect.spawn('gdb --nx %s' % exe)
+            self.child = pexpect.spawn('gdb --nx {0!s}'.format(exe))
             child = self.child
 
             # Turn on logging for what the child sends back.
@@ -89,7 +89,7 @@ class CompileRunToBreakpointBench(BenchBase):
                 child.logfile_read = sys.stdout
 
             child.expect_exact(prompt)
-            child.sendline('break %s' % function)
+            child.sendline('break {0!s}'.format(function))
             child.expect_exact(prompt)
             child.sendline('run')
             child.expect_exact(prompt)

--- a/packages/Python/lldbsuite/test/configuration.py
+++ b/packages/Python/lldbsuite/test/configuration.py
@@ -41,7 +41,7 @@ def setupCrashInfoHook():
             compile_lock.acquire()
             if not os.path.isfile(dylib_dst) or os.path.getmtime(dylib_dst) < os.path.getmtime(dylib_src):
                 # we need to compile
-                cmd = "SDKROOT= xcrun clang %s -o %s -framework Python -Xlinker -dylib -iframework /System/Library/Frameworks/ -Xlinker -F /System/Library/Frameworks/" % (dylib_src,dylib_dst)
+                cmd = "SDKROOT= xcrun clang {0!s} -o {1!s} -framework Python -Xlinker -dylib -iframework /System/Library/Frameworks/ -Xlinker -F /System/Library/Frameworks/".format(dylib_src, dylib_dst)
                 if subprocess.call(cmd,shell=True) != 0 or not os.path.isfile(dylib_dst):
                     raise Exception('command failed: "{}"'.format(cmd))
         finally:

--- a/packages/Python/lldbsuite/test/curses_results.py
+++ b/packages/Python/lldbsuite/test/curses_results.py
@@ -93,10 +93,10 @@ class Curses(result_formatter.ResultsFormatter):
             self.main_window.push_first_responder(self.info_panel)
             test_start = self.results[selected_idx][0]
             test_result = self.results[selected_idx][1]
-            self.info_panel.set_line(0, "File: %s" % (test_start['test_filename']))
-            self.info_panel.set_line(1, "Test: %s.%s" % (test_start['test_class'], test_start['test_name']))
-            self.info_panel.set_line(2, "Time: %s" % (test_result['elapsed_time']))
-            self.info_panel.set_line(3, "Status: %s" % (test_result['status']))
+            self.info_panel.set_line(0, "File: {0!s}".format((test_start['test_filename'])))
+            self.info_panel.set_line(1, "Test: {0!s}.{1!s}".format(test_start['test_class'], test_start['test_name']))
+            self.info_panel.set_line(2, "Time: {0!s}".format((test_result['elapsed_time'])))
+            self.info_panel.set_line(3, "Status: {0!s}".format((test_result['status'])))
 
     def hide_info_panel(self):
         self.main_window.pop_first_responder(self.info_panel)
@@ -122,7 +122,7 @@ class Curses(result_formatter.ResultsFormatter):
             if status in self.hide_status_list:
                 continue
             name = test_result['test_class'] + '.' + test_result['test_name']
-            self.results_panel.append_line('%s (%6.2f sec) %s' % (self.status_to_short_str(status), test_result['elapsed_time'], name))
+            self.results_panel.append_line('{0!s} ({1:6.2f} sec) {2!s}'.format(self.status_to_short_str(status), test_result['elapsed_time'], name))
         if update:
             self.main_window.refresh()
 
@@ -145,7 +145,7 @@ class Curses(result_formatter.ResultsFormatter):
                         name = test_event['test_class'] + '.' + test_event['test_name']
                         self.job_tests[worker_index] = test_event
                         if 'pid' in test_event:
-                            line = 'pid: %5d ' % (test_event['pid']) + name
+                            line = 'pid: {0:5d} '.format((test_event['pid'])) + name
                         else:
                             line = name
                         self.job_panel.set_line(worker_index, line)
@@ -154,14 +154,14 @@ class Curses(result_formatter.ResultsFormatter):
                         status = test_event['status']
                         self.status_panel.increment_status(status)
                         if 'pid' in test_event:
-                            line = 'pid: %5d ' % (test_event['pid'])
+                            line = 'pid: {0:5d} '.format((test_event['pid']))
                         else:
                             line = ''
                         self.job_panel.set_line(worker_index, line)
                         name = test_event['test_class'] + '.' + test_event['test_name']
                         elapsed_time = test_event['event_time'] - self.job_tests[worker_index]['event_time']
                         if not status in self.hide_status_list:
-                            self.results_panel.append_line('%s (%6.2f sec) %s' % (self.status_to_short_str(status), elapsed_time, name))
+                            self.results_panel.append_line('{0!s} ({1:6.2f} sec) {2!s}'.format(self.status_to_short_str(status), elapsed_time, name))
                         self.main_window.refresh()
                         # Append the result pairs
                         test_event['elapsed_time'] = elapsed_time
@@ -170,7 +170,7 @@ class Curses(result_formatter.ResultsFormatter):
                     elif event == 'job_begin':
                         self.jobs[worker_index] = test_event
                         if 'pid' in test_event:
-                            line = 'pid: %5d ' % (test_event['pid'])
+                            line = 'pid: {0:5d} '.format((test_event['pid']))
                         else:
                             line = ''
                         self.job_panel.set_line(worker_index, line)

--- a/packages/Python/lldbsuite/test/dosep.py
+++ b/packages/Python/lldbsuite/test/dosep.py
@@ -115,8 +115,8 @@ def report_test_failure(name, command, output):
         if not (RESULTS_FORMATTER and RESULTS_FORMATTER.is_using_terminal()):
             print(file=sys.stderr)
             print(output, file=sys.stderr)
-            print("[%s FAILED]" % name, file=sys.stderr)
-            print("Command invoked: %s" % ' '.join(command), file=sys.stderr)
+            print("[{0!s} FAILED]".format(name), file=sys.stderr)
+            print("Command invoked: {0!s}".format(' '.join(command)), file=sys.stderr)
         update_progress(name)
 
 
@@ -427,7 +427,7 @@ def process_dir(root, files, dotest_argv, inferior_pid_events):
 
         timeout_name = os.path.basename(os.path.splitext(base_name)[0]).upper()
 
-        timeout = (os.getenv("LLDB_%s_TIMEOUT" % timeout_name) or
+        timeout = (os.getenv("LLDB_{0!s}_TIMEOUT".format(timeout_name)) or
                    getDefaultTimeout(dotest_options.lldb_platform_name))
 
         results.append(call_with_timeout(
@@ -631,7 +631,7 @@ def initialize_global_vars_common(num_threads, test_work_items):
     test_counter = multiprocessing.Value('i', 0)
     test_name_len = multiprocessing.Value('i', 0)
     if not (RESULTS_FORMATTER and RESULTS_FORMATTER.is_using_terminal()):
-        print("Testing: %d test suites, %d thread%s" % (
+        print("Testing: {0:d} test suites, {1:d} thread{2!s}".format(
             total_tests, num_threads, (num_threads > 1) * "s"), file=sys.stderr)
     update_progress()
 
@@ -1638,32 +1638,32 @@ def main(num_threads, test_subdir, test_runner_name, results_formatter):
     else:
         # Print the legacy test results summary.
         print()
-        sys.stdout.write("Ran %d test suites" % num_test_files)
+        sys.stdout.write("Ran {0:d} test suites".format(num_test_files))
         if num_test_files > 0:
-            sys.stdout.write(" (%d failed) (%f%%)" % (
+            sys.stdout.write(" ({0:d} failed) ({1:f}%)".format(
                 len(failed), 100.0 * len(failed) / num_test_files))
         print()
-        sys.stdout.write("Ran %d test cases" % num_test_cases)
+        sys.stdout.write("Ran {0:d} test cases".format(num_test_cases))
         if num_test_cases > 0:
-            sys.stdout.write(" (%d failed) (%f%%)" % (
+            sys.stdout.write(" ({0:d} failed) ({1:f}%)".format(
                 fail_count, 100.0 * fail_count / num_test_cases))
         print()
         exit_code = 0
 
         if len(failed) > 0:
             failed.sort()
-            print("Failing Tests (%d)" % len(failed))
+            print("Failing Tests ({0:d})".format(len(failed)))
             for f in failed:
-                print("%s: LLDB (suite) :: %s (%s)" % (
+                print("{0!s}: LLDB (suite) :: {1!s} ({2!s})".format(
                     "TIMEOUT" if f in timed_out else "FAIL", f, system_info
                 ))
             exit_code = 1
 
         if len(unexpected_successes) > 0:
             unexpected_successes.sort()
-            print("\nUnexpected Successes (%d)" % len(unexpected_successes))
+            print("\nUnexpected Successes ({0:d})".format(len(unexpected_successes)))
             for u in unexpected_successes:
-                print("UNEXPECTED SUCCESS: LLDB (suite) :: %s (%s)" % (u, system_info))
+                print("UNEXPECTED SUCCESS: LLDB (suite) :: {0!s} ({1!s})".format(u, system_info))
 
     sys.exit(exit_code)
 

--- a/packages/Python/lldbsuite/test/dotest.py
+++ b/packages/Python/lldbsuite/test/dotest.py
@@ -237,7 +237,7 @@ def parseOptionsAndInitTestdirs():
     else:
         # Use a compiler appropriate appropriate for the Apple SDK if one was specified
         if platform_system == 'Darwin' and args.apple_sdk:
-            configuration.compilers = [seven.get_command_output('xcrun -sdk "%s" -find clang 2> /dev/null' % (args.apple_sdk))]
+            configuration.compilers = [seven.get_command_output('xcrun -sdk "{0!s}" -find clang 2> /dev/null'.format((args.apple_sdk)))]
         else:
             # 'clang' on ubuntu 14.04 is 3.4 so we try clang-3.5 first
             candidateCompilers = ['clang-3.5', 'clang', 'gcc']
@@ -254,7 +254,7 @@ def parseOptionsAndInitTestdirs():
 
     # Set SDKROOT if we are using an Apple SDK
     if platform_system == 'Darwin' and args.apple_sdk:
-        os.environ['SDKROOT'] = seven.get_command_output('xcrun --sdk "%s" --show-sdk-path 2> /dev/null' % (args.apple_sdk))
+        os.environ['SDKROOT'] = seven.get_command_output('xcrun --sdk "{0!s}" --show-sdk-path 2> /dev/null'.format((args.apple_sdk)))
 
     if args.archs:
         configuration.archs = args.archs
@@ -286,7 +286,7 @@ def parseOptionsAndInitTestdirs():
         os.environ['CFLAGS_EXTRAS'] = cflags_extras
 
     if args.d:
-        sys.stdout.write("Suspending the process %d to wait for debugger to attach...\n" % os.getpid())
+        sys.stdout.write("Suspending the process {0:d} to wait for debugger to attach...\n".format(os.getpid()))
         sys.stdout.flush()
         os.kill(os.getpid(), signal.SIGSTOP)
 
@@ -604,7 +604,7 @@ def setupSysPath():
     os.environ["LLDB_IMPLIB_DIR"] = lldbImpLibDir
     print("LLDB library dir:", os.environ["LLDB_LIB_DIR"])
     print("LLDB import library dir:", os.environ["LLDB_IMPLIB_DIR"])
-    os.system('%s -v' % lldbtest_config.lldbExec)
+    os.system('{0!s} -v'.format(lldbtest_config.lldbExec))
 
     # Assume lldb-mi is in same place as lldb
     # If not found, disable the lldb-mi tests
@@ -677,7 +677,7 @@ def setupSysPath():
                 print("     location of LLDB\'s site-packages folder.")
                 print("  3) A different version of Python than that which was built against is exported in")
                 print("     the system\'s PATH environment variable, causing conflicts.")
-                print("  4) The executable '%s' could not be found.  Please check " % lldbExecutable)
+                print("  4) The executable '{0!s}' could not be found.  Please check ".format(lldbExecutable))
                 print("     that it exists and is executable.")
 
     if lldbPythonDir:
@@ -709,7 +709,7 @@ def visit(prefix, dir, names):
         if '.py' == os.path.splitext(name)[1] and name.startswith(prefix):
 
             if name in configuration.all_tests:
-                raise Exception("Found multiple tests with the name %s" % name)
+                raise Exception("Found multiple tests with the name {0!s}".format(name))
             configuration.all_tests.add(name)
 
             # Try to match the regexp pattern, if specified.
@@ -833,7 +833,7 @@ def checkDsymForUUIDIsNotOn():
     pipe = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
     cmd_output = pipe.stdout.read()
     if cmd_output and "DBGFileMappedPaths = " in cmd_output:
-        print("%s =>" % ' '.join(cmd))
+        print("{0!s} =>".format(' '.join(cmd)))
         print(cmd_output)
         print("Disable automatic lookup and caching of dSYMs before running the test suite!")
         print("Exiting...")
@@ -855,7 +855,7 @@ def isMultiprocessTestRunner():
 
 def getVersionForSDK(sdk):
     sdk = str.lower(sdk)
-    full_path = seven.get_command_output('xcrun -sdk %s --show-sdk-path' % sdk)
+    full_path = seven.get_command_output('xcrun -sdk {0!s} --show-sdk-path'.format(sdk))
     basename = os.path.basename(full_path)
     basename = os.path.splitext(basename)[0]
     basename = str.lower(basename)
@@ -864,13 +864,13 @@ def getVersionForSDK(sdk):
 
 def getPathForSDK(sdk):
     sdk = str.lower(sdk)
-    full_path = seven.get_command_output('xcrun -sdk %s --show-sdk-path' % sdk)
+    full_path = seven.get_command_output('xcrun -sdk {0!s} --show-sdk-path'.format(sdk))
     if os.path.exists(full_path): return full_path
     return None
 
 def setDefaultTripleForPlatform():
     if configuration.lldb_platform_name == 'ios-simulator':
-        triple_str = 'x86_64-apple-ios%s' % (getVersionForSDK('iphonesimulator'))
+        triple_str = 'x86_64-apple-ios{0!s}'.format((getVersionForSDK('iphonesimulator')))
         os.environ['TRIPLE'] = triple_str
         return {'TRIPLE':triple_str}
     return {}
@@ -919,21 +919,21 @@ def run_suite():
     lldb.DBG = lldb.SBDebugger.Create()
 
     if configuration.lldb_platform_name:
-        print("Setting up remote platform '%s'" % (configuration.lldb_platform_name))
+        print("Setting up remote platform '{0!s}'".format((configuration.lldb_platform_name)))
         lldb.remote_platform = lldb.SBPlatform(configuration.lldb_platform_name)
         lldb.remote_platform_name = configuration.lldb_platform_name
         if not lldb.remote_platform.IsValid():
-            print("error: unable to create the LLDB platform named '%s'." % (configuration.lldb_platform_name))
+            print("error: unable to create the LLDB platform named '{0!s}'.".format((configuration.lldb_platform_name)))
             exitTestSuite(1)
         if configuration.lldb_platform_url:
             # We must connect to a remote platform if a LLDB platform URL was specified
-            print("Connecting to remote platform '%s' at '%s'..." % (configuration.lldb_platform_name, configuration.lldb_platform_url))
+            print("Connecting to remote platform '{0!s}' at '{1!s}'...".format(configuration.lldb_platform_name, configuration.lldb_platform_url))
             platform_connect_options = lldb.SBPlatformConnectOptions(configuration.lldb_platform_url)
             err = lldb.remote_platform.ConnectRemote(platform_connect_options)
             if err.Success():
                 print("Connected.")
             else:
-                print("error: failed to connect to remote platform using URL '%s': %s" % (configuration.lldb_platform_url, err))
+                print("error: failed to connect to remote platform using URL '{0!s}': {1!s}".format(configuration.lldb_platform_url, err))
                 exitTestSuite(1)
         else:
             configuration.lldb_platform_url = None
@@ -944,10 +944,10 @@ def run_suite():
         if first:
             print("Environment variables setup for platform support:")
             first = False
-        print("%s = %s" % (key,platform_changes[key]))
+        print("{0!s} = {1!s}".format(key, platform_changes[key]))
 
     if configuration.lldb_platform_working_dir:
-        print("Setting remote platform working directory to '%s'..." % (configuration.lldb_platform_working_dir))
+        print("Setting remote platform working directory to '{0!s}'...".format((configuration.lldb_platform_working_dir)))
         lldb.remote_platform.SetWorkingDirectory(configuration.lldb_platform_working_dir)
         lldb.remote_platform_working_directory = configuration.lldb_platform_working_dir
         lldb.DBG.SetSelectedPlatform(lldb.remote_platform)
@@ -999,7 +999,7 @@ def run_suite():
 
     sys.stderr.write("\nSession logs for test failures/errors/unexpected successes"
                         " will go into directory '%s'\n" % configuration.sdir_name)
-    sys.stderr.write("Command invoked: %s\n" % getMyCommandLine())
+    sys.stderr.write("Command invoked: {0!s}\n".format(getMyCommandLine()))
 
     if not os.path.isdir(configuration.sdir_name):
         try:
@@ -1008,11 +1008,11 @@ def run_suite():
             if exception.errno != errno.EEXIST:
                 raise
     where_to_save_session = os.getcwd()
-    fname = os.path.join(configuration.sdir_name, "TestStarted-%d" % os.getpid())
+    fname = os.path.join(configuration.sdir_name, "TestStarted-{0:d}".format(os.getpid()))
     with open(fname, "w") as f:
-        print("Test started at: %s\n" % timestamp_started, file=f)
+        print("Test started at: {0!s}\n".format(timestamp_started), file=f)
         print(configuration.svn_info, file=f)
-        print("Command invoked: %s\n" % getMyCommandLine(), file=f)
+        print("Command invoked: {0!s}\n".format(getMyCommandLine()), file=f)
 
     #
     # Invoke the default TextTestRunner to run the test suite, possibly iterating
@@ -1041,14 +1041,14 @@ def run_suite():
                 cmd_output = pipe.stdout.read()
                 if cmd_output:
                     if "not found" in cmd_output:
-                        print("dropping %s from the compilers used" % c)
+                        print("dropping {0!s} from the compilers used".format(c))
                         configuration.compilers.remove(i)
                     else:
                         configuration.compilers[i] = cmd_output.split('\n')[0]
-                        print("'xcrun -find %s' returning %s" % (c, configuration.compilers[i]))
+                        print("'xcrun -find {0!s}' returning {1!s}".format(c, configuration.compilers[i]))
 
     if not configuration.parsable:
-        print("compilers=%s" % str(configuration.compilers))
+        print("compilers={0!s}".format(str(configuration.compilers)))
 
     if not configuration.compilers or len(configuration.compilers) == 0:
         print("No eligible compiler found, exiting.")
@@ -1069,7 +1069,7 @@ def run_suite():
         archConfig = ""
         if iterArchs:
             os.environ["ARCH"] = configuration.archs[ia]
-            archConfig = "arch=%s" % configuration.archs[ia]
+            archConfig = "arch={0!s}".format(configuration.archs[ia])
         for ic in range(len(configuration.compilers) if iterCompilers else 1):
             if iterCompilers:
                 os.environ["CC"] = configuration.compilers[ic]
@@ -1077,17 +1077,17 @@ def run_suite():
                     os.environ["SWIFTCC"] = configuration.swiftCompiler
                 if configuration.swiftLibrary:
                     os.environ["USERSWIFTLIBRARY"] = configuration.swiftLibrary
-                configString = "%s compiler=%s" % (archConfig, configuration.compilers[ic])
+                configString = "{0!s} compiler={1!s}".format(archConfig, configuration.compilers[ic])
             elif sys.platform.startswith("darwin"):
                 pipe = subprocess.Popen(['xcrun', '-find', c], stdout = subprocess.PIPE, stderr = subprocess.STDOUT)
                 cmd_output = pipe.stdout.read()
                 if cmd_output:
                     if "not found" in cmd_output:
-                        print("dropping %s from the compilers used" % c)
+                        print("dropping {0!s} from the compilers used".format(c))
                         compilers.remove(i)
                     else:
                         compilers[i] = cmd_output.split('\n')[0]
-                        print("'xcrun -find %s' returning %s" % (c, compilers[i]))
+                        print("'xcrun -find {0!s}' returning {1!s}".format(c, compilers[i]))
             if iterArchs or iterCompilers:
                 # Translate ' ' to '-' for pathname component.
                 if six.PY2:
@@ -1107,8 +1107,7 @@ def run_suite():
             # First, write out the number of collected test cases.
             if not configuration.parsable:
                 sys.stderr.write(configuration.separator + "\n")
-                sys.stderr.write("Collected %d test%s\n\n"
-                                 % (configuration.suite.countTestCases(),
+                sys.stderr.write("Collected {0:d} test{1!s}\n\n".format(configuration.suite.countTestCases(),
                                     configuration.suite.countTestCases() != 1 and "s" or ""))
 
             if configuration.parsable:
@@ -1141,18 +1140,18 @@ def run_suite():
     if configuration.useCategories and len(configuration.failuresPerCategory) > 0:
         sys.stderr.write("Failures per category:\n")
         for category in configuration.failuresPerCategory:
-            sys.stderr.write("%s - %d\n" % (category, configuration.failuresPerCategory[category]))
+            sys.stderr.write("{0!s} - {1:d}\n".format(category, configuration.failuresPerCategory[category]))
 
     os.chdir(where_to_save_session)
-    fname = os.path.join(configuration.sdir_name, "TestFinished-%d" % os.getpid())
+    fname = os.path.join(configuration.sdir_name, "TestFinished-{0:d}".format(os.getpid()))
     with open(fname, "w") as f:
-        print("Test finished at: %s\n" % datetime.datetime.now().strftime("%Y-%m-%d-%H_%M_%S"), file=f)
+        print("Test finished at: {0!s}\n".format(datetime.datetime.now().strftime("%Y-%m-%d-%H_%M_%S")), file=f)
 
     # Terminate the test suite if ${LLDB_TESTSUITE_FORCE_FINISH} is defined.
     # This should not be necessary now.
     if ("LLDB_TESTSUITE_FORCE_FINISH" in os.environ):
         print("Terminating Test suite...")
-        subprocess.Popen(["/bin/sh", "-c", "kill %s; exit 0" % (os.getpid())])
+        subprocess.Popen(["/bin/sh", "-c", "kill {0!s}; exit 0".format((os.getpid()))])
 
     # Exiting.
     exitTestSuite(configuration.failed)

--- a/packages/Python/lldbsuite/test/dotest_args.py
+++ b/packages/Python/lldbsuite/test/dotest_args.py
@@ -22,7 +22,7 @@ def parse_args(parser, argv):
     args = ArgParseNamespace()
 
     if ('LLDB_TEST_ARGUMENTS' in os.environ):
-        print("Arguments passed through environment: '%s'" % os.environ['LLDB_TEST_ARGUMENTS'])
+        print("Arguments passed through environment: '{0!s}'".format(os.environ['LLDB_TEST_ARGUMENTS']))
         args = parser.parse_args([sys.argv[0]].__add__(os.environ['LLDB_TEST_ARGUMENTS'].split()),namespace=args)
 
     return parser.parse_args(args=argv, namespace=args)

--- a/packages/Python/lldbsuite/test/driver/batch_mode/TestBatchMode.py
+++ b/packages/Python/lldbsuite/test/driver/batch_mode/TestBatchMode.py
@@ -27,9 +27,9 @@ class DriverBatchModeTest (TestBase):
         try:
             self.child.expect_exact(string)
         except pexpect.EOF:
-            self.fail ("Got EOF waiting for '%s'"%(string))
+            self.fail ("Got EOF waiting for '{0!s}'".format((string)))
         except pexpect.TIMEOUT:
-            self.fail ("Timed out waiting for '%s'"%(string))
+            self.fail ("Timed out waiting for '{0!s}'".format((string)))
 
     @skipIfRemote # test not remote-ready llvm.org/pr24813
     @expectedFlakeyFreeBSD("llvm.org/pr25172 fails rarely on the buildbot")
@@ -46,7 +46,7 @@ class DriverBatchModeTest (TestBase):
 
         # Pass CRASH so the process will crash and stop in batch mode.
         run_commands = ' -b -o "break set -n main" -o "run" -o "continue" -k "frame var touch_me_not"'
-        self.child = pexpect.spawn('%s %s %s %s -- CRASH' % (lldbtest_config.lldbExec, self.lldbOption, run_commands, exe))
+        self.child = pexpect.spawn('{0!s} {1!s} {2!s} {3!s} -- CRASH'.format(lldbtest_config.lldbExec, self.lldbOption, run_commands, exe))
         child = self.child
         # Turn on logging for what the child sends back.
         if self.TraceOn():
@@ -83,7 +83,7 @@ class DriverBatchModeTest (TestBase):
 
         # Now do it again, and make sure if we don't crash, we quit:
         run_commands = ' -b -o "break set -n main" -o "run" -o "continue" '
-        self.child = pexpect.spawn('%s %s %s %s -- NOCRASH' % (lldbtest_config.lldbExec, self.lldbOption, run_commands, exe))
+        self.child = pexpect.spawn('{0!s} {1!s} {2!s} {3!s} -- NOCRASH'.format(lldbtest_config.lldbExec, self.lldbOption, run_commands, exe))
         child = self.child
         # Turn on logging for what the child sends back.
         if self.TraceOn():
@@ -124,7 +124,7 @@ class DriverBatchModeTest (TestBase):
         
         # Start up the process by hand and wait for it to get to the wait loop.
 
-        self.victim = pexpect.spawn('%s WAIT' %(exe))
+        self.victim = pexpect.spawn('{0!s} WAIT'.format((exe)))
         if self.victim == None:
             self.fail("Could not spawn ", exe, ".")
 
@@ -141,8 +141,8 @@ class DriverBatchModeTest (TestBase):
         
         self.victim.expect("Waiting")
 
-        run_commands = ' -b -o "process attach -p %d" -o "breakpoint set --file %s -p \'Stop here to unset keep_waiting\' -N keep_waiting" -o "continue" -o "break delete keep_waiting" -o "expr keep_waiting = 0" -o "continue" ' % (victim_pid, self.source)
-        self.child = pexpect.spawn('%s %s %s %s' % (lldbtest_config.lldbExec, self.lldbOption, run_commands, exe))
+        run_commands = ' -b -o "process attach -p {0:d}" -o "breakpoint set --file {1!s} -p \'Stop here to unset keep_waiting\' -N keep_waiting" -o "continue" -o "break delete keep_waiting" -o "expr keep_waiting = 0" -o "continue" '.format(victim_pid, self.source)
+        self.child = pexpect.spawn('{0!s} {1!s} {2!s} {3!s}'.format(lldbtest_config.lldbExec, self.lldbOption, run_commands, exe))
 
         child = self.child
         # Turn on logging for what the child sends back.
@@ -157,7 +157,7 @@ class DriverBatchModeTest (TestBase):
         self.expect_string(prompt + "continue")
 
         # Then we should see the process exit:
-        self.expect_string ("Process %d exited with status"%(victim_pid))
+        self.expect_string ("Process {0:d} exited with status".format((victim_pid)))
         
         victim_index = self.victim.expect([pexpect.EOF, pexpect.TIMEOUT])
         self.assertTrue(victim_index == 0, "Victim didn't really exit.")

--- a/packages/Python/lldbsuite/test/expression_command/call-restarts/TestCallThatRestarts.py
+++ b/packages/Python/lldbsuite/test/expression_command/call-restarts/TestCallThatRestarts.py
@@ -31,7 +31,7 @@ class ExprCommandThatRestartsTestCase(TestBase):
 
     def check_after_call (self, num_sigchld):
         after_call = self.sigchld_no.GetValueAsSigned(-1)
-        self.assertTrue (after_call - self.start_sigchld_no == num_sigchld, "Really got %d SIGCHLD signals through the call."%(num_sigchld))
+        self.assertTrue (after_call - self.start_sigchld_no == num_sigchld, "Really got {0:d} SIGCHLD signals through the call.".format((num_sigchld)))
         self.start_sigchld_no = after_call
 
         # Check that we are back where we were before:
@@ -81,7 +81,7 @@ class ExprCommandThatRestartsTestCase(TestBase):
         self.orig_frame_pc = frame.GetPC()
 
         num_sigchld = 30
-        value = frame.EvaluateExpression ("call_me (%d)"%(num_sigchld), options)
+        value = frame.EvaluateExpression ("call_me ({0:d})".format((num_sigchld)), options)
         self.assertTrue (value.IsValid())
         self.assertTrue (value.GetError().Success() == True)
         self.assertTrue (value.GetValueAsSigned(-1) == num_sigchld)
@@ -95,7 +95,7 @@ class ExprCommandThatRestartsTestCase(TestBase):
         options.SetIgnoreBreakpoints(True)
         options.SetUnwindOnError(True)
 
-        value = frame.EvaluateExpression("call_me (%d)"%(num_sigchld), options)
+        value = frame.EvaluateExpression("call_me ({0:d})".format((num_sigchld)), options)
 
         self.assertTrue (value.IsValid() and value.GetError().Success() == True)
         self.assertTrue (value.GetValueAsSigned(-1) == num_sigchld)
@@ -105,7 +105,7 @@ class ExprCommandThatRestartsTestCase(TestBase):
         self.dbg.GetCommandInterpreter().HandleCommand("process handle SIGCHLD -s 0 -p 1 -n 1", return_obj)
         self.assertTrue (return_obj.Succeeded() == True, "Set SIGCHLD to pass, no-stop, notify")
 
-        value = frame.EvaluateExpression("call_me (%d)"%(num_sigchld), options)
+        value = frame.EvaluateExpression("call_me ({0:d})".format((num_sigchld)), options)
 
         self.assertTrue (value.IsValid() and value.GetError().Success() == True)
         self.assertTrue (value.GetValueAsSigned(-1) == num_sigchld)
@@ -113,7 +113,7 @@ class ExprCommandThatRestartsTestCase(TestBase):
 
         # Now set this unwind on error to false, and make sure that we still complete the call:
         options.SetUnwindOnError(False)
-        value = frame.EvaluateExpression("call_me (%d)"%(num_sigchld), options)
+        value = frame.EvaluateExpression("call_me ({0:d})".format((num_sigchld)), options)
 
         self.assertTrue (value.IsValid() and value.GetError().Success() == True)
         self.assertTrue (value.GetValueAsSigned(-1) == num_sigchld)
@@ -125,7 +125,7 @@ class ExprCommandThatRestartsTestCase(TestBase):
         self.dbg.GetCommandInterpreter().HandleCommand("process handle SIGCHLD -s 1 -p 1 -n 1", return_obj)
         self.assertTrue (return_obj.Succeeded() == True, "Set SIGCHLD to pass, stop, notify")
         
-        value = frame.EvaluateExpression("call_me (%d)"%(num_sigchld), options)
+        value = frame.EvaluateExpression("call_me ({0:d})".format((num_sigchld)), options)
         self.assertTrue (value.IsValid() and value.GetError().Success() == False)
         
         # Set signal handling back to no-stop, and continue and we should end up back in out starting frame:

--- a/packages/Python/lldbsuite/test/expression_command/issue_11588/Test11588.py
+++ b/packages/Python/lldbsuite/test/expression_command/issue_11588/Test11588.py
@@ -65,7 +65,7 @@ class Issue11581TestCase(TestBase):
                 addr = pointer.GetValueAsUnsigned(0)
                 self.assertTrue(addr != 0, "could not read pointer to StgClosure")
                 addr = addr - 1
-                self.runCmd("register write r14 %d" % addr)
+                self.runCmd("register write r14 {0:d}".format(addr))
                 self.expect("register read r14",
                     substrs = ["0x",hex(addr)[2:].rstrip("L")])  # Remove trailing 'L' if it exists
                 self.expect("expr --show-types -- *(StgClosure*)$r14",

--- a/packages/Python/lldbsuite/test/functionalities/asan/TestMemoryHistory.py
+++ b/packages/Python/lldbsuite/test/functionalities/asan/TestMemoryHistory.py
@@ -36,7 +36,7 @@ class AsanTestCase(TestBase):
         exe = os.path.join (os.getcwd(), "a.out")
         self.expect("file " + exe, patterns = [ "Current executable set to .*a.out" ])
 
-        self.runCmd("breakpoint set -f main.c -l %d" % self.line_breakpoint)
+        self.runCmd("breakpoint set -f main.c -l {0:d}".format(self.line_breakpoint))
 
         # "memory history" command should not work without a process
         self.expect("memory history 0",
@@ -62,8 +62,8 @@ class AsanTestCase(TestBase):
         # test the 'memory history' command
         self.expect("memory history 'pointer'",
             substrs = [
-                'Memory allocated at', 'a.out`f1', 'main.c:%d' % self.line_malloc,
-                'Memory deallocated at', 'a.out`f2', 'main.c:%d' % self.line_free])
+                'Memory allocated at', 'a.out`f1', 'main.c:{0:d}'.format(self.line_malloc),
+                'Memory deallocated at', 'a.out`f2', 'main.c:{0:d}'.format(self.line_free)])
 
         # do the same using SB API
         process = self.dbg.GetSelectedTarget().process
@@ -100,4 +100,4 @@ class AsanTestCase(TestBase):
         # make sure the 'memory history' command still works even when we're generating a report now
         self.expect("memory history 'another_pointer'",
             substrs = [
-                'Memory allocated at', 'a.out`f1', 'main.c:%d' % self.line_malloc2])
+                'Memory allocated at', 'a.out`f1', 'main.c:{0:d}'.format(self.line_malloc2)])

--- a/packages/Python/lldbsuite/test/functionalities/asan/TestReportData.py
+++ b/packages/Python/lldbsuite/test/functionalities/asan/TestReportData.py
@@ -56,7 +56,7 @@ class AsanTestReportDataCase(TestBase):
         self.assertEqual(self.dbg.GetSelectedTarget().process.GetSelectedThread().GetStopReason(), lldb.eStopReasonInstrumentation)
 
         self.expect("bt", "The backtrace should show the crashing line",
-            substrs = ['main.c:%d' % self.line_crash])
+            substrs = ['main.c:{0:d}'.format(self.line_crash)])
 
         self.expect("thread info -s", "The extended stop info should contain the ASan provided fields",
             substrs = ["access_size", "access_type", "address", "pc", "description", "heap-use-after-free"])

--- a/packages/Python/lldbsuite/test/functionalities/attach_resume/TestAttachResume.py
+++ b/packages/Python/lldbsuite/test/functionalities/attach_resume/TestAttachResume.py
@@ -55,7 +55,7 @@ class AttachResumeTestCase(TestBase):
         self.expect("process interrupt", patterns=["Process is not running"], error=True)
 
         # check that this breakpoint is auto-cleared on detach (r204752)
-        self.runCmd("br set -f main.cpp -l %u" % (line_number('main.cpp', '// Set breakpoint here')))
+        self.runCmd("br set -f main.cpp -l {0:d}".format((line_number('main.cpp', '// Set breakpoint here'))))
 
         self.runCmd("c")
         lldbutil.expect_state_changes(self, listener, [lldb.eStateRunning, lldb.eStateStopped])

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_command/TestBreakpointCommand.py
@@ -59,14 +59,14 @@ class BreakpointCommandTestCase(TestBase):
 
         # The breakpoint list now only contains breakpoint 1.
         self.expect("breakpoint list", "Breakpoints 1 & 2 created",
-            substrs = ["2: file = 'main.c', line = %d, exact_match = 0, locations = 1" % self.line],
-            patterns = ["1: file = '.*main.c', line = %d, exact_match = 0, locations = 1" % self.line] )
+            substrs = ["2: file = 'main.c', line = {0:d}, exact_match = 0, locations = 1".format(self.line)],
+            patterns = ["1: file = '.*main.c', line = {0:d}, exact_match = 0, locations = 1".format(self.line)] )
 
         self.expect("breakpoint list -f", "Breakpoints 1 & 2 created",
-            substrs = ["2: file = 'main.c', line = %d, exact_match = 0, locations = 1" % self.line],
-            patterns = ["1: file = '.*main.c', line = %d, exact_match = 0, locations = 1" % self.line,
-                        "1.1: .+at main.c:%d, .+unresolved, hit count = 0" % self.line,
-                        "2.1: .+at main.c:%d, .+unresolved, hit count = 0" % self.line])
+            substrs = ["2: file = 'main.c', line = {0:d}, exact_match = 0, locations = 1".format(self.line)],
+            patterns = ["1: file = '.*main.c', line = {0:d}, exact_match = 0, locations = 1".format(self.line),
+                        "1.1: .+at main.c:{0:d}, .+unresolved, hit count = 0".format(self.line),
+                        "2.1: .+at main.c:{0:d}, .+unresolved, hit count = 0".format(self.line)])
 
         self.expect("breakpoint command list 1", "Breakpoint 1 command ok",
             substrs = ["Breakpoint commands:",
@@ -146,14 +146,14 @@ class BreakpointCommandTestCase(TestBase):
 
         # The breakpoint list now only contains breakpoint 1.
         self.expect("breakpoint list -f", "Breakpoint 1 exists",
-            patterns = ["1: file = '.*main.c', line = %d, exact_match = 0, locations = 1, resolved = 1" %
-                        self.line,
+            patterns = ["1: file = '.*main.c', line = {0:d}, exact_match = 0, locations = 1, resolved = 1".format(
+                        self.line),
                        "hit count = 1"])
 
         # Not breakpoint 2.
         self.expect("breakpoint list -f", "No more breakpoint 2", matching=False,
-            substrs = ["2: file = 'main.c', line = %d, exact_match = 0, locations = 1, resolved = 1" %
-                        self.line])
+            substrs = ["2: file = 'main.c', line = {0:d}, exact_match = 0, locations = 1, resolved = 1".format(
+                        self.line)])
 
         # Run the program again, with breakpoint 1 remaining.
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_command/TestBreakpointCommandsFromPython.py
@@ -68,7 +68,7 @@ class PythonBreakpointCommandSettingTestCase(TestBase):
 import TestBreakpointCommandsFromPython\n\
 TestBreakpointCommandsFromPython.PythonBreakpointCommandSettingTestCase.my_var = 20\n\
 print('Hit breakpoint')")
-        self.assertTrue (error.Success(), "Failed to set the script callback body: %s."%(error.GetCString()))
+        self.assertTrue (error.Success(), "Failed to set the script callback body: {0!s}.".format((error.GetCString())))
 
         self.dbg.HandleCommand("command script import --allow-reload ./bktptcmd.py")
         func_bkpt.SetScriptCallbackFunction("bktptcmd.function")

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_command/TestRegexpBreakCommand.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_command/TestRegexpBreakCommand.py
@@ -32,15 +32,15 @@ class RegexpBreakCommandTestCase(TestBase):
         exe = os.path.join(os.getcwd(), "a.out")
         self.runCmd("file " + exe, CURRENT_EXECUTABLE_SET)
 
-        break_results = lldbutil.run_break_set_command (self, "b %d" % self.line)
+        break_results = lldbutil.run_break_set_command (self, "b {0:d}".format(self.line))
         lldbutil.check_breakpoint_result (self, break_results, file_name='main.c', line_number=self.line, num_locations=1)
 
-        break_results = lldbutil.run_break_set_command (self, "b %s:%d" % (self.source, self.line))
+        break_results = lldbutil.run_break_set_command (self, "b {0!s}:{1:d}".format(self.source, self.line))
         lldbutil.check_breakpoint_result (self, break_results, file_name='main.c', line_number=self.line, num_locations=1)
 
         # Check breakpoint with full file path.
         full_path = os.path.join(os.getcwd(), self.source)
-        break_results = lldbutil.run_break_set_command (self, "b %s:%d" % (full_path, self.line))
+        break_results = lldbutil.run_break_set_command (self, "b {0!s}:{1:d}".format(full_path, self.line))
         lldbutil.check_breakpoint_result (self, break_results, file_name='main.c', line_number=self.line, num_locations=1)
 
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_conditions/TestBreakpointConditions.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_conditions/TestBreakpointConditions.py
@@ -78,8 +78,8 @@ class BreakpointConditionsTestCase(TestBase):
         # in function name 'c'.  And the parent frame should point to main.c:24.
         self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT_CONDITION,
             #substrs = ["stop reason = breakpoint"],
-            patterns = ["frame #0.*main.c:%d" % self.line1,
-                        "frame #1.*main.c:%d" % self.line2])
+            patterns = ["frame #0.*main.c:{0:d}".format(self.line1),
+                        "frame #1.*main.c:{0:d}".format(self.line2)])
 
         # Test that "breakpoint modify -c ''" clears the condition for the last
         # created breakpoint, so that when the breakpoint hits, val == 1.

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_ignore_count/TestBreakpointIgnoreCount.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_ignore_count/TestBreakpointIgnoreCount.py
@@ -61,8 +61,8 @@ class BreakpointIgnoreCountTestCase(TestBase):
         # in function name 'c'.  And frame #2 should point to main.c:45.
         self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT_IGNORE_COUNT,
             #substrs = ["stop reason = breakpoint"],
-            patterns = ["frame #0.*main.c:%d" % self.line1,
-                        "frame #2.*main.c:%d" % self.line2])
+            patterns = ["frame #0.*main.c:{0:d}".format(self.line1),
+                        "frame #2.*main.c:{0:d}".format(self.line2)])
 
         # continue -i 1 is the same as setting the ignore count to 1 again, try that:
         # Now run the program.
@@ -81,8 +81,8 @@ class BreakpointIgnoreCountTestCase(TestBase):
         # in function name 'c'.  And frame #2 should point to main.c:45.
         self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT_IGNORE_COUNT,
             #substrs = ["stop reason = breakpoint"],
-            patterns = ["frame #0.*main.c:%d" % self.line1,
-                        "frame #1.*main.c:%d" % self.line5])
+            patterns = ["frame #0.*main.c:{0:d}".format(self.line1),
+                        "frame #1.*main.c:{0:d}".format(self.line5)])
 
         
 

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_locations/TestBreakpointLocations.py
@@ -38,7 +38,7 @@ class BreakpointLocationsTestCase(TestBase):
 
         # The breakpoint list should show 3 locations.
         self.expect("breakpoint list -f", "Breakpoint locations shown correctly",
-            substrs = ["1: file = 'main.c', line = %d, exact_match = 0, locations = 3" % self.line],
+            substrs = ["1: file = 'main.c', line = {0:d}, exact_match = 0, locations = 3".format(self.line)],
             patterns = ["where = a.out`func_inlined .+unresolved, hit count = 0",
                         "where = a.out`main .+\[inlined\].+unresolved, hit count = 0"])
 

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/breakpoint_options/TestBreakpointOptions.py
@@ -47,9 +47,9 @@ class BreakpointOptionsTestCase(TestBase):
 
         # Check the list of breakpoint.
         self.expect("breakpoint list -f", "Breakpoint locations shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.line,
-                       "2: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.line,
-                       "3: file = 'main.cpp', line = %d, exact_match = 1, locations = 0" % self.line])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.line),
+                       "2: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.line),
+                       "3: file = 'main.cpp', line = {0:d}, exact_match = 1, locations = 0".format(self.line)])
 
         # Continue the program, there should be another stop.
         self.runCmd("process continue")

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/comp_dir_symlink/TestCompDirSymLink.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/comp_dir_symlink/TestCompDirSymLink.py
@@ -31,14 +31,14 @@ class CompDirSymLinkTestCase(TestBase):
     def test_symlink_paths_set(self):
         pwd_symlink = self.create_src_symlink()
         self.doBuild(pwd_symlink)
-        self.runCmd("settings set %s %s" % (_COMP_DIR_SYM_LINK_PROP, pwd_symlink))
+        self.runCmd("settings set {0!s} {1!s}".format(_COMP_DIR_SYM_LINK_PROP, pwd_symlink))
         lldbutil.run_break_set_by_file_and_line(self, self.src_path, self.line)
 
     @skipUnlessHostLinux
     def test_symlink_paths_set_procselfcwd(self):
         pwd_symlink = '/proc/self/cwd'
         self.doBuild(pwd_symlink)
-        self.runCmd("settings set %s %s" % (_COMP_DIR_SYM_LINK_PROP, pwd_symlink))
+        self.runCmd("settings set {0!s} {1!s}".format(_COMP_DIR_SYM_LINK_PROP, pwd_symlink))
         lldbutil.run_break_set_by_file_and_line(self, self.src_path, self.line)
 
     @skipIfHostWindows

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/cpp/TestCPPBreakpointLocations.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/cpp/TestCPPBreakpointLocations.py
@@ -34,7 +34,7 @@ class TestCPPBreakpointLocations(TestBase):
         for name in names:
             found = name in bp_loc_names
             if not found:
-                print("Didn't find '%s' in: %s" % (name, bp_loc_names))
+                print("Didn't find '{0!s}' in: {1!s}".format(name, bp_loc_names))
             self.assertTrue (found, "Make sure we find all required locations")
         
     def breakpoint_id_tests (self):

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/dummy_target_breakpoints/TestBreakpointsWithNoTargets.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/dummy_target_breakpoints/TestBreakpointsWithNoTargets.py
@@ -49,8 +49,8 @@ class BreakpointInDummyTarget (TestBase):
 
         # The breakpoint list should show 3 locations.
         self.expect("breakpoint list -f", "Breakpoint locations shown correctly",
-            substrs = ["1: file = 'main.c', line = %d, exact_match = 0, locations = 1" % self.line,
-                       "2: file = 'main.c', line = %d, exact_match = 0, locations = 1" % self.line2])
+            substrs = ["1: file = 'main.c', line = {0:d}, exact_match = 0, locations = 1".format(self.line),
+                       "2: file = 'main.c', line = {0:d}, exact_match = 0, locations = 1".format(self.line2)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/breakpoint/inlined_breakpoints/TestInlinedBreakpoints.py
+++ b/packages/Python/lldbsuite/test/functionalities/breakpoint/inlined_breakpoints/TestInlinedBreakpoints.py
@@ -54,4 +54,4 @@ class InlinedBreakpointsTestCase(TestBase):
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
             substrs = ['stopped',
                        'stop reason = breakpoint',
-                       'basic_type.cpp:%d' % self.line])
+                       'basic_type.cpp:{0:d}'.format(self.line)])

--- a/packages/Python/lldbsuite/test/functionalities/command_regex/TestCommandRegex.py
+++ b/packages/Python/lldbsuite/test/functionalities/command_regex/TestCommandRegex.py
@@ -23,7 +23,7 @@ class CommandRegexTestCase(TestBase):
         regex_prompt = "Enter one of more sed substitution commands in the form: 's/<regex>/<subst>/'.\r\nTerminate the substitution list with an empty line.\r\n"
         regex_prompt1 = "\r\n"
 
-        child = pexpect.spawn('%s %s' % (lldbtest_config.lldbExec, self.lldbOption))
+        child = pexpect.spawn('{0!s} {1!s}'.format(lldbtest_config.lldbExec, self.lldbOption))
         # Turn on logging for what the child sends back.
         if self.TraceOn():
             child.logfile_read = sys.stdout

--- a/packages/Python/lldbsuite/test/functionalities/command_script/mysto.py
+++ b/packages/Python/lldbsuite/test/functionalities/command_script/mysto.py
@@ -14,7 +14,7 @@ def StepOver(debugger, args, result, dict):
 	count = int(arg_split[0])
 	for i in range(0,count):
 		debugger.GetSelectedTarget().GetProcess().GetSelectedThread().StepOver(lldb.eOnlyThisThread)
-		print("step<%d>"%i)
+		print("step<{0:d}>".format(i))
 
 def __lldb_init_module(debugger, session_dict):
 	# by default, --synchronicity is set to synchronous

--- a/packages/Python/lldbsuite/test/functionalities/command_script_immediate_output/TestCommandScriptImmediateOutput.py
+++ b/packages/Python/lldbsuite/test/functionalities/command_script_immediate_output/TestCommandScriptImmediateOutput.py
@@ -30,7 +30,7 @@ class CommandScriptImmediateOutputTestCase (PExpectTest):
         script = os.path.join(os.getcwd(), 'custom_command.py')
         prompt = "(lldb)"
         
-        self.sendline('command script import %s' % script, patterns=[prompt])
+        self.sendline('command script import {0!s}'.format(script), patterns=[prompt])
         self.sendline('command script add -f custom_command.command_function mycommand', patterns=[prompt])
         self.sendline('mycommand', patterns='this is a test string, just a test string')
         self.sendline('command script delete mycommand', patterns=[prompt])

--- a/packages/Python/lldbsuite/test/functionalities/completion/TestCompletion.py
+++ b/packages/Python/lldbsuite/test/functionalities/completion/TestCompletion.py
@@ -291,7 +291,7 @@ class CommandLineCompletionTestCase(TestBase):
                 child.expect_exact(prompt)
                 child.setecho(True)
                 # Sends str_input and a Tab to invoke the completion machinery.
-                child.send("%s\t" % str_input)
+                child.send("{0!s}\t".format(str_input))
                 child.sendline('')
                 child.expect_exact(prompt)
                 child.sendline('')

--- a/packages/Python/lldbsuite/test/functionalities/conditional_break/TestConditionalBreak.py
+++ b/packages/Python/lldbsuite/test/functionalities/conditional_break/TestConditionalBreak.py
@@ -78,7 +78,7 @@ class ConditionalBreakTestCase(TestBase):
                     # In reality, similar logic can be used to find out the call
                     # site.
                     self.assertTrue(frame1.GetLineEntry().GetLine() == line,
-                                    "Immediate caller a() at main.c:%d" % line)
+                                    "Immediate caller a() at main.c:{0:d}".format(line))
 
                     # And the local variable 'val' should have a value of (int) 3.
                     val = frame1.FindVariable("val")

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-script/TestDataFormatterScript.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-script/TestDataFormatterScript.py
@@ -51,7 +51,7 @@ class ScriptDataFormatterTestCase(TestBase):
         # Set the script here to ease the formatting
         script = 'a = valobj.GetChildMemberWithName(\'integer\'); a_val = a.GetValue(); str = \'Hello from Python, \' + a_val + \' time\'; return str + (\'!\' if a_val == \'1\' else \'s!\');'
 
-        self.runCmd("type summary add i_am_cool --python-script \"%s\"" % script)
+        self.runCmd("type summary add i_am_cool --python-script \"{0!s}\"".format(script))
 
         self.expect("frame variable one",
             substrs = ['Hello from Python',
@@ -76,7 +76,7 @@ class ScriptDataFormatterTestCase(TestBase):
         script = 'a = valobj.GetChildMemberWithName(\'integer\'); a_val = a.GetValue(); str = \'int says \' + a_val; return str;'
 
         # Check that changes in the script are immediately reflected
-        self.runCmd("type summary add i_am_cool --python-script \"%s\"" % script)
+        self.runCmd("type summary add i_am_cool --python-script \"{0!s}\"".format(script))
 
         self.expect("frame variable two",
                     substrs = ['int says 1'])
@@ -96,14 +96,14 @@ class ScriptDataFormatterTestCase(TestBase):
                                'and float says 2.71'])
 
         # Force a failure for pointers
-        self.runCmd("type summary add i_am_cool -p --python-script \"%s\"" % script)
+        self.runCmd("type summary add i_am_cool -p --python-script \"{0!s}\"".format(script))
 
         self.expect("frame variable twoptr", matching=False,
                     substrs = ['and float says 2.71'])
 
         script = 'return \'Python summary\'';
 
-        self.runCmd("type summary add --name test_summary --python-script \"%s\"" % script)
+        self.runCmd("type summary add --name test_summary --python-script \"{0!s}\"".format(script))
 
         # attach the Python named summary to someone
         self.expect("frame variable one --summary test_summary",
@@ -138,7 +138,7 @@ class ScriptDataFormatterTestCase(TestBase):
 
         # disable type summary for pointers, and make a Python regex summary
         self.runCmd("type summary add i_am_cool -p --summary-string \"Text summary\"")
-        self.runCmd("type summary add -x cool --python-script \"%s\"" % script)
+        self.runCmd("type summary add -x cool --python-script \"{0!s}\"".format(script))
 
         # variables should stick to the type summary
         self.expect("frame variable one",

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/unordered/TestDataFormatterUnordered.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-stl/libcxx/unordered/TestDataFormatterUnordered.py
@@ -71,5 +71,5 @@ class LibcxxUnorderedDataFormatterTestCase(TestBase):
                          '(\[\d\] = "world"(\\n|.)+){2}'])
 
     def look_for_content_and_continue(self, var_name, patterns):
-        self.expect( ("frame variable %s" % var_name), patterns=patterns)
+        self.expect( ("frame variable {0!s}".format(var_name)), patterns=patterns)
         self.runCmd("continue")

--- a/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-synthval/TestDataFormatterSynthVal.py
+++ b/packages/Python/lldbsuite/test/functionalities/data-formatter/data-formatter-synthval/TestDataFormatterSynthVal.py
@@ -60,7 +60,7 @@ class DataFormatterSynthValueTestCase(TestBase):
         z_val = z.GetValueAsUnsigned
         
         if self.TraceOn():
-            print("x_val = %s; y_val = %s; z_val = %s" % (x_val(),y_val(),z_val()))
+            print("x_val = {0!s}; y_val = {1!s}; z_val = {2!s}".format(x_val(), y_val(), z_val()))
 
         self.assertFalse(x_val() == 3, "x == 3 before synthetics")
         self.assertFalse(y_val() == 4, "y == 4 before synthetics")
@@ -72,7 +72,7 @@ class DataFormatterSynthValueTestCase(TestBase):
         self.runCmd("type synth add -l myArraySynthProvider myArray")
         
         if self.TraceOn():
-            print("x_val = %s; y_val = %s; z_val = %s" % (x_val(),y_val(),z_val()))
+            print("x_val = {0!s}; y_val = {1!s}; z_val = {2!s}".format(x_val(), y_val(), z_val()))
         
         self.assertTrue(x_val() == 3, "x != 3 after synthetics")
         self.assertTrue(y_val() == 4, "y != 4 after synthetics")

--- a/packages/Python/lldbsuite/test/functionalities/embedded_interpreter/TestConvenienceVariables.py
+++ b/packages/Python/lldbsuite/test/functionalities/embedded_interpreter/TestConvenienceVariables.py
@@ -30,7 +30,7 @@ class ConvenienceVariablesCase(TestBase):
         python_prompt = ">>> "
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s %s %s' % (lldbtest_config.lldbExec, self.lldbOption, exe))
+        self.child = pexpect.spawn('{0!s} {1!s} {2!s}'.format(lldbtest_config.lldbExec, self.lldbOption, exe))
         child = self.child
         # Turn on logging for what the child sends back.
         if self.TraceOn():
@@ -39,7 +39,7 @@ class ConvenienceVariablesCase(TestBase):
         # Set the breakpoint, run the inferior, when it breaks, issue print on
         # the various convenience variables.
         child.expect_exact(prompt)
-        child.sendline('breakpoint set -f main.c -l %d' % self.line)
+        child.sendline('breakpoint set -f main.c -l {0:d}'.format(self.line))
         child.expect_exact(prompt)
         child.sendline('run')
         child.expect_exact("stop reason = breakpoint 1.1")
@@ -70,9 +70,9 @@ class ConvenienceVariablesCase(TestBase):
         child.expect_exact(python_prompt)
         # Linux outputs decimal tid and 'name' instead of 'queue'
         self.expect(child.before, exe=False,
-            patterns = ['thread #1: tid = (0x[0-9a-f]+|[0-9]+), 0x[0-9a-f]+ a\.out`main\(argc=1, argv=0x[0-9a-f]+\) \+ \d+ at main\.c:%d, (name|queue) = \'.+\', stop reason = breakpoint 1\.1' % self.line])
+            patterns = ['thread #1: tid = (0x[0-9a-f]+|[0-9]+), 0x[0-9a-f]+ a\.out`main\(argc=1, argv=0x[0-9a-f]+\) \+ \d+ at main\.c:{0:d}, (name|queue) = \'.+\', stop reason = breakpoint 1\.1'.format(self.line)])
 
         child.sendline('print(lldb.frame)')
         child.expect_exact(python_prompt)
         self.expect(child.before, exe=False,
-            patterns = ['frame #0: 0x[0-9a-f]+ a\.out`main\(argc=1, argv=0x[0-9a-f]+\) \+ \d+ at main\.c:%d' % self.line])
+            patterns = ['frame #0: 0x[0-9a-f]+ a\.out`main\(argc=1, argv=0x[0-9a-f]+\) \+ \d+ at main\.c:{0:d}'.format(self.line)])

--- a/packages/Python/lldbsuite/test/functionalities/exec/TestExec.py
+++ b/packages/Python/lldbsuite/test/functionalities/exec/TestExec.py
@@ -30,11 +30,11 @@ class ExecTestCase(TestBase):
         if self.getArchitecture() == 'x86_64':
             source = os.path.join (os.getcwd(), "main.cpp")
             o_file = os.path.join (os.getcwd(), "main.o")
-            execute_command ("'%s' -g -O0 -arch i386 -arch x86_64 '%s' -c -o '%s'" % (os.environ["CC"], source, o_file))
-            execute_command ("'%s' -g -O0 -arch i386 -arch x86_64 '%s'" % (os.environ["CC"], o_file))
+            execute_command ("'{0!s}' -g -O0 -arch i386 -arch x86_64 '{1!s}' -c -o '{2!s}'".format(os.environ["CC"], source, o_file))
+            execute_command ("'{0!s}' -g -O0 -arch i386 -arch x86_64 '{1!s}'".format(os.environ["CC"], o_file))
             if self.debug_info != "dsym":
                 dsym_path = os.path.join (os.getcwd(), "a.out.dSYM")
-                execute_command ("rm -rf '%s'" % (dsym_path))
+                execute_command ("rm -rf '{0!s}'".format((dsym_path)))
         else:
             self.build()
 

--- a/packages/Python/lldbsuite/test/functionalities/fat_archives/TestFatArchives.py
+++ b/packages/Python/lldbsuite/test/functionalities/fat_archives/TestFatArchives.py
@@ -28,7 +28,7 @@ class FatArchiveTestCase(TestBase):
     @expectedFailureDarwin("rdar://23589961")
     def test (self):
         if self.getArchitecture() == 'x86_64':
-            execute_command ("make CC='%s'" % (os.environ["CC"]))
+            execute_command ("make CC='{0!s}'".format((os.environ["CC"])))
             self.main ()
         else:
             self.skipTest("This test requires x86_64 as the architecture for the inferior")

--- a/packages/Python/lldbsuite/test/functionalities/format/TestFormats.py
+++ b/packages/Python/lldbsuite/test/functionalities/format/TestFormats.py
@@ -20,7 +20,7 @@ class TestFormats(TestBase):
         self.build()
         import pexpect
         prompt = "(lldb) "
-        child = pexpect.spawn('%s %s -x -o "b main" -o r a.out' % (lldbtest_config.lldbExec, self.lldbOption))
+        child = pexpect.spawn('{0!s} {1!s} -x -o "b main" -o r a.out'.format(lldbtest_config.lldbExec, self.lldbOption))
         # Turn on logging for what the child sends back.
         if self.TraceOn():
             child.logfile_read = sys.stdout

--- a/packages/Python/lldbsuite/test/functionalities/inferior-assert/TestInferiorAssert.py
+++ b/packages/Python/lldbsuite/test/functionalities/inferior-assert/TestInferiorAssert.py
@@ -94,7 +94,7 @@ class AssertingInferiorTestCase(TestBase):
         # And it should report the correct line number.
         self.expect("thread backtrace all",
             substrs = [stop_reason,
-                       'main.c:%d' % self.line])
+                       'main.c:{0:d}'.format(self.line)])
 
     def inferior_asserting_python(self):
         """Inferior asserts upon launching; lldb should catch the event and stop."""
@@ -171,7 +171,7 @@ class AssertingInferiorTestCase(TestBase):
             if isi386Arch == True:
                 if lastframeID == frame.GetFrameID():
                     pc_backup_offset = 0
-            self.expect("disassemble -a %s" % (frame.GetPC() - pc_backup_offset),
+            self.expect("disassemble -a {0!s}".format((frame.GetPC() - pc_backup_offset)),
                     substrs = ['<+0>: '])
 
     def check_expr_in_main(self, thread):
@@ -180,7 +180,7 @@ class AssertingInferiorTestCase(TestBase):
             frame = thread.GetFrameAtIndex(i)
             self.assertTrue(frame.IsValid(), "current frame is valid")
             if self.TraceOn():
-                print("Checking if function %s is main" % frame.GetFunctionName())
+                print("Checking if function {0!s} is main".format(frame.GetFunctionName()))
 
             if 'main' == frame.GetFunctionName():
                 frame_id = frame.GetFrameID()
@@ -226,7 +226,7 @@ class AssertingInferiorTestCase(TestBase):
         target.LaunchSimple (None, None, self.get_process_working_directory())
 
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = ['main.c:%d' % self.line,
+            substrs = ['main.c:{0:d}'.format(self.line),
                        'stop reason = breakpoint'])
 
         self.runCmd("next")
@@ -250,4 +250,4 @@ class AssertingInferiorTestCase(TestBase):
         # And it should report the correct line number.
         self.expect("thread backtrace all",
             substrs = [stop_reason,
-                       'main.c:%d' % self.line])
+                       'main.c:{0:d}'.format(self.line)])

--- a/packages/Python/lldbsuite/test/functionalities/inferior-changed/TestInferiorChanged.py
+++ b/packages/Python/lldbsuite/test/functionalities/inferior-changed/TestInferiorChanged.py
@@ -50,7 +50,7 @@ class ChangedInferiorTestCase(TestBase):
                 STOPPED_DUE_TO_EXC_BAD_ACCESS)
 
         # And it should report the correct line number.
-        self.expect("thread backtrace all", substrs = ['main.c:%d' % self.line1])
+        self.expect("thread backtrace all", substrs = ['main.c:{0:d}'.format(self.line1)])
 
     def inferior_not_crashing(self):
         """Test lldb reloads the inferior after it was changed during the session."""

--- a/packages/Python/lldbsuite/test/functionalities/inferior-crashing/TestInferiorCrashing.py
+++ b/packages/Python/lldbsuite/test/functionalities/inferior-crashing/TestInferiorCrashing.py
@@ -100,7 +100,7 @@ class CrashingInferiorTestCase(TestBase):
         # And it should report the correct line number.
         self.expect("thread backtrace all",
             substrs = [stop_reason,
-                       'main.c:%d' % self.line])
+                       'main.c:{0:d}'.format(self.line)])
 
     def inferior_crashing_python(self):
         """Inferior crashes upon launching; lldb should catch the event and stop."""
@@ -159,7 +159,7 @@ class CrashingInferiorTestCase(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
 
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = ['main.c:%d' % self.line,
+            substrs = ['main.c:{0:d}'.format(self.line),
                        'stop reason = breakpoint'])
 
         self.runCmd("next")
@@ -176,7 +176,7 @@ class CrashingInferiorTestCase(TestBase):
 
         # And it should report the correct line number.
         self.expect("thread backtrace all",
-            substrs = ['main.c:%d' % self.line])
+            substrs = ['main.c:{0:d}'.format(self.line)])
 
     def inferior_crashing_step_after_break(self):
         """Test that lldb behaves correctly when stepping after a crash."""

--- a/packages/Python/lldbsuite/test/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferior.py
+++ b/packages/Python/lldbsuite/test/functionalities/inferior-crashing/recursive-inferior/TestRecursiveInferior.py
@@ -103,7 +103,7 @@ class CrashingRecursiveInferiorTestCase(TestBase):
         # And it should report the correct line number.
         self.expect("thread backtrace all",
             substrs = [stop_reason,
-                       'main.c:%d' % self.line])
+                       'main.c:{0:d}'.format(self.line)])
 
     def recursive_inferior_crashing_python(self):
         """Inferior crashes upon launching; lldb should catch the event and stop."""
@@ -159,7 +159,7 @@ class CrashingRecursiveInferiorTestCase(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
 
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = ['main.c:%d' % self.line,
+            substrs = ['main.c:{0:d}'.format(self.line),
                        'stop reason = breakpoint'])
 
         self.runCmd("next")
@@ -174,7 +174,7 @@ class CrashingRecursiveInferiorTestCase(TestBase):
 
         # And it should report the correct line number.
         self.expect("thread backtrace all",
-            substrs = ['main.c:%d' % self.line])
+            substrs = ['main.c:{0:d}'.format(self.line)])
 
     def recursive_inferior_crashing_step_after_break(self):
         """Test that lldb behaves correctly when stepping after a crash."""

--- a/packages/Python/lldbsuite/test/functionalities/inline-stepping/TestInlineStepping.py
+++ b/packages/Python/lldbsuite/test/functionalities/inline-stepping/TestInlineStepping.py
@@ -88,7 +88,7 @@ class TestInlineStepping(TestBase):
         if test_stack_depth and real_stack_depth != expected_stack_depth:
             destination_description = lldb.SBStream()
             destination_line_entry.GetDescription(destination_description)
-            self.fail ("Step %s to %s got wrong number of frames, should be: %d was: %d."%(step_type, destination_description.GetData(), expected_stack_depth, real_stack_depth))
+            self.fail ("Step {0!s} to {1!s} got wrong number of frames, should be: {2:d} was: {3:d}.".format(step_type, destination_description.GetData(), expected_stack_depth, real_stack_depth))
             
     def run_step_sequence(self, step_sequence):
         """This function takes a list of duples instructing how to run the program.  The first element in each duple is

--- a/packages/Python/lldbsuite/test/functionalities/launch_with_shellexpand/TestLaunchWithShellExpand.py
+++ b/packages/Python/lldbsuite/test/functionalities/launch_with_shellexpand/TestLaunchWithShellExpand.py
@@ -22,7 +22,7 @@ class LaunchWithShellExpandTestCase(TestBase):
         self.build()
         exe = os.path.join (os.getcwd(), "a.out")
         
-        self.runCmd("target create %s" % exe)
+        self.runCmd("target create {0!s}".format(exe))
         
         # Create the target
         target = self.dbg.CreateTarget(exe)
@@ -31,7 +31,7 @@ class LaunchWithShellExpandTestCase(TestBase):
         breakpoint = target.BreakpointCreateBySourceRegex ('break here', lldb.SBFileSpec ("main.cpp", False))
         self.assertTrue(breakpoint, VALID_BREAKPOINT)
 
-        self.runCmd("process launch -X true -w %s -- fi*.tx?" % (os.getcwd()))
+        self.runCmd("process launch -X true -w {0!s} -- fi*.tx?".format((os.getcwd())))
 
         process = self.process()
 
@@ -56,7 +56,7 @@ class LaunchWithShellExpandTestCase(TestBase):
 
         self.runCmd("process kill")
 
-        self.runCmd('process launch -X true -w %s -- "foo bar"' % (os.getcwd()))
+        self.runCmd('process launch -X true -w {0!s} -- "foo bar"'.format((os.getcwd())))
         
         process = self.process()
 
@@ -77,7 +77,7 @@ class LaunchWithShellExpandTestCase(TestBase):
 
         self.runCmd("process kill")
 
-        self.runCmd('process launch -X true -w %s -- foo\ bar' % (os.getcwd()))
+        self.runCmd('process launch -X true -w {0!s} -- foo\ bar'.format((os.getcwd())))
         
         process = self.process()
 

--- a/packages/Python/lldbsuite/test/functionalities/load_unload/TestLoadUnload.py
+++ b/packages/Python/lldbsuite/test/functionalities/load_unload/TestLoadUnload.py
@@ -53,8 +53,7 @@ class LoadUnloadTestCase(TestBase):
                     lldb.SBFileSpec(os.path.join(wd, f)))
                 if err.Fail():
                     raise RuntimeError(
-                        "Unable copy '%s' to '%s'.\n>>> %s" %
-                        (f, wd, err.GetCString()))
+                        "Unable copy '{0!s}' to '{1!s}'.\n>>> {2!s}".format(f, wd, err.GetCString()))
             if hidden_dir:
                 shlib = 'libloadunload_d.so'
                 hidden_dir = os.path.join(wd, 'hidden')
@@ -62,14 +61,13 @@ class LoadUnloadTestCase(TestBase):
                 err = lldb.remote_platform.MakeDirectory(hidden_dir)
                 if err.Fail():
                     raise RuntimeError(
-                        "Unable to create a directory '%s'." % hidden_dir)
+                        "Unable to create a directory '{0!s}'.".format(hidden_dir))
                 err = lldb.remote_platform.Put(
                     lldb.SBFileSpec(os.path.join(cwd, 'hidden', shlib)),
                     lldb.SBFileSpec(hidden_file))
                 if err.Fail():
                     raise RuntimeError(
-                        "Unable copy 'libloadunload_d.so' to '%s'.\n>>> %s" %
-                        (wd, err.GetCString()))
+                        "Unable copy 'libloadunload_d.so' to '{0!s}'.\n>>> {1!s}".format(wd, err.GetCString()))
 
     @skipIfFreeBSD # llvm.org/pr14424 - missing FreeBSD Makefiles/testcase support
     @not_remote_testsuite_ready
@@ -99,12 +97,12 @@ class LoadUnloadTestCase(TestBase):
         #self.expect("target modules list -t 3",
         #    patterns = ["%s-[^-]*-[^-]*" % self.getArchitecture()])
         # Add an image search path substitution pair.
-        self.runCmd("target modules search-paths add %s %s" % (os.getcwd(), new_dir))
+        self.runCmd("target modules search-paths add {0!s} {1!s}".format(os.getcwd(), new_dir))
 
         self.expect("target modules search-paths list",
             substrs = [os.getcwd(), new_dir])
 
-        self.expect("target modules search-paths query %s" % os.getcwd(), "Image search path successfully transformed",
+        self.expect("target modules search-paths query {0!s}".format(os.getcwd()), "Image search path successfully transformed",
             substrs = [new_dir])
 
         # Obliterate traces of libd from the old location.
@@ -171,8 +169,7 @@ class LoadUnloadTestCase(TestBase):
         self.runCmd("continue")
 
         # Add the hidden directory first in the search path.
-        env_cmd_string = ("settings set target.env-vars %s=%s" %
-                          (self.dylibPath, new_dir))
+        env_cmd_string = ("settings set target.env-vars {0!s}={1!s}".format(self.dylibPath, new_dir))
         if not self.platformIsDarwin():
             env_cmd_string += ":" + wd
         self.runCmd(env_cmd_string)
@@ -216,8 +213,8 @@ class LoadUnloadTestCase(TestBase):
                     error=True, matching=False, patterns = ["1 match found"])
 
         # Use lldb 'process load' to load the dylib.
-        self.expect("process load %s --install" % dylibName, "%s loaded correctly" % dylibName,
-            patterns = ['Loading "%s".*ok' % dylibName,
+        self.expect("process load {0!s} --install".format(dylibName), "{0!s} loaded correctly".format(dylibName),
+            patterns = ['Loading "{0!s}".*ok'.format(dylibName),
                         'Image [0-9]+ loaded'])
 
         # Search for and match the "Image ([0-9]+) loaded" pattern.
@@ -232,11 +229,11 @@ class LoadUnloadTestCase(TestBase):
 
         # Now we should have an entry for a_function.
         self.expect("image lookup -n a_function", "a_function should now exist",
-            patterns = ["1 match found .*%s" % dylibName])
+            patterns = ["1 match found .*{0!s}".format(dylibName)])
 
         # Use lldb 'process unload' to unload the dylib.
-        self.expect("process unload %s" % index, "%s unloaded correctly" % dylibName,
-            patterns = ["Unloading .* with index %s.*ok" % index])
+        self.expect("process unload {0!s}".format(index), "{0!s} unloaded correctly".format(dylibName),
+            patterns = ["Unloading .* with index {0!s}.*ok".format(index)])
 
         self.runCmd("process continue")
 
@@ -334,13 +331,13 @@ class LoadUnloadTestCase(TestBase):
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
             substrs = ['stopped',
                        'd_init',
-                       'stop reason = breakpoint %d' % d_init_bp_num])
+                       'stop reason = breakpoint {0:d}'.format(d_init_bp_num)])
 
         self.runCmd("continue")
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
             substrs = ['stopped',
                        'a_init',
-                       'stop reason = breakpoint %d' % a_init_bp_num])
+                       'stop reason = breakpoint {0:d}'.format(a_init_bp_num)])
         self.expect("thread backtrace",
             substrs = ['a_init',
                        'dlopen',
@@ -350,7 +347,7 @@ class LoadUnloadTestCase(TestBase):
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
             substrs = ['stopped',
                        'b_init',
-                       'stop reason = breakpoint %d' % b_init_bp_num])
+                       'stop reason = breakpoint {0:d}'.format(b_init_bp_num)])
         self.expect("thread backtrace",
             substrs = ['b_init',
                        'dlopen',

--- a/packages/Python/lldbsuite/test/functionalities/non-overlapping-index-variable-i/TestIndexVariable.py
+++ b/packages/Python/lldbsuite/test/functionalities/non-overlapping-index-variable-i/TestIndexVariable.py
@@ -24,7 +24,7 @@ class NonOverlappingIndexVariableCase(TestBase):
         self.build()
         self.exe_name = 'a.out'
         exe = os.path.join(os.getcwd(), self.exe_name)
-        self.runCmd("file %s" % exe, CURRENT_EXECUTABLE_SET)
+        self.runCmd("file {0!s}".format(exe), CURRENT_EXECUTABLE_SET)
 
         lldbutil.run_break_set_by_file_and_line (self, self.source, self.line_to_break, num_expected_locations=1, loc_exact=True)
 

--- a/packages/Python/lldbsuite/test/functionalities/nosucharch/TestNoSuchArch.py
+++ b/packages/Python/lldbsuite/test/functionalities/nosucharch/TestNoSuchArch.py
@@ -18,7 +18,7 @@ class NoSuchArchTestCase(TestBase):
         exe = os.path.join (os.getcwd(), "a.out")
 
         # Check that passing an invalid arch via the command-line fails but doesn't crash
-        self.expect("target crete --arch nothingtoseehere %s" % (exe), error=True)
+        self.expect("target crete --arch nothingtoseehere {0!s}".format((exe)), error=True)
 
         # Check that passing an invalid arch via the SB API fails but doesn't crash
         target = self.dbg.CreateTargetWithFileAndArch(exe,"nothingtoseehere")

--- a/packages/Python/lldbsuite/test/functionalities/plugins/commands/TestPluginCommands.py
+++ b/packages/Python/lldbsuite/test/functionalities/plugins/commands/TestPluginCommands.py
@@ -25,9 +25,9 @@ class PluginCommandTestCase(TestBase):
 
         plugin_name = "plugin"
         if sys.platform.startswith("darwin"):
-            plugin_lib_name = "lib%s.dylib" % plugin_name
+            plugin_lib_name = "lib{0!s}.dylib".format(plugin_name)
         else:
-            plugin_lib_name = "lib%s.so" % plugin_name
+            plugin_lib_name = "lib{0!s}.so".format(plugin_name)
 
         # Invoke the library build rule.
         self.buildLibrary("plugin.cpp", plugin_name)
@@ -36,7 +36,7 @@ class PluginCommandTestCase(TestBase):
 
         retobj = lldb.SBCommandReturnObject()
 
-        retval = debugger.GetCommandInterpreter().HandleCommand("plugin load %s" % plugin_lib_name, retobj)
+        retval = debugger.GetCommandInterpreter().HandleCommand("plugin load {0!s}".format(plugin_lib_name), retobj)
 
         retobj.Clear()
 

--- a/packages/Python/lldbsuite/test/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
+++ b/packages/Python/lldbsuite/test/functionalities/plugins/python_os_plugin/TestPythonOSPlugin.py
@@ -69,7 +69,7 @@ class PluginPythonOSPlugin(TestBase):
 
         # Now load the python OS plug-in which should update the thread list and we should have
         # OS plug-in created threads with the IDs: 0x111111111, 0x222222222, 0x333333333
-        command = "settings set target.process.python-os-plugin-path '%s'" % python_os_plugin_path
+        command = "settings set target.process.python-os-plugin-path '{0!s}'".format(python_os_plugin_path)
         self.dbg.HandleCommand(command)
 
         # Verify our OS plug-in threads showed up
@@ -125,7 +125,7 @@ class PluginPythonOSPlugin(TestBase):
 
         # Now load the python OS plug-in which should update the thread list and we should have
         # OS plug-in created threads with the IDs: 0x111111111, 0x222222222, 0x333333333
-        command = "settings set target.process.python-os-plugin-path '%s'" % python_os_plugin_path
+        command = "settings set target.process.python-os-plugin-path '{0!s}'".format(python_os_plugin_path)
         self.dbg.HandleCommand(command)
 
         # Verify our OS plug-in threads showed up

--- a/packages/Python/lldbsuite/test/functionalities/process_attach/attach_denied/TestAttachDenied.py
+++ b/packages/Python/lldbsuite/test/functionalities/process_attach/attach_denied/TestAttachDenied.py
@@ -32,8 +32,8 @@ class AttachDeniedTestCase(TestBase):
 
         # Use a file as a synchronization point between test and inferior.
         pid_file_path = lldbutil.append_to_process_working_directory(
-                "pid_file_%d" % (int(time.time())))
-        self.addTearDownHook(lambda: self.run_platform_command("rm %s" % (pid_file_path)))
+                "pid_file_{0:d}".format((int(time.time()))))
+        self.addTearDownHook(lambda: self.run_platform_command("rm {0!s}".format((pid_file_path))))
 
         # Spawn a new process
         popen = self.spawnSubprocess(exe, [pid_file_path])
@@ -41,7 +41,7 @@ class AttachDeniedTestCase(TestBase):
 
         max_attempts = 5
         for i in range(max_attempts):
-            err, retcode, msg = self.run_platform_command("ls %s" % pid_file_path)
+            err, retcode, msg = self.run_platform_command("ls {0!s}".format(pid_file_path))
             if err.Success() and retcode == 0:
                 break
             else:
@@ -50,10 +50,10 @@ class AttachDeniedTestCase(TestBase):
                 # Exponential backoff!
                 time.sleep(pow(2, i) * 0.25)
         else:
-            self.fail("Child PID file %s not found even after %d attempts." % (pid_file_path, max_attempts))
-        err, retcode, pid = self.run_platform_command("cat %s" % (pid_file_path))
+            self.fail("Child PID file {0!s} not found even after {1:d} attempts.".format(pid_file_path, max_attempts))
+        err, retcode, pid = self.run_platform_command("cat {0!s}".format((pid_file_path)))
         self.assertTrue(err.Success() and retcode == 0,
-                        "Failed to read file %s: %s, retcode: %d" % (pid_file_path, err.GetCString(), retcode))
+                        "Failed to read file {0!s}: {1!s}, retcode: {2:d}".format(pid_file_path, err.GetCString(), retcode))
 
         self.expect('process attach -p ' + pid,
                     startstr = 'error: attach failed:',

--- a/packages/Python/lldbsuite/test/functionalities/process_group/TestChangeProcessGroup.py
+++ b/packages/Python/lldbsuite/test/functionalities/process_group/TestChangeProcessGroup.py
@@ -29,15 +29,15 @@ class ChangeProcessGroupTestCase(TestBase):
 
         # Use a file as a synchronization point between test and inferior.
         pid_file_path = lldbutil.append_to_process_working_directory(
-                "pid_file_%d" % (int(time.time())))
-        self.addTearDownHook(lambda: self.run_platform_command("rm %s" % (pid_file_path)))
+                "pid_file_{0:d}".format((int(time.time()))))
+        self.addTearDownHook(lambda: self.run_platform_command("rm {0!s}".format((pid_file_path))))
 
         popen = self.spawnSubprocess(exe, [pid_file_path])
         self.addTearDownHook(self.cleanupSubprocesses)
 
         max_attempts = 5
         for i in range(max_attempts):
-            err, retcode, msg = self.run_platform_command("ls %s" % pid_file_path)
+            err, retcode, msg = self.run_platform_command("ls {0!s}".format(pid_file_path))
             if err.Success() and retcode == 0:
                 break
             else:
@@ -46,12 +46,12 @@ class ChangeProcessGroupTestCase(TestBase):
                 # Exponential backoff!
                 time.sleep(pow(2, i) * 0.25)
         else:
-            self.fail("Child PID file %s not found even after %d attempts." % (pid_file_path, max_attempts))
+            self.fail("Child PID file {0!s} not found even after {1:d} attempts.".format(pid_file_path, max_attempts))
 
-        err, retcode, pid = self.run_platform_command("cat %s" % (pid_file_path))
+        err, retcode, pid = self.run_platform_command("cat {0!s}".format((pid_file_path)))
 
         self.assertTrue(err.Success() and retcode == 0,
-                "Failed to read file %s: %s, retcode: %d" % (pid_file_path, err.GetCString(), retcode))
+                "Failed to read file {0!s}: {1!s}, retcode: {2:d}".format(pid_file_path, err.GetCString(), retcode))
 
         # make sure we cleanup the forked child also
         def cleanupChild():

--- a/packages/Python/lldbsuite/test/functionalities/process_launch/TestProcessLaunch.py
+++ b/packages/Python/lldbsuite/test/functionalities/process_launch/TestProcessLaunch.py
@@ -134,15 +134,15 @@ class ProcessLaunchTestCase(TestBase):
             pass
 
         # Check that we get an error when we have a nonexisting path
-        launch_command = "process launch -w %s -o %s -e %s" % (my_working_dir_path + 'z',
+        launch_command = "process launch -w {0!s} -o {1!s} -e {2!s}".format(my_working_dir_path + 'z',
                                                                out_file_path,
                                                                err_file_path)
 
         self.expect(launch_command, error=True,
-                patterns = ["error:.* No such file or directory: %sz" % my_working_dir_path])
+                patterns = ["error:.* No such file or directory: {0!s}z".format(my_working_dir_path)])
 
         # Really launch the process
-        launch_command = "process launch -w %s -o %s -e %s" % (my_working_dir_path,
+        launch_command = "process launch -w {0!s} -o {1!s} -e {2!s}".format(my_working_dir_path,
                                                                out_file_path,
                                                                err_file_path)
 
@@ -197,7 +197,7 @@ class ProcessLaunchTestCase(TestBase):
 
         out = out[:len(evil_var)]
         if out != evil_var:
-            self.fail('The environment variable was mis-coded: %s\n' % repr(out))
+            self.fail('The environment variable was mis-coded: {0!s}\n'.format(repr(out)))
 
         newline = process.GetSTDOUT(1)
         self.assertIsNotNone(newline, "Encountered an error reading the process's output")

--- a/packages/Python/lldbsuite/test/functionalities/register/TestRegisters.py
+++ b/packages/Python/lldbsuite/test/functionalities/register/TestRegisters.py
@@ -77,9 +77,9 @@ class RegisterCommandsTestCase(TestBase):
             gpr = "r0"
             vector = "q0"
 
-        self.expect("expr/x $%s" % gpr, substrs = ['unsigned int', ' = 0x'])
-        self.expect("expr $%s" % vector, substrs = ['vector_type'])
-        self.expect("expr (unsigned int)$%s[0]" % vector, substrs = ['unsigned int'])
+        self.expect("expr/x ${0!s}".format(gpr), substrs = ['unsigned int', ' = 0x'])
+        self.expect("expr ${0!s}".format(vector), substrs = ['vector_type'])
+        self.expect("expr (unsigned int)${0!s}[0]".format(vector), substrs = ['unsigned int'])
 
         if self.getArchitecture() in ['amd64', 'x86_64']:
             self.expect("expr -- ($rax & 0xffffffff) == $eax", substrs = ['true'])
@@ -173,7 +173,7 @@ class RegisterCommandsTestCase(TestBase):
         for str1 in substrs:
             matched = output.find(str1) != -1
             with recording(self, False) as sbuf:
-                print("%s sub string: %s" % ('Expecting', str1), file=sbuf)
+                print("{0!s} sub string: {1!s}".format('Expecting', str1), file=sbuf)
                 print("Matched" if matched else "Not Matched", file=sbuf)
             if matched:
                 break
@@ -212,18 +212,18 @@ class RegisterCommandsTestCase(TestBase):
             # Verify fstat and save it to be used for verification in next execution of 'si' command
             if not (reg_value_fstat_initial & 0x3800):
                 self.expect("register read fstat",
-                    substrs = ['fstat' + ' = ', str("0x%0.4x" %((reg_value_fstat_initial & ~(0x3800))| 0x3800))])
+                    substrs = ['fstat' + ' = ', str("0x{0:0.4x}".format(((reg_value_fstat_initial & ~(0x3800))| 0x3800)))])
                 reg_value_fstat_initial = ((reg_value_fstat_initial & ~(0x3800))| 0x3800)
                 fstat_top_pointer_initial = 7
             else :
                 self.expect("register read fstat",
-                    substrs = ['fstat' + ' = ', str("0x%0.4x" % (reg_value_fstat_initial - 0x0800))])
+                    substrs = ['fstat' + ' = ', str("0x{0:0.4x}".format((reg_value_fstat_initial - 0x0800)))])
                 reg_value_fstat_initial = (reg_value_fstat_initial - 0x0800)
                 fstat_top_pointer_initial -= 1
 
             # Verify ftag and save it to be used for verification in next execution of 'si' command
             self.expect("register read ftag",
-                substrs = ['ftag' + ' = ', str("0x%0.2x" % (reg_value_ftag_initial | (1<< fstat_top_pointer_initial)))])
+                substrs = ['ftag' + ' = ', str("0x{0:0.2x}".format((reg_value_ftag_initial | (1<< fstat_top_pointer_initial))))])
             reg_value_ftag_initial = reg_value_ftag_initial | (1<< fstat_top_pointer_initial)
 
     def fp_register_write(self):
@@ -333,9 +333,9 @@ class RegisterCommandsTestCase(TestBase):
         self.addTearDownHook(self.cleanupSubprocesses)
 
         if self.TraceOn():
-            print("pid of spawned process: %d" % pid)
+            print("pid of spawned process: {0:d}".format(pid))
 
-        self.runCmd("process attach -p %d" % pid)
+        self.runCmd("process attach -p {0:d}".format(pid))
 
         # Check that "register read eax" works.
         self.runCmd("register read eax")

--- a/packages/Python/lldbsuite/test/functionalities/rerun/TestRerun.py
+++ b/packages/Python/lldbsuite/test/functionalities/rerun/TestRerun.py
@@ -19,7 +19,7 @@ class TestRerun(TestBase):
         self.build()
         exe = os.path.join (os.getcwd(), "a.out")
         
-        self.runCmd("target create %s" % exe)
+        self.runCmd("target create {0!s}".format(exe))
         
         # Create the target
         target = self.dbg.CreateTarget(exe)

--- a/packages/Python/lldbsuite/test/functionalities/signal/TestSendSignal.py
+++ b/packages/Python/lldbsuite/test/functionalities/signal/TestSendSignal.py
@@ -102,5 +102,5 @@ class SendSignalTestCase(TestBase):
         self.assertTrue(got_event, "Got an event")
         state = lldb.SBProcess.GetStateFromEvent(event)
         self.assertTrue(state == expected_state,
-                        "It was the %s state." %
-                        lldb.SBDebugger_StateAsCString(expected_state))
+                        "It was the {0!s} state.".format(
+                        lldb.SBDebugger_StateAsCString(expected_state)))

--- a/packages/Python/lldbsuite/test/functionalities/signal/raise/TestRaise.py
+++ b/packages/Python/lldbsuite/test/functionalities/signal/raise/TestRaise.py
@@ -39,7 +39,7 @@ class RaiseTestCase(TestBase):
     def set_handle(self, signal, pass_signal, stop_at_signal, notify_signal):
         return_obj = lldb.SBCommandReturnObject()
         self.dbg.GetCommandInterpreter().HandleCommand(
-                "process handle %s -p %s -s %s -n %s" % (signal, pass_signal, stop_at_signal, notify_signal),
+                "process handle {0!s} -p {1!s} -s {2!s} -n {3!s}".format(signal, pass_signal, stop_at_signal, notify_signal),
                 return_obj)
         self.assertTrue (return_obj.Succeeded() == True, "Setting signal handling failed")
 
@@ -59,7 +59,7 @@ class RaiseTestCase(TestBase):
 
         # retrieve default signal disposition
         return_obj = lldb.SBCommandReturnObject()
-        self.dbg.GetCommandInterpreter().HandleCommand("process handle %s " % signal, return_obj)
+        self.dbg.GetCommandInterpreter().HandleCommand("process handle {0!s} ".format(signal), return_obj)
         match = re.match('NAME *PASS *STOP *NOTIFY.*(false|true) *(false|true) *(false|true)',
                 return_obj.GetOutput(), re.IGNORECASE | re.DOTALL)
         if not match:
@@ -76,7 +76,7 @@ class RaiseTestCase(TestBase):
         self.assertTrue(thread.IsValid(), "Thread should be stopped due to a signal")
         self.assertTrue(thread.GetStopReasonDataCount() >= 1, "There was data in the event.")
         self.assertEqual(thread.GetStopReasonDataAtIndex(0), signo,
-                "The stop signal was %s" % signal)
+                "The stop signal was {0!s}".format(signal))
 
         # Continue until we exit.
         process.Continue()
@@ -118,7 +118,7 @@ class RaiseTestCase(TestBase):
         self.assertTrue(thread.GetStopReasonDataCount() >= 1, "There was data in the event.")
         self.assertEqual(thread.GetStopReasonDataAtIndex(0),
                 process.GetUnixSignals().GetSignalNumberFromName(signal),
-                "The stop signal was %s" % signal)
+                "The stop signal was {0!s}".format(signal))
 
         # Continue until we exit. The process should receive the signal.
         process.Continue()
@@ -215,7 +215,7 @@ class RaiseTestCase(TestBase):
         self.assertTrue(thread.GetStopReasonDataCount() >= 1, "There was data in the event.")
         signo = process.GetUnixSignals().GetSignalNumberFromName("SIGSTOP")
         self.assertEqual(thread.GetStopReasonDataAtIndex(0), signo,
-                "The stop signal was %s" % signal)
+                "The stop signal was {0!s}".format(signal))
 
         # We are done
         process.Kill()

--- a/packages/Python/lldbsuite/test/functionalities/single-quote-in-filename-to-lldb/TestSingleQuoteInFilename.py
+++ b/packages/Python/lldbsuite/test/functionalities/single-quote-in-filename-to-lldb/TestSingleQuoteInFilename.py
@@ -31,13 +31,13 @@ class SingleQuoteInCommandLineTestCase(TestBase):
         """Test that 'lldb my_file_name' works where my_file_name is a string with a single quote char in it."""
         import pexpect
         self.buildDefault()
-        system([["cp", "a.out", "\"%s\"" % self.myexe]])
+        system([["cp", "a.out", "\"{0!s}\"".format(self.myexe)]])
 
         # The default lldb prompt.
         prompt = "(lldb) "
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s %s "%s"' % (lldbtest_config.lldbExec, self.lldbOption, self.myexe))
+        self.child = pexpect.spawn('{0!s} {1!s} "{2!s}"'.format(lldbtest_config.lldbExec, self.lldbOption, self.myexe))
         child = self.child
         child.setecho(True)
         # Turn on logging for input/output to/from the child.

--- a/packages/Python/lldbsuite/test/functionalities/step-avoids-no-debug/TestStepNoDebug.py
+++ b/packages/Python/lldbsuite/test/functionalities/step-avoids-no-debug/TestStepNoDebug.py
@@ -54,11 +54,11 @@ class ReturnValueTestCase(TestBase):
         target_line = line_number (self.main_source, pattern)
         self.assertTrue (target_line != 0, "Could not find source pattern " + pattern)
         cur_line = self.thread.frames[0].GetLineEntry().GetLine()
-        self.assertTrue (cur_line == target_line, "Stepped to line %d instead of expected %d with pattern '%s'."%(cur_line, target_line, pattern))
+        self.assertTrue (cur_line == target_line, "Stepped to line {0:d} instead of expected {1:d} with pattern '{2!s}'.".format(cur_line, target_line, pattern))
 
     def hit_correct_function (self, pattern):
         name = self.thread.frames[0].GetFunctionName()
-        self.assertTrue (pattern in name, "Got to '%s' not the expected function '%s'."%(name, pattern))
+        self.assertTrue (pattern in name, "Got to '{0!s}' not the expected function '{1!s}'.".format(name, pattern))
 
     def get_to_starting_point (self):
         exe = os.path.join(os.getcwd(), "a.out")

--- a/packages/Python/lldbsuite/test/functionalities/stop-hook/TestStopHookCmd.py
+++ b/packages/Python/lldbsuite/test/functionalities/stop-hook/TestStopHookCmd.py
@@ -38,7 +38,7 @@ class StopHookCmdTestCase(TestBase):
 
         lldbutil.run_break_set_by_file_and_line (self, "main.cpp", self.line, num_expected_locations=1, loc_exact=True)
 
-        self.runCmd("target stop-hook add -f main.cpp -l %d -e %d -o 'expr ptr'" % (self.begl, self.endl))
+        self.runCmd("target stop-hook add -f main.cpp -l {0:d} -e {1:d} -o 'expr ptr'".format(self.begl, self.endl))
 
         self.expect('target stop-hook list', 'Stop Hook added successfully',
             substrs = ['State: enabled',

--- a/packages/Python/lldbsuite/test/functionalities/stop-hook/TestStopHookMechanism.py
+++ b/packages/Python/lldbsuite/test/functionalities/stop-hook/TestStopHookMechanism.py
@@ -38,7 +38,7 @@ class StopHookMechanismTestCase(TestBase):
         add_prompt1 = "> "
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s %s' % (lldbtest_config.lldbExec, self.lldbOption))
+        self.child = pexpect.spawn('{0!s} {1!s}'.format(lldbtest_config.lldbExec, self.lldbOption))
         child = self.child
         # Turn on logging for what the child sends back.
         if self.TraceOn():
@@ -46,22 +46,22 @@ class StopHookMechanismTestCase(TestBase):
 
         if lldb.remote_platform:
             child.expect_exact(prompt)
-            child.sendline('platform select %s' % lldb.remote_platform.GetName())
+            child.sendline('platform select {0!s}'.format(lldb.remote_platform.GetName()))
             child.expect_exact(prompt)
-            child.sendline('platform connect %s' % configuration.lldb_platform_url)
+            child.sendline('platform connect {0!s}'.format(configuration.lldb_platform_url))
             child.expect_exact(prompt)
-            child.sendline('platform settings -w %s' % configuration.lldb_platform_working_dir)
+            child.sendline('platform settings -w {0!s}'.format(configuration.lldb_platform_working_dir))
 
         child.expect_exact(prompt)
-        child.sendline('target create %s' % exe)
+        child.sendline('target create {0!s}'.format(exe))
 
         # Set the breakpoint, followed by the target stop-hook commands.
         child.expect_exact(prompt)
-        child.sendline('breakpoint set -f main.cpp -l %d' % self.begl)
+        child.sendline('breakpoint set -f main.cpp -l {0:d}'.format(self.begl))
         child.expect_exact(prompt)
-        child.sendline('breakpoint set -f main.cpp -l %d' % self.line)
+        child.sendline('breakpoint set -f main.cpp -l {0:d}'.format(self.line))
         child.expect_exact(prompt)
-        child.sendline('target stop-hook add -f main.cpp -l %d -e %d' % (self.begl, self.endl))
+        child.sendline('target stop-hook add -f main.cpp -l {0:d} -e {1:d}'.format(self.begl, self.endl))
         child.expect_exact(add_prompt)
         child.expect_exact(add_prompt1)
         child.sendline('expr ptr')
@@ -85,8 +85,8 @@ class StopHookMechanismTestCase(TestBase):
         # I fixed that in lldb and I'm sticking in a test here because I don't want to have to
         # make up a whole nother test case for it.
         child.sendline('frame info')
-        at_line = 'at main.cpp:%d' % (self.correct_step_line)
-        print('expecting "%s"' % at_line)
+        at_line = 'at main.cpp:{0:d}'.format((self.correct_step_line))
+        print('expecting "{0!s}"'.format(at_line))
         child.expect_exact(at_line)
 
         # Now continue the inferior, we'll stop at another breakpoint which is outside the stop-hook range.

--- a/packages/Python/lldbsuite/test/functionalities/stop-hook/multiple_threads/TestStopHookMultipleThreads.py
+++ b/packages/Python/lldbsuite/test/functionalities/stop-hook/multiple_threads/TestStopHookMultipleThreads.py
@@ -40,7 +40,7 @@ class StopHookForMultipleThreadsTestCase(TestBase):
         prompt = "(lldb) "
 
         # So that the child gets torn down after the test.
-        self.child = pexpect.spawn('%s %s' % (lldbtest_config.lldbExec, self.lldbOption))
+        self.child = pexpect.spawn('{0!s} {1!s}'.format(lldbtest_config.lldbExec, self.lldbOption))
         child = self.child
         # Turn on logging for what the child sends back.
         if self.TraceOn():
@@ -48,20 +48,20 @@ class StopHookForMultipleThreadsTestCase(TestBase):
 
         if lldb.remote_platform:
             child.expect_exact(prompt)
-            child.sendline('platform select %s' % lldb.remote_platform.GetName())
+            child.sendline('platform select {0!s}'.format(lldb.remote_platform.GetName()))
             child.expect_exact(prompt)
-            child.sendline('platform connect %s' % configuration.lldb_platform_url)
+            child.sendline('platform connect {0!s}'.format(configuration.lldb_platform_url))
             child.expect_exact(prompt)
-            child.sendline('platform settings -w %s' % configuration.lldb_platform_working_dir)
+            child.sendline('platform settings -w {0!s}'.format(configuration.lldb_platform_working_dir))
 
         child.expect_exact(prompt)
-        child.sendline('target create %s' % exe)
+        child.sendline('target create {0!s}'.format(exe))
 
         # Set the breakpoint, followed by the target stop-hook commands.
         child.expect_exact(prompt)
-        child.sendline('breakpoint set -f main.cpp -l %d' % self.first_stop)
+        child.sendline('breakpoint set -f main.cpp -l {0:d}'.format(self.first_stop))
         child.expect_exact(prompt)
-        child.sendline('breakpoint set -f main.cpp -l %d' % self.thread_function)
+        child.sendline('breakpoint set -f main.cpp -l {0:d}'.format(self.thread_function))
         child.expect_exact(prompt)
 
         # Now run the program, expect to stop at the first breakpoint which is within the stop-hook range.

--- a/packages/Python/lldbsuite/test/functionalities/target_command/TestTargetCommand.py
+++ b/packages/Python/lldbsuite/test/functionalities/target_command/TestTargetCommand.py
@@ -94,17 +94,17 @@ class targetCommandTestCase(TestBase):
 
         self.runCmd("target list")
 
-        self.runCmd("target select %d" % base)
+        self.runCmd("target select {0:d}".format(base))
         self.runCmd("thread backtrace")
 
-        self.runCmd("target select %d" % (base + 2))
+        self.runCmd("target select {0:d}".format((base + 2)))
         self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = ['c.c:%d' % self.line_c,
+            substrs = ['c.c:{0:d}'.format(self.line_c),
                        'stop reason = breakpoint'])
 
-        self.runCmd("target select %d" % (base + 1))
+        self.runCmd("target select {0:d}".format((base + 1)))
         self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = ['b.c:%d' % self.line_b,
+            substrs = ['b.c:{0:d}'.format(self.line_b),
                        'stop reason = breakpoint'])
 
         self.runCmd("target list")

--- a/packages/Python/lldbsuite/test/functionalities/thread/TestNumThreads.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/TestNumThreads.py
@@ -32,7 +32,7 @@ class NumberOfThreadsTestCase(TestBase):
 
         # The breakpoint list should show 3 locations.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.line])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.line)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/thread/backtrace_all/TestBacktraceAll.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/backtrace_all/TestBacktraceAll.py
@@ -33,7 +33,7 @@ class BreakpointAfterJoinTestCase(TestBase):
 
         # The breakpoint list should show 1 location.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'ParallelTask.cpp', line = %d, exact_match = 0" % self.breakpoint])
+            substrs = ["1: file = 'ParallelTask.cpp', line = {0:d}, exact_match = 0".format(self.breakpoint)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/thread/break_after_join/TestBreakAfterJoin.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/break_after_join/TestBreakAfterJoin.py
@@ -36,7 +36,7 @@ class BreakpointAfterJoinTestCase(TestBase):
 
         # The breakpoint list should show 1 location.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.breakpoint])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.breakpoint)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/thread/concurrent_events/TestConcurrentEvents.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/concurrent_events/TestConcurrentEvents.py
@@ -325,18 +325,18 @@ class ConcurrentEventsTestCase(TestBase):
             if reason == lldb.eStopReasonBreakpoint:
                 bpid = x.GetStopReasonDataAtIndex(0)
                 bp = self.inferior_target.FindBreakpointByID(bpid)
-                reason_str = "%s hit %d times" % (lldbutil.get_description(bp), bp.GetHitCount())
+                reason_str = "{0!s} hit {1:d} times".format(lldbutil.get_description(bp), bp.GetHitCount())
             elif reason == lldb.eStopReasonWatchpoint:
                 watchid = x.GetStopReasonDataAtIndex(0)
                 watch = self.inferior_target.FindWatchpointByID(watchid)
-                reason_str = "%s hit %d times" % (lldbutil.get_description(watch), watch.GetHitCount())
+                reason_str = "{0!s} hit {1:d} times".format(lldbutil.get_description(watch), watch.GetHitCount())
             elif reason == lldb.eStopReasonSignal:
                 signals = self.inferior_process.GetUnixSignals()
                 signal_name = signals.GetSignalAsCString(x.GetStopReasonDataAtIndex(0))
-                reason_str = "signal %s" % signal_name
+                reason_str = "signal {0!s}".format(signal_name)
 
             location = "\t".join([lldbutil.get_description(x.GetFrameAtIndex(i)) for i in range(x.GetNumFrames())])
-            ret.append("thread %d %s due to %s at\n\t%s" % (id, status, reason_str, location))
+            ret.append("thread {0:d} {1!s} due to {2!s} at\n\t{3!s}".format(id, status, reason_str, location))
         return ret
 
     def add_breakpoint(self, line, descriptions):
@@ -346,7 +346,7 @@ class ConcurrentEventsTestCase(TestBase):
 
         bpno = lldbutil.run_break_set_by_file_and_line(self, self.filename, line, num_expected_locations=-1)
         bp = self.inferior_target.FindBreakpointByID(bpno)
-        descriptions.append(": file = 'main.cpp', line = %d" % self.finish_breakpoint_line)
+        descriptions.append(": file = 'main.cpp', line = {0:d}".format(self.finish_breakpoint_line))
         return bp
 
     def inferior_done(self):
@@ -419,15 +419,15 @@ class ConcurrentEventsTestCase(TestBase):
         # threads doing each action (break/crash/signal/watch)
         self.assertEqual(self.inferior_process.GetNumThreads(), 1, 'Expected to stop before any additional threads are spawned.')
 
-        self.runCmd("expr num_breakpoint_threads=%d" % num_breakpoint_threads)
-        self.runCmd("expr num_crash_threads=%d" % num_crash_threads)
-        self.runCmd("expr num_signal_threads=%d" % num_signal_threads)
-        self.runCmd("expr num_watchpoint_threads=%d" % num_watchpoint_threads)
+        self.runCmd("expr num_breakpoint_threads={0:d}".format(num_breakpoint_threads))
+        self.runCmd("expr num_crash_threads={0:d}".format(num_crash_threads))
+        self.runCmd("expr num_signal_threads={0:d}".format(num_signal_threads))
+        self.runCmd("expr num_watchpoint_threads={0:d}".format(num_watchpoint_threads))
 
-        self.runCmd("expr num_delay_breakpoint_threads=%d" % num_delay_breakpoint_threads)
-        self.runCmd("expr num_delay_crash_threads=%d" % num_delay_crash_threads)
-        self.runCmd("expr num_delay_signal_threads=%d" % num_delay_signal_threads)
-        self.runCmd("expr num_delay_watchpoint_threads=%d" % num_delay_watchpoint_threads)
+        self.runCmd("expr num_delay_breakpoint_threads={0:d}".format(num_delay_breakpoint_threads))
+        self.runCmd("expr num_delay_crash_threads={0:d}".format(num_delay_crash_threads))
+        self.runCmd("expr num_delay_signal_threads={0:d}".format(num_delay_signal_threads))
+        self.runCmd("expr num_delay_watchpoint_threads={0:d}".format(num_delay_watchpoint_threads))
 
         # Continue the inferior so threads are spawned
         self.runCmd("continue")
@@ -440,7 +440,7 @@ class ConcurrentEventsTestCase(TestBase):
                              + num_watchpoint_threads + num_delay_watchpoint_threads \
                              + num_crash_threads + num_delay_crash_threads + 1
         self.assertEqual(num_threads, expected_num_threads,
-            'Expected to see %d threads, but seeing %d. Details:\n%s' % (expected_num_threads,
+            'Expected to see {0:d} threads, but seeing {1:d}. Details:\n{2!s}'.format(expected_num_threads,
                                                                          num_threads,
                                                                          "\n\t".join(self.describe_threads())))
 
@@ -458,7 +458,7 @@ class ConcurrentEventsTestCase(TestBase):
         if num_crash_threads > 0 or num_delay_crash_threads > 0:
             # Expecting a crash
             self.assertTrue(self.crash_count > 0,
-                "Expecting at least one thread to crash. Details: %s" % "\t\n".join(self.describe_threads()))
+                "Expecting at least one thread to crash. Details: {0!s}".format("\t\n".join(self.describe_threads())))
 
             # Ensure the zombie process is reaped
             self.runCmd("process kill")
@@ -468,7 +468,7 @@ class ConcurrentEventsTestCase(TestBase):
             self.assertEqual(1, self.finish_breakpoint.GetHitCount(), "Expected main thread (finish) breakpoint to be hit once")
 
             num_threads = self.inferior_process.GetNumThreads()
-            self.assertEqual(1, num_threads, "Expecting 1 thread but seeing %d. Details:%s" % (num_threads,
+            self.assertEqual(1, num_threads, "Expecting 1 thread but seeing {0:d}. Details:{1!s}".format(num_threads,
                                                                                              "\n\t".join(self.describe_threads())))
             self.runCmd("continue")
 
@@ -480,13 +480,13 @@ class ConcurrentEventsTestCase(TestBase):
             expected_breakpoint_threads = num_delay_breakpoint_threads + num_breakpoint_threads
             breakpoint_hit_count = self.thread_breakpoint.GetHitCount() if expected_breakpoint_threads > 0 else 0
             self.assertEqual(expected_breakpoint_threads, breakpoint_hit_count,
-                "Expected %d breakpoint hits, but got %d" % (expected_breakpoint_threads, breakpoint_hit_count))
+                "Expected {0:d} breakpoint hits, but got {1:d}".format(expected_breakpoint_threads, breakpoint_hit_count))
 
             expected_signal_threads = num_delay_signal_threads + num_signal_threads
             self.assertEqual(expected_signal_threads, self.signal_count,
-                "Expected %d stops due to signal delivery, but got %d" % (expected_signal_threads, self.signal_count))
+                "Expected {0:d} stops due to signal delivery, but got {1:d}".format(expected_signal_threads, self.signal_count))
 
             expected_watchpoint_threads = num_delay_watchpoint_threads + num_watchpoint_threads
             watchpoint_hit_count = self.thread_watchpoint.GetHitCount() if expected_watchpoint_threads > 0 else 0
             self.assertEqual(expected_watchpoint_threads, watchpoint_hit_count,
-                "Expected %d watchpoint hits, got %d" % (expected_watchpoint_threads, watchpoint_hit_count))
+                "Expected {0:d} watchpoint hits, got {1:d}".format(expected_watchpoint_threads, watchpoint_hit_count))

--- a/packages/Python/lldbsuite/test/functionalities/thread/create_during_step/TestCreateDuringStep.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/create_during_step/TestCreateDuringStep.py
@@ -59,7 +59,7 @@ class CreateDuringStepTestCase(TestBase):
 
         # The breakpoint list should show 1 location.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, locations = 1" % self.breakpoint])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, locations = 1".format(self.breakpoint)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)
@@ -90,11 +90,11 @@ class CreateDuringStepTestCase(TestBase):
         # Find the thread that is stopped at the breakpoint
         stepping_thread = None
         for thread in process:
-            expected_bp_desc = "breakpoint %s." % self.bp_num
+            expected_bp_desc = "breakpoint {0!s}.".format(self.bp_num)
             if expected_bp_desc in thread.GetStopDescription(100):
                 stepping_thread = thread
                 break
-        self.assertTrue(stepping_thread != None, "unable to find thread stopped at %s" % expected_bp_desc)
+        self.assertTrue(stepping_thread != None, "unable to find thread stopped at {0!s}".format(expected_bp_desc))
         current_line = self.breakpoint
         # Keep stepping until we've reached our designated continue point
         while current_line != self.continuepoint:

--- a/packages/Python/lldbsuite/test/functionalities/thread/exit_during_break/TestExitDuringBreak.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/exit_during_break/TestExitDuringBreak.py
@@ -36,7 +36,7 @@ class ExitDuringBreakpointTestCase(TestBase):
 
         # The breakpoint list should show 1 location.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, locations = 1" % self.breakpoint])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, locations = 1".format(self.breakpoint)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/thread/exit_during_step/TestExitDuringStep.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/exit_during_step/TestExitDuringStep.py
@@ -62,7 +62,7 @@ class ExitDuringStepTestCase(TestBase):
 
         # The breakpoint list should show 1 location.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.breakpoint])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.breakpoint)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)
@@ -97,12 +97,12 @@ class ExitDuringStepTestCase(TestBase):
         # Find the thread that is stopped at the breakpoint
         stepping_thread = None
         for thread in process:
-            expected_bp_desc = "breakpoint %s." % self.bp_num
+            expected_bp_desc = "breakpoint {0!s}.".format(self.bp_num)
             stop_desc = thread.GetStopDescription(100)
             if stop_desc and (expected_bp_desc in stop_desc):
                 stepping_thread = thread
                 break
-        self.assertTrue(stepping_thread != None, "unable to find thread stopped at %s" % expected_bp_desc)
+        self.assertTrue(stepping_thread != None, "unable to find thread stopped at {0!s}".format(expected_bp_desc))
 
         current_line = self.breakpoint
         stepping_frame = stepping_thread.GetFrameAtIndex(0)

--- a/packages/Python/lldbsuite/test/functionalities/thread/jump/TestThreadJump.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/jump/TestThreadJump.py
@@ -43,18 +43,18 @@ class ThreadJumpTestCase(TestBase):
         self.do_min_test(self.mark4, self.mark2, "j", "8"); # Try the double path, force it to return 'b'
 
         # Try jumping to another function in a different file.
-        self.runCmd("thread jump --file other.cpp --line %i --force" % self.mark5)
+        self.runCmd("thread jump --file other.cpp --line {0:d} --force".format(self.mark5))
         self.expect("process status",
-            substrs = ["at other.cpp:%i" % self.mark5])
+            substrs = ["at other.cpp:{0:d}".format(self.mark5)])
 
         # Try jumping to another function (without forcing)
-        self.expect("j main.cpp:%i" % self.mark1, COMMAND_FAILED_AS_EXPECTED, error = True,
+        self.expect("j main.cpp:{0:d}".format(self.mark1), COMMAND_FAILED_AS_EXPECTED, error = True,
             substrs = ["error"])
     
     def do_min_test(self, start, jump, var, value):
-        self.runCmd("j %i" % start)                     # jump to the start marker
+        self.runCmd("j {0:d}".format(start))                     # jump to the start marker
         self.runCmd("thread step-in")                   # step into the min fn
-        self.runCmd("j %i" % jump)                      # jump to the branch we're interested in
+        self.runCmd("j {0:d}".format(jump))                      # jump to the branch we're interested in
         self.runCmd("thread step-out")                  # return out
         self.runCmd("thread step-over")                 # assign to the global
-        self.expect("expr %s" % var, substrs = [value]) # check it
+        self.expect("expr {0!s}".format(var), substrs = [value]) # check it

--- a/packages/Python/lldbsuite/test/functionalities/thread/multi_break/TestMultipleBreakpoints.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/multi_break/TestMultipleBreakpoints.py
@@ -36,7 +36,7 @@ class MultipleBreakpointTestCase(TestBase):
 
         # The breakpoint list should show 1 location.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, locations = 1" % self.breakpoint])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, locations = 1".format(self.breakpoint)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/thread/step_out/TestThreadStepOut.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/step_out/TestThreadStepOut.py
@@ -55,35 +55,35 @@ class ThreadStepOutTestCase(TestBase):
     def step_out_single_thread_with_cmd(self):
         self.step_out_with_cmd("this-thread")
         self.expect("thread backtrace all", "Thread location after step out is correct",
-            substrs = ["main.cpp:%d" % self.step_out_destination,
-                       "main.cpp:%d" % self.breakpoint])
+            substrs = ["main.cpp:{0:d}".format(self.step_out_destination),
+                       "main.cpp:{0:d}".format(self.breakpoint)])
 
     def step_out_all_threads_with_cmd(self):
         self.step_out_with_cmd("all-threads")
         self.expect("thread backtrace all", "Thread location after step out is correct",
-            substrs = ["main.cpp:%d" % self.step_out_destination])
+            substrs = ["main.cpp:{0:d}".format(self.step_out_destination)])
 
     def step_out_with_cmd(self, run_mode):
-        self.runCmd("thread select %d" % self.step_out_thread.GetIndexID())
-        self.runCmd("thread step-out -m %s" % run_mode)
+        self.runCmd("thread select {0:d}".format(self.step_out_thread.GetIndexID()))
+        self.runCmd("thread step-out -m {0!s}".format(run_mode))
         self.expect("process status", "Expected stop reason to be step-out",
             substrs = ["stop reason = step out"])
 
         self.expect("thread list", "Selected thread did not change during step-out",
-            substrs = ["* thread #%d" % self.step_out_thread.GetIndexID()])
+            substrs = ["* thread #{0:d}".format(self.step_out_thread.GetIndexID())])
 
     def step_out_with_python(self):
         self.step_out_thread.StepOut()
 
         reason = self.step_out_thread.GetStopReason()
         self.assertEqual(lldb.eStopReasonPlanComplete, reason,
-            "Expected thread stop reason 'plancomplete', but got '%s'" % lldbutil.stop_reason_to_str(reason))
+            "Expected thread stop reason 'plancomplete', but got '{0!s}'".format(lldbutil.stop_reason_to_str(reason)))
 
         # Verify location after stepping out
         frame = self.step_out_thread.GetFrameAtIndex(0)
         desc = lldbutil.get_description(frame.GetLineEntry())
-        expect = "main.cpp:%d" % self.step_out_destination
-        self.assertTrue(expect in desc, "Expected %s but thread stopped at %s" % (expect, desc))
+        expect = "main.cpp:{0:d}".format(self.step_out_destination)
+        self.assertTrue(expect in desc, "Expected {0!s} but thread stopped at {1!s}".format(expect, desc))
 
     def step_out_test(self, step_out_func):
         """Test single thread step out of a function."""
@@ -95,7 +95,7 @@ class ThreadStepOutTestCase(TestBase):
 
         # The breakpoint list should show 1 location.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.breakpoint])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.breakpoint)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)
@@ -114,7 +114,7 @@ class ThreadStepOutTestCase(TestBase):
                                       other_threads=other_threads)
 
         while len(breakpoint_threads) < 2:
-            self.runCmd("thread continue %s" % " ".join([str(x.GetIndexID()) for x in other_threads]))
+            self.runCmd("thread continue {0!s}".format(" ".join([str(x.GetIndexID()) for x in other_threads])))
             lldbutil.sort_stopped_threads(self.inferior_process,
                                           breakpoint_threads=breakpoint_threads,
                                           other_threads=other_threads)

--- a/packages/Python/lldbsuite/test/functionalities/thread/thread_exit/TestThreadExit.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/thread_exit/TestThreadExit.py
@@ -39,10 +39,10 @@ class ThreadExitTestCase(TestBase):
 
         # The breakpoint list should show 1 locations.
         self.expect("breakpoint list -f", "Breakpoint location shown correctly",
-            substrs = ["1: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.break_1,
-                       "2: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.break_2,
-                       "3: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.break_3,
-                       "4: file = 'main.cpp', line = %d, exact_match = 0, locations = 1" % self.break_4])
+            substrs = ["1: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.break_1),
+                       "2: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.break_2),
+                       "3: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.break_3),
+                       "4: file = 'main.cpp', line = {0:d}, exact_match = 0, locations = 1".format(self.break_4)])
 
         # Run the program.
         self.runCmd("run", RUN_SUCCEEDED)

--- a/packages/Python/lldbsuite/test/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
+++ b/packages/Python/lldbsuite/test/functionalities/thread/thread_specific_break_plus_condition/TestThreadSpecificBpPlusCondition.py
@@ -53,7 +53,7 @@ class ThreadSpecificBreakPlusConditionTestCase(TestBase):
         value = frame.FindVariable("my_value").GetValueAsSigned(0)
         self.assertTrue (value > 0 and value < 11, "Got a reasonable value for my_value.")
 
-        cond_string = "my_value != %d"%(value)
+        cond_string = "my_value != {0:d}".format((value))
 
         break_thread_body.SetThreadID(victim_thread.GetThreadID())
         break_thread_body.SetCondition (cond_string)

--- a/packages/Python/lldbsuite/test/functionalities/unwind/noreturn/TestNoreturnUnwind.py
+++ b/packages/Python/lldbsuite/test/functionalities/unwind/noreturn/TestNoreturnUnwind.py
@@ -46,7 +46,7 @@ class NoreturnUnwind(TestBase):
         if self.TraceOn():
             print("Backtrace once we're stopped:")
             for f in thread.frames:
-                print("  %d %s" % (f.GetFrameID(), f.GetFunctionName()))
+                print("  {0:d} {1!s}".format(f.GetFrameID(), f.GetFunctionName()))
 
         # I'm going to assume that abort() ends up calling/invoking another
         # function before halting the process.  In which case if abort_frame_number

--- a/packages/Python/lldbsuite/test/functionalities/unwind/sigtramp/TestSigtrampUnwind.py
+++ b/packages/Python/lldbsuite/test/functionalities/unwind/sigtramp/TestSigtrampUnwind.py
@@ -67,7 +67,7 @@ class SigtrampUnwind(TestBase):
         if self.TraceOn():
             print("Backtrace once we're stopped:")
             for f in thread.frames:
-                print("  %d %s" % (f.GetFrameID(), f.GetFunctionName()))
+                print("  {0:d} {1!s}".format(f.GetFrameID(), f.GetFunctionName()))
 
         if found_handler == False:
             self.fail("Unable to find handler() in backtrace.")

--- a/packages/Python/lldbsuite/test/functionalities/unwind/standard/TestStandardUnwind.py
+++ b/packages/Python/lldbsuite/test/functionalities/unwind/standard/TestStandardUnwind.py
@@ -86,7 +86,7 @@ class StandardUnwindTest(TestBase):
             thread = process.GetThreadAtIndex(0)
 
             if self.TraceOn():
-                print("INDEX: %u" % index)
+                print("INDEX: {0:d}".format(index))
                 for f in thread.frames:
                     print(f)
 

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/hello_watchlocation/TestWatchLocation.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/hello_watchlocation/TestWatchLocation.py
@@ -82,7 +82,7 @@ class HelloWatchLocationTestCase(TestBase):
         # only once.  The stop reason of the thread should be watchpoint.
         self.expect("thread list", STOPPED_DUE_TO_WATCHPOINT,
             substrs = ['stopped',
-                       'stop reason = watchpoint %d' % expected_wp_id])
+                       'stop reason = watchpoint {0:d}'.format(expected_wp_id)])
 
         # Switch to the thread stopped due to watchpoint and issue some commands.
         self.switch_to_thread_with_stop_reason(lldb.eStopReasonWatchpoint)

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/hello_watchpoint/TestMyFirstWatchpoint.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/hello_watchpoint/TestMyFirstWatchpoint.py
@@ -56,7 +56,7 @@ class HelloWatchpointTestCase(TestBase):
         # There should be only one watchpoint hit (see main.c).
         self.expect("watchpoint set variable -w write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = w',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         # Use the '-v' option to do verbose listing of the watchpoint.
         # The hit count should be 0 initially.

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/multiple_threads/TestWatchpointMultipleThreads.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/multiple_threads/TestWatchpointMultipleThreads.py
@@ -42,7 +42,7 @@ class WatchpointForMultipleThreadsTestCase(TestBase):
 
     def hello_multiple_threads(self):
         """Test that lldb watchpoint works for multiple threads."""
-        self.runCmd("file %s" % os.path.join(os.getcwd(), 'a.out'), CURRENT_EXECUTABLE_SET)
+        self.runCmd("file {0!s}".format(os.path.join(os.getcwd(), 'a.out')), CURRENT_EXECUTABLE_SET)
 
         # Add a breakpoint to set a watchpoint when stopped on the breakpoint.
         lldbutil.run_break_set_by_file_and_line (self, None, self.first_stop, num_expected_locations=1)
@@ -86,7 +86,7 @@ class WatchpointForMultipleThreadsTestCase(TestBase):
 
     def hello_multiple_threads_wp_set_and_then_delete(self):
         """Test that lldb watchpoint works for multiple threads, and after the watchpoint is deleted, the watchpoint event should no longer fires."""
-        self.runCmd("file %s" % os.path.join(os.getcwd(), 'a.out'), CURRENT_EXECUTABLE_SET)
+        self.runCmd("file {0!s}".format(os.path.join(os.getcwd(), 'a.out')), CURRENT_EXECUTABLE_SET)
 
         # Add a breakpoint to set a watchpoint when stopped on the breakpoint.
         lldbutil.run_break_set_by_file_and_line (self, None, self.first_stop, num_expected_locations=1)
@@ -128,7 +128,7 @@ class WatchpointForMultipleThreadsTestCase(TestBase):
                     self.fail("Watchpoint hits not supposed to exceed 1 by design!")
                 # Good, we verified that the watchpoint works!  Now delete the watchpoint.
                 if self.TraceOn():
-                    print("watchpoint_stops=%d at the moment we delete the watchpoint" % watchpoint_stops)
+                    print("watchpoint_stops={0:d} at the moment we delete the watchpoint".format(watchpoint_stops))
                 self.runCmd("watchpoint delete 1")
                 self.expect("watchpoint list -v",
                     substrs = ['No watchpoints currently set.'])

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/step_over_watchpoint/TestStepOverWatchpoint.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/step_over_watchpoint/TestStepOverWatchpoint.py
@@ -50,8 +50,8 @@ class TestStepOverWatchpoint(TestBase):
         # resolve_location=True, read=True, write=False
         read_watchpoint = read_value.Watch(True, True, False, error)
         self.assertTrue(error.Success(),
-                        "Error while setting watchpoint: %s" %
-                        error.GetCString())
+                        "Error while setting watchpoint: {0!s}".format(
+                        error.GetCString()))
         self.assertTrue(read_watchpoint, "Failed to set read watchpoint.")
 
         thread.StepOver()
@@ -79,8 +79,8 @@ class TestStepOverWatchpoint(TestBase):
         write_watchpoint = write_value.Watch(True, False, True, error)
         self.assertTrue(read_watchpoint, "Failed to set write watchpoint.")
         self.assertTrue(error.Success(),
-                        "Error while setting watchpoint: %s" %
-                        error.GetCString())
+                        "Error while setting watchpoint: {0!s}".format(
+                        error.GetCString()))
 
         thread.StepOver()
         self.assertTrue(thread.GetStopReason() == lldb.eStopReasonWatchpoint,
@@ -102,7 +102,7 @@ class TestStepOverWatchpoint(TestBase):
             stop_reason = self.thread().GetStopReason()
             if stop_reason == lldb.eStopReasonWatchpoint:
                 self.assertFalse(watchpoint_hit, "Watchpoint already hit.")
-                expected_stop_desc = "watchpoint %d" % wp_id
+                expected_stop_desc = "watchpoint {0:d}".format(wp_id)
                 actual_stop_desc = self.thread().GetStopDescription(20)
                 self.assertTrue(actual_stop_desc == expected_stop_desc,
                                 "Watchpoint ID didn't match.")

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_commands/TestWatchpointCommands.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_commands/TestWatchpointCommands.py
@@ -55,7 +55,7 @@ class WatchpointCommandsTestCase(TestBase):
         # There should be two watchpoint hits (see main.c).
         self.expect("watchpoint set variable -w read_write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = rw',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         # Use the '-v' option to do verbose listing of the watchpoint.
         # The hit count should be 0 initially.
@@ -115,7 +115,7 @@ class WatchpointCommandsTestCase(TestBase):
         # There should be two watchpoint hits (see main.c).
         self.expect("watchpoint set variable -w read_write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = rw',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         # Delete the watchpoint immediately, but set auto-confirm to true first.
         self.runCmd("settings set auto-confirm true")
@@ -160,7 +160,7 @@ class WatchpointCommandsTestCase(TestBase):
         # There should be two watchpoint hits (see main.c).
         self.expect("watchpoint set variable -w read_write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = rw',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         # Set the ignore count of the watchpoint immediately.
         self.expect("watchpoint ignore -i 2",
@@ -209,7 +209,7 @@ class WatchpointCommandsTestCase(TestBase):
         # There should be two watchpoint hits (see main.c).
         self.expect("watchpoint set variable -w read_write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = rw',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         # Use the '-v' option to do verbose listing of the watchpoint.
         # The hit count should be 0 initially.
@@ -269,7 +269,7 @@ class WatchpointCommandsTestCase(TestBase):
         # There should be two watchpoint hits (see main.c).
         self.expect("watchpoint set variable -w read_write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = rw',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         # Immediately, we disable the watchpoint.  We won't be stopping due to a
         # watchpoint after this.

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_commands/command/TestWatchpointCommandLLDB.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_commands/command/TestWatchpointCommandLLDB.py
@@ -25,7 +25,7 @@ class WatchpointLLDBCommandTestCase(TestBase):
         # And the watchpoint variable declaration line number.
         self.decl = line_number(self.source, '// Watchpoint variable declaration.')
         # Build dictionary to have unique executable names for each test method.
-        self.exe_name = 'a%d.out' % self.test_number
+        self.exe_name = 'a{0:d}.out'.format(self.test_number)
         self.d = {'CXX_SOURCES': self.source, 'EXE': self.exe_name}
 
     @expectedFailureAndroid(archs=['arm', 'aarch64']) # Watchpoints not supported
@@ -53,7 +53,7 @@ class WatchpointLLDBCommandTestCase(TestBase):
         # Now let's set a write-type watchpoint for 'global'.
         self.expect("watchpoint set variable -w write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = w',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         self.runCmd('watchpoint command add 1 -o "expr -- cookie = 777"')
 
@@ -107,7 +107,7 @@ class WatchpointLLDBCommandTestCase(TestBase):
         # Now let's set a write-type watchpoint for 'global'.
         self.expect("watchpoint set variable -w write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = w',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         self.runCmd('watchpoint command add 1 -o "watchpoint disable 1"')
 

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_commands/command/TestWatchpointCommandPython.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_commands/command/TestWatchpointCommandPython.py
@@ -57,7 +57,7 @@ class WatchpointPythonCommandTestCase(TestBase):
         # Now let's set a write-type watchpoint for 'global'.
         self.expect("watchpoint set variable -w write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = w',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         self.runCmd('watchpoint command add -s python 1 -o \'frame.EvaluateExpression("cookie = 777")\'')
 

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_commands/condition/TestWatchpointConditionCmd.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_commands/condition/TestWatchpointConditionCmd.py
@@ -54,7 +54,7 @@ class WatchpointConditionCmdTestCase(TestBase):
         # With a condition of 'global==5'.
         self.expect("watchpoint set variable -w write global", WATCHPOINT_CREATED,
             substrs = ['Watchpoint created', 'size = 4', 'type = w',
-                       '%s:%d' % (self.source, self.decl)])
+                       '{0!s}:{1:d}'.format(self.source, self.decl)])
 
         self.runCmd("watchpoint modify -c 'global==5'")
 

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_events/TestWatchpointEvents.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_events/TestWatchpointEvents.py
@@ -60,7 +60,7 @@ class TestWatchpointEvents (TestBase):
         error = lldb.SBError()
         local_watch = local_var.Watch(True, True, True, error)
         if not error.Success():
-            self.fail ("Failed to make watchpoint for local_var: %s"%(error.GetCString()))
+            self.fail ("Failed to make watchpoint for local_var: {0!s}".format((error.GetCString())))
 
         self.GetWatchpointEvent (lldb.eWatchpointEventTypeAdded)
         # Now change some of the features of this watchpoint and make sure we get events:
@@ -80,7 +80,7 @@ class TestWatchpointEvents (TestBase):
         self.assertTrue(success == True, "Successfully got watchpoint event")
         self.assertTrue (lldb.SBWatchpoint.EventIsWatchpointEvent(event), "Event is a watchpoint event.")
         found_type = lldb.SBWatchpoint.GetWatchpointEventTypeFromEvent (event)
-        self.assertTrue (found_type == event_type, "Event is not correct type, expected: %d, found: %d"%(event_type, found_type))
+        self.assertTrue (found_type == event_type, "Event is not correct type, expected: {0:d}, found: {1:d}".format(event_type, found_type))
         # There shouldn't be another event waiting around:
         found_event = self.listener.PeekAtNextEventForBroadcasterWithType (self.target_bcast, lldb.SBTarget.eBroadcastBitBreakpointChanged, event)
         if found_event:

--- a/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_set_command/TestWatchLocationWithWatchSet.py
+++ b/packages/Python/lldbsuite/test/functionalities/watchpoint/watchpoint_set_command/TestWatchLocationWithWatchSet.py
@@ -84,6 +84,6 @@ class WatchLocationUsingWatchpointSetTestCase(TestBase):
         # stopped on a watchpoint.
         threads = lldbutil.get_stopped_threads(self.process(), lldb.eStopReasonWatchpoint)
         self.expect("watchpoint list -v",
-            substrs = ['hit_count = %d' % len(threads)])
+            substrs = ['hit_count = {0:d}'.format(len(threads))])
 
         self.runCmd("thread backtrace all")

--- a/packages/Python/lldbsuite/test/lang/c/array_types/TestArrayTypes.py
+++ b/packages/Python/lldbsuite/test/lang/c/array_types/TestArrayTypes.py
@@ -84,7 +84,7 @@ class ArrayTypesTestCase(TestBase):
         bp = str(breakpoint)
         self.expect(bp, msg="Breakpoint looks good", exe=False,
             substrs = ["file = 'main.c'",
-                       "line = %d" % self.line,
+                       "line = {0:d}".format(self.line),
                        "locations = 1"])
         self.expect(bp, msg="Breakpoint is not resolved as yet", exe=False, matching=False,
             substrs = ["resolved = 1"])
@@ -113,9 +113,9 @@ class ArrayTypesTestCase(TestBase):
         # match the check in Core/FormatEntity.cpp in the function FormatEntity::Format() for
         # the Entry::Type::ThreadID case of the switch statement.
         if self.getPlatform() == "linux" or self.getPlatform() == "freebsd":
-            tidstr = "tid = %u" % thread.GetThreadID()
+            tidstr = "tid = {0:d}".format(thread.GetThreadID())
         else:
-            tidstr = "tid = 0x%4.4x" % thread.GetThreadID()
+            tidstr = "tid = 0x{0:4.4x}".format(thread.GetThreadID())
         self.expect(thr, "Thread looks good with stop reason = breakpoint", exe=False,
             substrs = [tidstr])
 
@@ -126,23 +126,23 @@ class ArrayTypesTestCase(TestBase):
         bp = str(breakpoint)
         self.expect(bp, "Breakpoint looks good and is resolved", exe=False,
             substrs = ["file = 'main.c'",
-                       "line = %d" % self.line,
+                       "line = {0:d}".format(self.line),
                        "locations = 1"])
 
         # Sanity check the print representation of frame.
         frame = thread.GetFrameAtIndex(0)
         frm = str(frame)
         self.expect(frm,
-                    "Frame looks good with correct index %d" % frame.GetFrameID(),
+                    "Frame looks good with correct index {0:d}".format(frame.GetFrameID()),
                     exe=False,
-            substrs = ["#%d" % frame.GetFrameID()])
+            substrs = ["#{0:d}".format(frame.GetFrameID())])
 
         # Lookup the "strings" string array variable and sanity check its print
         # representation.
         variable = frame.FindVariable("strings")
         var = str(variable)
         self.expect(var, "Variable for 'strings' looks good with correct name", exe=False,
-            substrs = ["%s" % variable.GetName()])
+            substrs = ["{0!s}".format(variable.GetName())])
         self.DebugSBValue(variable)
         self.assertTrue(variable.GetNumChildren() == 4,
                         "Variable 'strings' should have 4 children")
@@ -189,10 +189,10 @@ class ArrayTypesTestCase(TestBase):
         # and "argc" has eValueTypeVariableArgument.
         from lldbsuite.test.lldbutil import value_type_to_str
         self.assertTrue(variable.GetValueType() == lldb.eValueTypeVariableLocal,
-                        "Variable 'long_6' should have '%s' value type." %
-                        value_type_to_str(lldb.eValueTypeVariableLocal))
+                        "Variable 'long_6' should have '{0!s}' value type.".format(
+                        value_type_to_str(lldb.eValueTypeVariableLocal)))
         argc = frame.FindVariable("argc")
         self.DebugSBValue(argc)
         self.assertTrue(argc.GetValueType() == lldb.eValueTypeVariableArgument,
-                        "Variable 'argc' should have '%s' value type." %
-                        value_type_to_str(lldb.eValueTypeVariableArgument))
+                        "Variable 'argc' should have '{0!s}' value type.".format(
+                        value_type_to_str(lldb.eValueTypeVariableArgument)))

--- a/packages/Python/lldbsuite/test/lang/c/stepping/TestStepAndBreakpoints.py
+++ b/packages/Python/lldbsuite/test/lang/c/stepping/TestStepAndBreakpoints.py
@@ -168,7 +168,7 @@ class TestCStepping(TestBase):
 
         # See that we are still in b:
         func_name = thread.GetFrameAtIndex(0).GetFunctionName()
-        self.assertTrue (func_name == "b", "Should be in 'b', were in %s"%(func_name))
+        self.assertTrue (func_name == "b", "Should be in 'b', were in {0!s}".format((func_name)))
 
         # Okay, now if we continue, we will finish off our function call and we should end up back in "a" as if nothing had happened:
         process.Continue ()

--- a/packages/Python/lldbsuite/test/lang/c/stepping/TestThreadStepping.py
+++ b/packages/Python/lldbsuite/test/lang/c/stepping/TestThreadStepping.py
@@ -46,8 +46,8 @@ class ThreadSteppingTestCase(TestBase):
         # in function name 'c'.  And frame #3 should point to main.c:37.
         self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT,
             substrs = ["stop reason = breakpoint"],
-            patterns = ["frame #0.*main.c:%d" % self.line1,
-                        "frame #3.*main.c:%d" % self.line2])
+            patterns = ["frame #0.*main.c:{0:d}".format(self.line1),
+                        "frame #3.*main.c:{0:d}".format(self.line2)])
 
         # We want to move the pc to frame #3.  This can be accomplished by
         # 'frame select 2', followed by 'thread step-out'.
@@ -55,7 +55,7 @@ class ThreadSteppingTestCase(TestBase):
         self.runCmd("thread step-out")
         self.expect("thread backtrace", STEP_OUT_SUCCEEDED,
             substrs = ["stop reason = step out"],
-            patterns = ["frame #0.*main.c:%d" % self.line2])
+            patterns = ["frame #0.*main.c:{0:d}".format(self.line2)])
 
         # Let's move on to a single step-out case.
         self.runCmd("process continue")
@@ -66,7 +66,7 @@ class ThreadSteppingTestCase(TestBase):
         self.runCmd("thread step-out")
         self.expect("thread backtrace", STEP_OUT_SUCCEEDED,
             substrs = ["stop reason = step out"],
-            patterns = ["frame #0.*main.c:%d" % self.line3])
+            patterns = ["frame #0.*main.c:{0:d}".format(self.line3)])
 
         # Do another frame selct, followed by thread step-out.
         self.runCmd("process continue")
@@ -78,4 +78,4 @@ class ThreadSteppingTestCase(TestBase):
         self.runCmd("thread step-out")
         self.expect("thread backtrace", STEP_OUT_SUCCEEDED,
             substrs = ["stop reason = step out"],
-            patterns = ["frame #0.*main.c:%d" % self.line4])
+            patterns = ["frame #0.*main.c:{0:d}".format(self.line4)])

--- a/packages/Python/lldbsuite/test/lang/cpp/class_types/TestClassTypes.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/class_types/TestClassTypes.py
@@ -100,9 +100,9 @@ class ClassTypesTestCase(TestBase):
 
         # The filename of frame #0 should be 'main.cpp' and the line number
         # should be 93.
-        self.expect("%s:%d" % (lldbutil.get_filenames(thread)[0],
+        self.expect("{0!s}:{1:d}".format(lldbutil.get_filenames(thread)[0],
                                lldbutil.get_line_numbers(thread)[0]),
-                    "Break correctly at main.cpp:%d" % self.line, exe=False,
+                    "Break correctly at main.cpp:{0:d}".format(self.line), exe=False,
             startstr = "main.cpp:")
             ### clang compiled code reported main.cpp:94?
             ### startstr = "main.cpp:93")

--- a/packages/Python/lldbsuite/test/lang/cpp/class_types/TestClassTypesDisassembly.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/class_types/TestClassTypesDisassembly.py
@@ -34,7 +34,7 @@ class IterateFrameAndDisassembleTestCase(TestBase):
                 function = match.group(1)
                 #print("line:", line)
                 #print("function:", function)
-                self.runCmd("disassemble -n '%s'" % function)
+                self.runCmd("disassemble -n '{0!s}'".format(function))
 
     @add_test_categories(['pyapi'])
     def test_and_python_api(self):
@@ -84,7 +84,7 @@ class IterateFrameAndDisassembleTestCase(TestBase):
         # The stop reason of the thread should be breakpoint.
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
             substrs = ['stopped',
-                       'stop reason = breakpoint %d.'%(bpno)])
+                       'stop reason = breakpoint {0:d}.'.format((bpno))])
 
         # This test was failing because we fail to put the C:: in front of constructore.
         # We should maybe make another testcase to cover that specifically, but we shouldn't

--- a/packages/Python/lldbsuite/test/lang/cpp/namespace/TestNamespace.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/namespace/TestNamespace.py
@@ -72,12 +72,12 @@ class NamespaceTestCase(TestBase):
 
         # 'frame variable' with basename 'i' should work.
         self.expect("frame variable --show-declaration --show-globals i",
-            startstr = "main.cpp:%d: (int) (anonymous namespace)::i = 3" % self.line_var_i)
+            startstr = "main.cpp:{0:d}: (int) (anonymous namespace)::i = 3".format(self.line_var_i))
         # main.cpp:12: (int) (anonymous namespace)::i = 3
 
         # 'frame variable' with basename 'j' should work, too.
         self.expect("frame variable --show-declaration --show-globals j",
-            startstr = "main.cpp:%d: (int) A::B::j = 4" % self.line_var_j)
+            startstr = "main.cpp:{0:d}: (int) A::B::j = 4".format(self.line_var_j))
         # main.cpp:19: (int) A::B::j = 4
 
         # 'frame variable' should support address-of operator.

--- a/packages/Python/lldbsuite/test/lang/cpp/stl/TestSTL.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/stl/TestSTL.py
@@ -45,7 +45,7 @@ class STLTestCase(TestBase):
 
         # Stop at 'std::string hello_world ("Hello World!");'.
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = ['main.cpp:%d' % self.line,
+            substrs = ['main.cpp:{0:d}'.format(self.line),
                        'stop reason = breakpoint'])
 
         # The breakpoint should have a hit count of 1.

--- a/packages/Python/lldbsuite/test/lang/cpp/stl/TestStdCXXDisassembly.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/stl/TestStdCXXDisassembly.py
@@ -57,7 +57,7 @@ class StdCXXDisassembleTestCase(TestBase):
             frame = thread.GetFrameAtIndex(i)
             function = frame.GetFunction()
             if function.GetName():
-                self.runCmd("disassemble -n '%s'" % function.GetName())
+                self.runCmd("disassemble -n '{0!s}'".format(function.GetName()))
 
         lib_stdcxx = "FAILHORRIBLYHERE"
         # Iterate through the available modules, looking for stdc++ library...
@@ -74,7 +74,7 @@ class StdCXXDisassembleTestCase(TestBase):
         self.expect(lib_stdcxx, "Libraray StdC++ is located", exe=False,
             substrs = ["lib"])
 
-        self.runCmd("image dump symtab '%s'" % lib_stdcxx)
+        self.runCmd("image dump symtab '{0!s}'".format(lib_stdcxx))
         raw_output = self.res.GetOutput()
         # Now, look for every 'Code' symbol and feed its load address into the
         # command: 'disassemble -s load_address -e end_address', where the
@@ -104,7 +104,7 @@ class StdCXXDisassembleTestCase(TestBase):
                     print("SA:", SA)
                 if SA and LA:
                     if int(LA, 16) > int(SA, 16):
-                        self.runCmd("disassemble -s %s -e %s" % (SA, LA))
+                        self.runCmd("disassemble -s {0!s} -e {1!s}".format(SA, LA))
                 SA = LA
             else:
                 # This entry is not a Code entry.  Reset SA = None.

--- a/packages/Python/lldbsuite/test/lang/cpp/virtual/TestVirtual.py
+++ b/packages/Python/lldbsuite/test/lang/cpp/virtual/TestVirtual.py
@@ -11,7 +11,7 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 def Msg(expr, val):
-    return "'expression %s' matches the output (from compiled code): %s" % (expr, val)
+    return "'expression {0!s}' matches the output (from compiled code): {1!s}".format(expr, val)
 
 class CppVirtualMadness(TestBase):
 
@@ -82,7 +82,7 @@ class CppVirtualMadness(TestBase):
         # 'expression var'.
         for my_expr, val in gl:
 
-            self.runCmd("expression %s" % my_expr)
+            self.runCmd("expression {0!s}".format(my_expr))
             output = self.res.GetOutput()
             
             # The expression output must match the oracle.

--- a/packages/Python/lldbsuite/test/lang/go/types/TestGoASTContext.py
+++ b/packages/Python/lldbsuite/test/lang/go/types/TestGoASTContext.py
@@ -86,7 +86,7 @@ class TestGoASTContext(TestBase):
 
     def var(self, name):
         var = self.frame().FindVariable(name)
-        self.assertTrue(var.IsValid(), "%s %s" % (VALID_VARIABLE, name))
+        self.assertTrue(var.IsValid(), "{0!s} {1!s}".format(VALID_VARIABLE, name))
         return var
 
     def check_main_vars(self):

--- a/packages/Python/lldbsuite/test/lang/mixed/TestMixedLanguages.py
+++ b/packages/Python/lldbsuite/test/lang/mixed/TestMixedLanguages.py
@@ -21,7 +21,7 @@ class MixedLanguagesTestCase(TestBase):
         # Execute the cleanup function during test case tear down
         # to restore the frame format.
         def cleanup():
-            self.runCmd("settings set frame-format %s" % self.format_string, check=False)
+            self.runCmd("settings set frame-format {0!s}".format(self.format_string), check=False)
         self.addTearDownHook(cleanup)
         self.runCmd("settings show frame-format")
         m = re.match(
@@ -32,7 +32,7 @@ class MixedLanguagesTestCase(TestBase):
 
         # Change the default format to print the language.
         format_string = "frame #${frame.index}: ${frame.pc}{ ${module.file.basename}`${function.name}{${function.pc-offset}}}{, lang=${language}}\n"
-        self.runCmd("settings set frame-format %s" % format_string)
+        self.runCmd("settings set frame-format {0!s}".format(format_string))
         self.expect("settings show frame-format", SETTING_MSG("frame-format"),
             substrs = [format_string])
 

--- a/packages/Python/lldbsuite/test/lang/objc/foundation/TestConstStrings.py
+++ b/packages/Python/lldbsuite/test/lang/objc/foundation/TestConstStrings.py
@@ -37,7 +37,7 @@ class ConstStringTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("process status", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = [" at %s:%d" % (self.main_source, self.line),
+            substrs = [" at {0!s}:{1:d}".format(self.main_source, self.line),
                        "stop reason = breakpoint"])
 
         self.expect('expression (int)[str compare:@"hello"]',

--- a/packages/Python/lldbsuite/test/lang/objc/foundation/TestFoundationDisassembly.py
+++ b/packages/Python/lldbsuite/test/lang/objc/foundation/TestFoundationDisassembly.py
@@ -43,7 +43,7 @@ class FoundationDisassembleTestCase(TestBase):
                 break
 
         self.assertTrue(foundation_framework != None, "Foundation.framework path located")
-        self.runCmd("image dump symtab '%s'" % foundation_framework)
+        self.runCmd("image dump symtab '{0!s}'".format(foundation_framework))
         raw_output = self.res.GetOutput()
         # Now, grab every 'Code' symbol and feed it into the command:
         # 'disassemble -n func'.
@@ -62,7 +62,7 @@ class FoundationDisassembleTestCase(TestBase):
                 func = match.group(1)
                 #print("line:", line)
                 #print("func:", func)
-                self.runCmd('disassemble -n "%s"' % func)
+                self.runCmd('disassemble -n "{0!s}"'.format(func))
         
 
     def test_simple_disasm(self):
@@ -79,7 +79,7 @@ class FoundationDisassembleTestCase(TestBase):
 
         # Stop at +[NSString stringWithFormat:].
         symbol_name = "+[NSString stringWithFormat:]"
-        break_results = lldbutil.run_break_set_command (self, "_regexp-break %s"%(symbol_name))
+        break_results = lldbutil.run_break_set_command (self, "_regexp-break {0!s}".format((symbol_name)))
         
         lldbutil.check_breakpoint_result (self, break_results, symbol_name=symbol_name, num_locations=1)
 

--- a/packages/Python/lldbsuite/test/lang/objc/foundation/TestObjCMethods.py
+++ b/packages/Python/lldbsuite/test/lang/objc/foundation/TestObjCMethods.py
@@ -238,7 +238,7 @@ class FoundationTestCase(TestBase):
         # Log any DWARF lookups
         ++file_index
         logfile = os.path.join(os.getcwd(), "dwarf-lookups-" + self.getArchitecture() + "-" + str(file_index) + ".txt")
-        self.runCmd("log enable -f %s dwarf lookups" % (logfile))
+        self.runCmd("log enable -f {0!s} dwarf lookups".format((logfile)))
         self.runCmd("expr self")
         self.runCmd("log disable dwarf lookups")
         

--- a/packages/Python/lldbsuite/test/lang/objc/objc-optimized/TestObjcOptimized.py
+++ b/packages/Python/lldbsuite/test/lang/objc/objc-optimized/TestObjcOptimized.py
@@ -25,7 +25,7 @@ class ObjcOptimizedTestCase(TestBase):
     mydir = TestBase.compute_mydir(__file__)
     myclass = "MyClass"
     mymethod = "description"
-    method_spec = "-[%s %s]" % (myclass, mymethod)
+    method_spec = "-[{0!s} {1!s}]".format(myclass, mymethod)
 
     def test_break(self):
         """Test 'expr member' continues to work for optimized build."""
@@ -38,7 +38,7 @@ class ObjcOptimizedTestCase(TestBase):
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("thread backtrace", STOPPED_DUE_TO_BREAKPOINT,
             substrs = ["stop reason = breakpoint"],
-            patterns = ["frame.*0:.*%s %s" % (self.myclass, self.mymethod)])
+            patterns = ["frame.*0:.*{0!s} {1!s}".format(self.myclass, self.mymethod)])
 
         self.expect('expression member',
             startstr = "(int) $0 = 5")
@@ -57,7 +57,7 @@ class ObjcOptimizedTestCase(TestBase):
             desired_pointer = mo.group(0)
 
         self.expect('expression (self)',
-            substrs = [("(%s *) $1 = " % self.myclass), desired_pointer])
+            substrs = [("({0!s} *) $1 = ".format(self.myclass)), desired_pointer])
 
         self.expect('expression self->non_member', error=True,
             substrs = ["does not have a member named 'non_member'"])

--- a/packages/Python/lldbsuite/test/lang/objc/radar-9691614/TestObjCMethodReturningBOOL.py
+++ b/packages/Python/lldbsuite/test/lang/objc/radar-9691614/TestObjCMethodReturningBOOL.py
@@ -38,7 +38,7 @@ class MethodReturningBOOLTestCase(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("process status", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = [" at %s:%d" % (self.main_source, self.line),
+            substrs = [" at {0!s}:{1:d}".format(self.main_source, self.line),
                        "stop reason = breakpoint"])
 
         # rdar://problem/9691614

--- a/packages/Python/lldbsuite/test/lang/swift/expression/access_control/TestExpressionAccessControl.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/access_control/TestExpressionAccessControl.py
@@ -44,7 +44,7 @@ class TestSwiftExpressionAccessControl(TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "%s expected: %s got: %s"%(expression, expected_result, answer)
+        report_str = "{0!s} expected: {1!s} got: {2!s}".format(expression, expected_result, answer)
         self.assertTrue(answer == expected_result, report_str)
 
     def do_test(self):

--- a/packages/Python/lldbsuite/test/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/classes/fromobjc/TestSwiftExpressionsInMethodsFromObjc.py
@@ -43,7 +43,7 @@ class TestExpressionsInSwiftMethodsFromObjC(TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "%s expected: %s got: %s"%(expression, expected_result, answer)
+        report_str = "{0!s} expected: {1!s} got: {2!s}".format(expression, expected_result, answer)
         self.assertTrue(answer == expected_result, report_str)
 
     def do_test(self):

--- a/packages/Python/lldbsuite/test/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/classes/pureswift/TestSwiftExpressionsInMethodsPureSwift.py
@@ -42,7 +42,7 @@ class TestExpressionsInSwiftMethodsPureSwift(TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "%s expected: %s got: %s"%(expression, expected_result, answer)
+        report_str = "{0!s} expected: {1!s} got: {2!s}".format(expression, expected_result, answer)
         self.assertTrue(answer == expected_result, report_str)
 
     def do_test(self):

--- a/packages/Python/lldbsuite/test/lang/swift/expression/errors/TestExpressionErrors.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/errors/TestExpressionErrors.py
@@ -81,17 +81,17 @@ class TestExpressionErrors(TestBase):
         # FIXME: pull the "try" back out when we fix <rdar://problem/21949031>
         enum_value = self.frame.EvaluateExpression ("IThrowEnumOver10(101)", options)
         self.assertTrue(enum_value.IsValid(), "Got a valid enum value.")
-        self.assertTrue(enum_value.GetError().Success(), "Got error %s getting enum value"%(enum_value.GetError().GetCString()))
-        self.assertTrue(enum_value.GetValue() == "ImportantError", "Expected 'ImportantError', got %s"%(enum_value.GetValue()))
+        self.assertTrue(enum_value.GetError().Success(), "Got error {0!s} getting enum value".format((enum_value.GetError().GetCString())))
+        self.assertTrue(enum_value.GetValue() == "ImportantError", "Expected 'ImportantError', got {0!s}".format((enum_value.GetValue())))
 
         object_value = self.frame.EvaluateExpression("IThrowObjectOver10(101)", options)
         self.assertTrue(object_value.IsValid(), "Got a valid object value.")
-        self.assertTrue(object_value.GetError().Success(), "Got error %s getting object value"%(object_value.GetError().GetCString()))
+        self.assertTrue(object_value.GetError().Success(), "Got error {0!s} getting object value".format((object_value.GetError().GetCString())))
 
         message = object_value.GetChildMemberWithName("m_message")
         self.assertTrue(message.IsValid(), "Found some m_message child.")
         self.assertTrue(message.GetError().Success(), "No errors fetching m_message value")
-        self.assertTrue(message.GetSummary() == '"Over 100"', "Expected 'Over 100', got %s"%(message.GetSummary()))
+        self.assertTrue(message.GetSummary() == '"Over 100"', "Expected 'Over 100', got {0!s}".format((message.GetSummary())))
 
 if __name__ == '__main__':
     import atexit

--- a/packages/Python/lldbsuite/test/lang/swift/expression/generic/TestSwiftGenericExpressions.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/generic/TestSwiftGenericExpressions.py
@@ -53,7 +53,7 @@ class TestSwiftGenericExpressions(lldbtest.TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "Use summary: %d %s expected: %s got: %s" % (
+        report_str = "Use summary: {0:d} {1!s} expected: {2!s} got: {3!s}".format(
             use_summary, expression, expected_result, answer)
         self.assertTrue(answer == expected_result, report_str)
 

--- a/packages/Python/lldbsuite/test/lang/swift/expression/scopes/TestExpressionScopes.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/scopes/TestExpressionScopes.py
@@ -41,7 +41,7 @@ class TestSwiftExpressionScopes(TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "%s expected: %s got: %s"%(expression, expected_result, answer)
+        report_str = "{0!s} expected: {1!s} got: {2!s}".format(expression, expected_result, answer)
         if answer != expected_result :
             print report_str
             print value.GetError()

--- a/packages/Python/lldbsuite/test/lang/swift/expression/simple/TestSimpleExpressions.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/simple/TestSimpleExpressions.py
@@ -44,7 +44,7 @@ class TestSimpleSwiftExpressions(TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "%s expected: %s got: %s"%(expression, expected_result, answer)
+        report_str = "{0!s} expected: {1!s} got: {2!s}".format(expression, expected_result, answer)
         self.assertTrue(answer == expected_result, report_str)
 
     def do_test(self):

--- a/packages/Python/lldbsuite/test/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/static/TestSwiftExpressionsInClassFunctions.py
@@ -41,7 +41,7 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "%s expected: %s got: %s"%(expression, expected_result, answer)
+        report_str = "{0!s} expected: {1!s} got: {2!s}".format(expression, expected_result, answer)
         self.assertTrue(answer == expected_result, report_str)
 
     def do_test(self):
@@ -58,7 +58,7 @@ class TestSwiftExpressionsInClassFunctions(TestBase):
         # Set the breakpoints
         for i in range(1,8):
             breakpoints.append(target.BreakpointCreateBySourceRegex("breakpoint " + str(i), self.main_source_spec))
-            self.assertTrue(breakpoints[i].GetNumLocations() > 0, "Didn't get valid breakpoint for %s"%(str(i)))
+            self.assertTrue(breakpoints[i].GetNumLocations() > 0, "Didn't get valid breakpoint for {0!s}".format((str(i))))
 
         # Launch the process, and do not stop at the entry point.
         process = target.LaunchSimple(None, None, os.getcwd())

--- a/packages/Python/lldbsuite/test/lang/swift/expression/submodule_import/TestSubmoduleImport.py
+++ b/packages/Python/lldbsuite/test/lang/swift/expression/submodule_import/TestSubmoduleImport.py
@@ -78,7 +78,7 @@ class TestSwiftSubmoduleImport(TestBase):
         # Now make sure we can explicitly do the import:
         value = self.frame.EvaluateExpression ('import Darwin.C\n b', options)
         self.assertTrue(value.IsValid(), "Got a valid value back from import Darwin.C")
-        self.assertTrue(value.GetError().Success(), "The import was not successful: %s"%(value.GetError().GetCString()))
+        self.assertTrue(value.GetError().Success(), "The import was not successful: {0!s}".format((value.GetError().GetCString())))
 
 if __name__ == '__main__':
     import atexit

--- a/packages/Python/lldbsuite/test/lang/swift/file_private/TestFilePrivate.py
+++ b/packages/Python/lldbsuite/test/lang/swift/file_private/TestFilePrivate.py
@@ -39,7 +39,7 @@ class TestFilePrivate(TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "%s expected: %s got: %s"%(expression, expected_result, answer)
+        report_str = "{0!s} expected: {1!s} got: {2!s}".format(expression, expected_result, answer)
         self.assertTrue(answer == expected_result, report_str)
 
     @swiftTest

--- a/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
+++ b/packages/Python/lldbsuite/test/lang/swift/return/TestSwiftReturns.py
@@ -50,15 +50,15 @@ class TestSwiftReturns(TestBase):
         Returns an error string describing what parts of "a" and "b" didn't match
         or returns None for a successful compare'''
         if compare_name and a.name != b.name:
-            return 'error: name mismatch "%s" != "%s"' % (a.name, b.name)
+            return 'error: name mismatch "{0!s}" != "{1!s}"'.format(a.name, b.name)
         if a.type.name != b.type.name:
-            return 'error: typename mismatch "%s" != "%s"' % (a.type.name, b.type.name)
+            return 'error: typename mismatch "{0!s}" != "{1!s}"'.format(a.type.name, b.type.name)
         if a.value != b.value:
-            return 'error: value string mismatch "%s" != "%s"' % (a.value, b.value)
+            return 'error: value string mismatch "{0!s}" != "{1!s}"'.format(a.value, b.value)
         if a.summary != b.summary:
-            return 'error: summary mismatch "%s" != "%s"' % (a.summary, b.summary)
+            return 'error: summary mismatch "{0!s}" != "{1!s}"'.format(a.summary, b.summary)
         if a.num_children != b.num_children:
-            return 'error: num_children mismatch %i != %i' % (a.num_children, b.num_children)
+            return 'error: num_children mismatch {0:d} != {1:d}'.format(a.num_children, b.num_children)
         for i in range(a.num_children):
             a_child = a.GetChildAtIndex (i, lldb.eNoDynamicValues, False)
             b_child = b.GetChildAtIndex (i, lldb.eNoDynamicValues, False)
@@ -77,8 +77,8 @@ class TestSwiftReturns(TestBase):
         err = self.compare_value(return_value, variable, False)
         if err:
             if self.TraceOn():
-                print 'return value: %s' % (return_value)
-                print '    variable: %s' % (variable)
+                print 'return value: {0!s}'.format((return_value))
+                print '    variable: {0!s}'.format((variable))
             self.assertTrue(False, err)
 
     def do_test(self):

--- a/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
+++ b/packages/Python/lldbsuite/test/lang/swift/stepping/TestSwiftStepping.py
@@ -67,7 +67,7 @@ class TestSwiftStepping(lldbtest.TestBase):
         name = thread.frames[0].GetFunctionName()
         self.assertTrue(
             pattern in name,
-            "Got to '%s' not the expected function '%s'." % (name, pattern))
+            "Got to '{0!s}' not the expected function '{1!s}'.".format(name, pattern))
 
     def do_test(self):
         """Tests that we can step reliably in swift code."""

--- a/packages/Python/lldbsuite/test/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/dictionary/TestSwiftStdlibDictionary.py
@@ -77,9 +77,9 @@ class TestSwiftStdlibDictionary(TestBase):
             value_str = str(value_summary)
 
         if fail_on_missing:
-            self.assertTrue(found, ("could not find an expected child for '%s':'%s'" % (key_str,value_str)))
+            self.assertTrue(found, ("could not find an expected child for '{0!s}':'{1!s}'".format(key_str, value_str)))
         else:
-            self.assertFalse(found, ("found a not expected child for '%s':'%s'" % (key_str,value_str)))
+            self.assertFalse(found, ("found a not expected child for '{0!s}':'{1!s}'".format(key_str, value_str)))
 
     def do_test(self):
         """Tests that we properly vend synthetic children for Swift.Dictionary"""
@@ -118,7 +118,7 @@ class TestSwiftStdlibDictionary(TestBase):
         self.runCmd('type summary add a.Wrapper -s ${var.value%S}')
 
         for i in range(0,100):
-            self.find_dictionary_entry(self.get_variable("d"), key_value = str(i), value_summary = '"%s"' % (i * 2 + 1))
+            self.find_dictionary_entry(self.get_variable("d"), key_value = str(i), value_summary = '"{0!s}"'.format((i * 2 + 1)))
         
         self.runCmd('expression d.removeValueForKey(34)')
         self.find_dictionary_entry(self.get_variable("d"), key_value = 34, value_summary = '"43"', fail_on_missing=False)

--- a/packages/Python/lldbsuite/test/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/indirect_enums/TestIndirectEnumVariables.py
@@ -42,9 +42,9 @@ class TestIndirectEnumVariables(TestBase):
 
     def check_enum(self, enum, value=None, summary=None, child_path=None, child_value=None, child_summary=None):
         if value:
-            self.assertTrue(enum.GetValue() == value, "%s.GetValue() == %s" % (enum.GetName(), value))
+            self.assertTrue(enum.GetValue() == value, "{0!s}.GetValue() == {1!s}".format(enum.GetName(), value))
         if summary:
-            self.assertTrue(enum.GetSummary() == summary, "%s.GetSummary() == %s" % (enum.GetName(), summary))
+            self.assertTrue(enum.GetSummary() == summary, "{0!s}.GetSummary() == {1!s}".format(enum.GetName(), summary))
 
         if child_path:
             child = enum
@@ -52,11 +52,11 @@ class TestIndirectEnumVariables(TestBase):
                 child = child.GetChildAtIndex(child_index)
                 child.SetPreferDynamicValue(lldb.eDynamicCanRunTarget)
                 child.SetPreferSyntheticValue(True)
-            self.assertTrue(child.IsValid(), "child at path %s valid" % (child_path))
+            self.assertTrue(child.IsValid(), "child at path {0!s} valid".format((child_path)))
             if child_value:
-                self.assertTrue(child.GetValue() == child_value, "%s.GetValue() == %s" % (child.GetName(), child_value))
+                self.assertTrue(child.GetValue() == child_value, "{0!s}.GetValue() == {1!s}".format(child.GetName(), child_value))
             if child_summary:
-                self.assertTrue(child.GetSummary() == child_summary, "%s.GetSummary() == %s" % (child.GetName(), child_summary))
+                self.assertTrue(child.GetSummary() == child_summary, "{0!s}.GetSummary() == {1!s}".format(child.GetName(), child_summary))
 
 
     def do_test(self):

--- a/packages/Python/lldbsuite/test/lang/swift/variables/inout/TestInOutVariables.py
+++ b/packages/Python/lldbsuite/test/lang/swift/variables/inout/TestInOutVariables.py
@@ -39,24 +39,24 @@ class TestInOutVariables(TestBase):
             # At present the expression parser strips off the @lvalue bit:
             message_end = "from EvaluateExpression"
             x_actual = self.frame.EvaluateExpression ("x",lldb.eDynamicCanRunTarget)
-            self.assertTrue(x_actual.GetError().Success(), "Expression evaluation failed: %s"%(x_actual.GetError().GetCString()))
+            self.assertTrue(x_actual.GetError().Success(), "Expression evaluation failed: {0!s}".format((x_actual.GetError().GetCString())))
         else:
             message_end = "from FindVariable"
             x = self.frame.FindVariable("x").GetDynamicValue(lldb.eDynamicCanRunTarget)
-            self.assertTrue(x.IsValid(), "did not find x %s"%(message_end))
+            self.assertTrue(x.IsValid(), "did not find x {0!s}".format((message_end)))
             if is_wrapped:
-                self.assertTrue(x.GetNumChildren() == 1, "x has too many children %s"%(message_end))
+                self.assertTrue(x.GetNumChildren() == 1, "x has too many children {0!s}".format((message_end)))
                 x_actual = x.GetChildAtIndex(0).GetDynamicValue(lldb.eDynamicCanRunTarget)
-                self.assertTrue(x_actual.IsValid(),"did not find the child of x %s"%(message_end))
+                self.assertTrue(x_actual.IsValid(),"did not find the child of x {0!s}".format((message_end)))
             else:
                 x_actual = x
 
         ivar = x_actual.GetChildAtIndex(0).GetChildAtIndex(0)
         ovar = x_actual.GetChildAtIndex(1)
-        self.assertTrue(ivar.GetName() == "ivar", "Name: %s is not ivar %s"%(ivar.GetName(), message_end))
-        self.assertTrue(ovar.GetName() == "ovar", "ovar is not ovar %s"%(message_end))
-        self.assertTrue(ivar.GetValue() == ivar_value, "ivar wrong %s"%(message_end))
-        self.assertTrue(ovar.GetValue() == ovar_value, "ovar wrong %s"%(message_end))
+        self.assertTrue(ivar.GetName() == "ivar", "Name: {0!s} is not ivar {1!s}".format(ivar.GetName(), message_end))
+        self.assertTrue(ovar.GetName() == "ovar", "ovar is not ovar {0!s}".format((message_end)))
+        self.assertTrue(ivar.GetValue() == ivar_value, "ivar wrong {0!s}".format((message_end)))
+        self.assertTrue(ovar.GetValue() == ovar_value, "ovar wrong {0!s}".format((message_end)))
 
     def check_class (self, ivar_value, ovar_value, is_wrapped = True):
         self.check_class_internal (ivar_value, ovar_value, True, is_wrapped)
@@ -70,12 +70,12 @@ class TestInOutVariables(TestBase):
             x = self.frame.FindVariable("x").GetDynamicValue(lldb.eDynamicCanRunTarget)
             message_end = "from FindVariable"
 
-        self.assertTrue(x.IsValid(), "did not find x %s"%(message_end))
-        self.assertTrue(x.GetNumChildren() == 1, "x has too many children %s"%(message_end))
+        self.assertTrue(x.IsValid(), "did not find x {0!s}".format((message_end)))
+        self.assertTrue(x.GetNumChildren() == 1, "x has too many children {0!s}".format((message_end)))
         ivar = x.GetChildAtIndex(0)
         if not use_expression: ivar = ivar.GetChildAtIndex(0)
-        self.assertTrue(ivar.GetName() == "ivar", "ivar is not ivar %s"%(message_end))
-        self.assertTrue(ivar.GetValue() == ivar_value, "ivar wrong %s"%(message_end))
+        self.assertTrue(ivar.GetName() == "ivar", "ivar is not ivar {0!s}".format((message_end)))
+        self.assertTrue(ivar.GetValue() == ivar_value, "ivar wrong {0!s}".format((message_end)))
 
     def check_struct (self, ivar_value):
         self.check_struct_internal(ivar_value, True)

--- a/packages/Python/lldbsuite/test/lldbbench.py
+++ b/packages/Python/lldbsuite/test/lldbbench.py
@@ -96,7 +96,7 @@ class Stopwatch(object):
     #    return numpy.std(self.__nums__)
 
     def __str__(self):
-        return "Avg: %f (Laps: %d, Total Elapsed Time: %f, min=%f, max=%f)" % (self.avg(),
+        return "Avg: {0:f} (Laps: {1:d}, Total Elapsed Time: {2:f}, min={3:f}, max={4:f})".format(self.avg(),
                                                                                self.__laps__,
                                                                                self.__total_elapsed__,
                                                                                min(self.__nums__),

--- a/packages/Python/lldbsuite/test/lldbcurses.py
+++ b/packages/Python/lldbsuite/test/lldbcurses.py
@@ -20,7 +20,7 @@ class Point(object):
         return str(self)
 
     def __str__(self):
-        return "(x=%u, y=%u)" % (self.x, self.y)
+        return "(x={0:d}, y={1:d})".format(self.x, self.y)
 
     def __eq__(self, rhs):
         return self.x == rhs.x and self.y == rhs.y
@@ -40,7 +40,7 @@ class Size(object):
         return str(self)
 
     def __str__(self):
-        return "(w=%u, h=%u)" % (self.w, self.h)
+        return "(w={0:d}, h={1:d})".format(self.w, self.h)
 
     def __eq__(self, rhs):
         return self.w == rhs.w and self.h == rhs.h
@@ -57,7 +57,7 @@ class Rect(object):
         return str(self)
 
     def __str__(self):
-        return "{ %s, %s }" % (str(self.origin), str(self.size))
+        return "{{ {0!s}, {1!s} }}".format(str(self.origin), str(self.size))
 
     def get_min_x(self):
         return self.origin.x
@@ -1117,7 +1117,7 @@ class StatusPanel(Panel):
     def update(self):
         self.erase();
         for status_item_dict in self.status_items:
-            self.addnstr_at_point(Point(x=status_item_dict['x'], y=0), '%s: %s' % (status_item_dict['title'], status_item_dict['value']), status_item_dict['width'])
+            self.addnstr_at_point(Point(x=status_item_dict['x'], y=0), '{0!s}: {1!s}'.format(status_item_dict['title'], status_item_dict['value']), status_item_dict['width'])
 
 stdscr = None
 

--- a/packages/Python/lldbsuite/test/lldbinline.py
+++ b/packages/Python/lldbsuite/test/lldbinline.py
@@ -86,9 +86,9 @@ class InlineTest(TestBase):
             # The test was skipped altogether.
             return ""
         elif self.using_dsym:
-            return "-N dwarf %s" % (self.mydir)
+            return "-N dwarf {0!s}".format((self.mydir))
         else:
-            return "-N dsym %s" % (self.mydir)
+            return "-N dsym {0!s}".format((self.mydir))
 
     def BuildMakefile(self):
         if os.path.exists("Makefile"):
@@ -178,7 +178,7 @@ class InlineTest(TestBase):
             answer = value.GetSummary()
         else:
             answer = value.GetValue()
-        report_str = "%s expected: %s got: %s"%(expression, expected_result, answer)
+        report_str = "{0!s} expected: {1!s} got: {2!s}".format(expression, expected_result, answer)
         self.assertTrue(answer == expected_result, report_str)
 
 def ApplyDecoratorsToFunction(func, decorators):

--- a/packages/Python/lldbsuite/test/lldbpexpect.py
+++ b/packages/Python/lldbsuite/test/lldbpexpect.py
@@ -31,7 +31,7 @@ class PExpectTest(TestBase):
     def launch(self, timeout=None):
         if timeout is None: timeout = 30
         logfile = sys.stdout if self.TraceOn() else None
-        self.child = pexpect.spawn('%s %s' % (lldbtest_config.lldbExec, self.launchArgs()), logfile=logfile)
+        self.child = pexpect.spawn('{0!s} {1!s}'.format(lldbtest_config.lldbExec, self.launchArgs()), logfile=logfile)
         self.child.timeout = timeout
         self.timeout = timeout
 

--- a/packages/Python/lldbsuite/test/lldbplatformutil.py
+++ b/packages/Python/lldbsuite/test/lldbplatformutil.py
@@ -24,4 +24,4 @@ def check_first_register_readable(test_case):
         test_case.expect("register read zero", substrs = ['zero = 0x'])
     else:
         # TODO: Add check for other architectures
-        test_case.fail("Unsupported architecture for test case (arch: %s)" % test_case.getArchitecture())
+        test_case.fail("Unsupported architecture for test case (arch: {0!s})".format(test_case.getArchitecture()))

--- a/packages/Python/lldbsuite/test/lldbrepl.py
+++ b/packages/Python/lldbsuite/test/lldbrepl.py
@@ -51,7 +51,7 @@ class REPLTest(PExpectTest):
         PExpectTest.setUp(self)
 
     def launchArgs(self):
-        return '-x "--repl=-enable-objc-interop -sdk %s -color-diagnostics"' % (swift.getSwiftSDKRoot())
+        return '-x "--repl=-enable-objc-interop -sdk {0!s} -color-diagnostics"'.format((swift.getSwiftSDKRoot()))
 
     # run a REPL command and wait for the prompt
     def command(self, command, patterns=None, timeout=None, exact=None, prompt_sync=True):

--- a/packages/Python/lldbsuite/test/lldbtest.py
+++ b/packages/Python/lldbsuite/test/lldbtest.py
@@ -139,7 +139,7 @@ STOPPED_DUE_TO_ASSERT = "Process should be stopped due to an assertion"
 
 STOPPED_DUE_TO_BREAKPOINT = "Process should be stopped due to breakpoint"
 
-STOPPED_DUE_TO_BREAKPOINT_WITH_STOP_REASON_AS = "%s, %s" % (
+STOPPED_DUE_TO_BREAKPOINT_WITH_STOP_REASON_AS = "{0!s}, {1!s}".format(
     STOPPED_DUE_TO_BREAKPOINT, "instead, the actual stop reason is: '%s'")
 
 STOPPED_DUE_TO_BREAKPOINT_CONDITION = "Stopped due to breakpoint condition"
@@ -182,20 +182,20 @@ WATCHPOINT_CREATED = "Watchpoint created successfully"
 
 def CMD_MSG(str):
     '''A generic "Command '%s' returns successfully" message generator.'''
-    return "Command '%s' returns successfully" % str
+    return "Command '{0!s}' returns successfully".format(str)
 
 def COMPLETION_MSG(str_before, str_after):
     '''A generic message generator for the completion mechanism.'''
-    return "'%s' successfully completes to '%s'" % (str_before, str_after)
+    return "'{0!s}' successfully completes to '{1!s}'".format(str_before, str_after)
 
 def EXP_MSG(str, exe):
     '''A generic "'%s' returns expected result" message generator if exe.
     Otherwise, it generates "'%s' matches expected result" message.'''
-    return "'%s' %s expected result" % (str, 'returns' if exe else 'matches')
+    return "'{0!s}' {1!s} expected result".format(str, 'returns' if exe else 'matches')
 
 def SETTING_MSG(setting):
     '''A generic "Value of setting '%s' is correct" message generator.'''
-    return "Value of setting '%s' is correct" % setting
+    return "Value of setting '{0!s}' is correct".format(setting)
 
 def EnvArray():
     """Returns an env variable array from the os.environ map object."""
@@ -208,7 +208,7 @@ def line_number(filename, string_to_match):
             if line.find(string_to_match) != -1:
                 # Found our match.
                 return i+1
-    raise Exception("Unable to find '%s' within file %s" % (string_to_match, filename))
+    raise Exception("Unable to find '{0!s}' within file {1!s}".format(string_to_match, filename))
 
 def pointer_size():
     """Return the pointer size of the host system."""
@@ -337,7 +337,7 @@ class _RemoteProcess(_BaseProcess):
             dst_file_spec = lldb.SBFileSpec(dst_path, False)
             err = lldb.remote_platform.Install(lldb.SBFileSpec(src_path, True), dst_file_spec)
             if err.Fail():
-                raise Exception("remote_platform.Install('%s', '%s') failed: %s" % (src_path, dst_path, err))
+                raise Exception("remote_platform.Install('{0!s}', '{1!s}') failed: {2!s}".format(src_path, dst_path, err))
         else:
             dst_path = executable
             dst_file_spec = lldb.SBFileSpec(executable, False)
@@ -352,7 +352,7 @@ class _RemoteProcess(_BaseProcess):
 
         err = lldb.remote_platform.Launch(launch_info)
         if err.Fail():
-            raise Exception("remote_platform.Launch('%s', '%s') failed: %s" % (dst_path, args, err))
+            raise Exception("remote_platform.Launch('{0!s}', '{1!s}') failed: {2!s}".format(dst_path, args, err))
         self._pid = launch_info.GetProcessID()
 
     def terminate(self):
@@ -862,7 +862,7 @@ def skipUnlessListedRemote(remote_list=None):
                     if r in triple:
                         func(*args, **kwargs)
                         return
-                self.skipTest("skip on remote platform %s" % str(triple))
+                self.skipTest("skip on remote platform {0!s}".format(str(triple)))
             else:
                 func(*args, **kwargs)
         return wrapper
@@ -1024,9 +1024,9 @@ def skipIfHostIncompatibleWithRemote(func):
         target_arch = self.getArchitecture()
         target_platform = 'darwin' if self.platformIsDarwin() else self.getPlatform()
         if not (target_arch == 'x86_64' and host_arch == 'i386') and host_arch != target_arch:
-            self.skipTest("skipping because target %s is not compatible with host architecture %s" % (target_arch, host_arch))
+            self.skipTest("skipping because target {0!s} is not compatible with host architecture {1!s}".format(target_arch, host_arch))
         elif target_platform != host_platform:
-            self.skipTest("skipping because target is %s but host is %s" % (target_platform, host_platform))
+            self.skipTest("skipping because target is {0!s} but host is {1!s}".format(target_platform, host_platform))
         else:
             func(*args, **kwargs)
     return wrapper
@@ -1034,12 +1034,12 @@ def skipIfHostIncompatibleWithRemote(func):
 def skipIfHostPlatform(oslist):
     """Decorate the item to skip tests if running on one of the listed host platforms."""
     return unittest2.skipIf(getHostPlatform() in oslist,
-                            "skip on %s" % (", ".join(oslist)))
+                            "skip on {0!s}".format((", ".join(oslist))))
 
 def skipUnlessHostPlatform(oslist):
     """Decorate the item to skip tests unless running on one of the listed host platforms."""
     return unittest2.skipUnless(getHostPlatform() in oslist,
-                                "requires on of %s" % (", ".join(oslist)))
+                                "requires on of {0!s}".format((", ".join(oslist))))
 
 def skipUnlessArch(archlist):
     """Decorate the item to skip tests unless running on one of the listed architectures."""
@@ -1051,8 +1051,7 @@ def skipUnlessArch(archlist):
         def wrapper(*args, **kwargs):
             self = args[0]
             if self.getArchitecture() not in archlist:
-                self.skipTest("skipping for architecture %s (requires one of %s)" % 
-                    (self.getArchitecture(), ", ".join(archlist)))
+                self.skipTest("skipping for architecture {0!s} (requires one of {1!s})".format(self.getArchitecture(), ", ".join(archlist)))
             else:
                 func(*args, **kwargs)
         return wrapper
@@ -1062,12 +1061,12 @@ def skipUnlessArch(archlist):
 def skipIfPlatform(oslist):
     """Decorate the item to skip tests if running on one of the listed platforms."""
     return unittest2.skipIf(getPlatform() in oslist,
-                            "skip on %s" % (", ".join(oslist)))
+                            "skip on {0!s}".format((", ".join(oslist))))
 
 def skipUnlessPlatform(oslist):
     """Decorate the item to skip tests unless running on one of the listed platforms."""
     return unittest2.skipUnless(getPlatform() in oslist,
-                                "requires on of %s" % (", ".join(oslist)))
+                                "requires on of {0!s}".format((", ".join(oslist))))
 
 def skipIfLinuxClang(func):
     """Decorate the item to skip tests that should be skipped if building on 
@@ -1117,7 +1116,7 @@ def skipIf(bugnumber=None, oslist=None, compiler=None, compiler_version=None, ar
     args = [x for x in inspect.getargspec(skipIf).args]
     arg_vals = [eval(x, globals(), local_vars) for x in args]
     args = [x for x in zip(args, arg_vals) if x[1] is not None]
-    reasons = ['%s=%s' % (x, str(y)) for (x,y) in args]
+    reasons = ['{0!s}={1!s}'.format(x, str(y)) for (x,y) in args]
     return skipTestIfFn(fn, bugnumber, skipReason='skipping because ' + ' && '.join(reasons))
 
 def skipIfDebugInfo(bugnumber=None, debug_info=None):
@@ -1210,8 +1209,7 @@ def skipIfTargetAndroid(api_levels=None, archs=None):
             from unittest2 import case
             self = args[0]
             if matchAndroid(api_levels, archs)(self):
-                self.skipTest("skiped on Android target with API %d and architecture %s" %
-                        (android_device_api(), self.getArchitecture()))
+                self.skipTest("skiped on Android target with API {0:d} and architecture {1!s}".format(android_device_api(), self.getArchitecture()))
             func(*args, **kwargs)
         return wrapper
     return myImpl
@@ -1760,7 +1758,7 @@ class Base(unittest2.TestCase):
                 print("unexpected success (problem id:" + str(bugnumber) + ")", file=sbuf)
 
     def getRerunArgs(self):
-        return " -f %s.%s" % (self.__class__.__name__, self._testMethodName)
+        return " -f {0!s}.{1!s}".format(self.__class__.__name__, self._testMethodName)
 
     def getLogBasenameForCurrentTest(self, prefix=None):
         """
@@ -1847,7 +1845,7 @@ class Base(unittest2.TestCase):
         import datetime
         print("Session info generated @", datetime.datetime.now().ctime(), file=self.session)
         print("To rerun this test, issue the following command from the 'test' directory:\n", file=self.session)
-        print("./dotest.py %s -v %s %s" % (self.getRunOptions(),
+        print("./dotest.py {0!s} -v {1!s} {2!s}".format(self.getRunOptions(),
                                                  ('+b' if benchmarks else '-t'),
                                                  self.getRerunArgs()), file=self.session)
         self.session.close()
@@ -2029,7 +2027,7 @@ class Base(unittest2.TestCase):
         if comp:
             option_str += " -C " + comp
         if lldb.remote_platform:
-            option_str += ' --platform-name=%s' % (lldb.remote_platform_name)
+            option_str += ' --platform-name={0!s}'.format((lldb.remote_platform_name))
         return option_str
 
     # ==================================================
@@ -2065,22 +2063,22 @@ class Base(unittest2.TestCase):
             dsym = os.path.join(lib_dir, 'LLDB.framework', 'LLDB')
             d = {'CXX_SOURCES' : sources,
                  'EXE' : exe_name,
-                 'CFLAGS_EXTRAS' : "%s %s" % (stdflag, stdlibflag),
-                 'FRAMEWORK_INCLUDES' : "-F%s" % lib_dir,
-                 'LD_EXTRAS' : "%s -Wl,-rpath,%s" % (dsym, lib_dir),
+                 'CFLAGS_EXTRAS' : "{0!s} {1!s}".format(stdflag, stdlibflag),
+                 'FRAMEWORK_INCLUDES' : "-F{0!s}".format(lib_dir),
+                 'LD_EXTRAS' : "{0!s} -Wl,-rpath,{1!s}".format(dsym, lib_dir),
                 }
         elif sys.platform.rstrip('0123456789') in ('freebsd', 'linux', 'netbsd') or os.environ.get('LLDB_BUILD_TYPE') == 'Makefile':
             d = {'CXX_SOURCES' : sources,
                  'EXE' : exe_name,
-                 'CFLAGS_EXTRAS' : "%s %s -I%s" % (stdflag, stdlibflag, os.path.join(os.environ["LLDB_SRC"], "include")),
-                 'LD_EXTRAS' : "-L%s -llldb" % lib_dir}
+                 'CFLAGS_EXTRAS' : "{0!s} {1!s} -I{2!s}".format(stdflag, stdlibflag, os.path.join(os.environ["LLDB_SRC"], "include")),
+                 'LD_EXTRAS' : "-L{0!s} -llldb".format(lib_dir)}
         elif sys.platform.startswith('win'):
             d = {'CXX_SOURCES' : sources,
                  'EXE' : exe_name,
-                 'CFLAGS_EXTRAS' : "%s %s -I%s" % (stdflag, stdlibflag, os.path.join(os.environ["LLDB_SRC"], "include")),
-                 'LD_EXTRAS' : "-L%s -lliblldb" % os.environ["LLDB_IMPLIB_DIR"]}
+                 'CFLAGS_EXTRAS' : "{0!s} {1!s} -I{2!s}".format(stdflag, stdlibflag, os.path.join(os.environ["LLDB_SRC"], "include")),
+                 'LD_EXTRAS' : "-L{0!s} -lliblldb".format(os.environ["LLDB_IMPLIB_DIR"])}
         if self.TraceOn():
-            print("Building LLDB Driver (%s) from sources %s" % (exe_name, sources))
+            print("Building LLDB Driver ({0!s}) from sources {1!s}".format(exe_name, sources))
 
         self.buildDefault(dictionary=d)
 
@@ -2094,22 +2092,22 @@ class Base(unittest2.TestCase):
             dsym = os.path.join(lib_dir, 'LLDB.framework', 'LLDB')
             d = {'DYLIB_CXX_SOURCES' : sources,
                  'DYLIB_NAME' : lib_name,
-                 'CFLAGS_EXTRAS' : "%s -stdlib=libc++" % stdflag,
-                 'FRAMEWORK_INCLUDES' : "-F%s" % lib_dir,
-                 'LD_EXTRAS' : "%s -Wl,-rpath,%s -dynamiclib" % (dsym, lib_dir),
+                 'CFLAGS_EXTRAS' : "{0!s} -stdlib=libc++".format(stdflag),
+                 'FRAMEWORK_INCLUDES' : "-F{0!s}".format(lib_dir),
+                 'LD_EXTRAS' : "{0!s} -Wl,-rpath,{1!s} -dynamiclib".format(dsym, lib_dir),
                 }
         elif self.getPlatform() in ('freebsd', 'linux', 'netbsd') or os.environ.get('LLDB_BUILD_TYPE') == 'Makefile':
             d = {'DYLIB_CXX_SOURCES' : sources,
                  'DYLIB_NAME' : lib_name,
-                 'CFLAGS_EXTRAS' : "%s -I%s -fPIC" % (stdflag, os.path.join(os.environ["LLDB_SRC"], "include")),
-                 'LD_EXTRAS' : "-shared -L%s -llldb" % lib_dir}
+                 'CFLAGS_EXTRAS' : "{0!s} -I{1!s} -fPIC".format(stdflag, os.path.join(os.environ["LLDB_SRC"], "include")),
+                 'LD_EXTRAS' : "-shared -L{0!s} -llldb".format(lib_dir)}
         elif self.getPlatform() == 'windows':
             d = {'DYLIB_CXX_SOURCES' : sources,
                  'DYLIB_NAME' : lib_name,
-                 'CFLAGS_EXTRAS' : "%s -I%s -fPIC" % (stdflag, os.path.join(os.environ["LLDB_SRC"], "include")),
-                 'LD_EXTRAS' : "-shared -l%s\liblldb.lib" % self.os.environ["LLDB_IMPLIB_DIR"]}
+                 'CFLAGS_EXTRAS' : "{0!s} -I{1!s} -fPIC".format(stdflag, os.path.join(os.environ["LLDB_SRC"], "include")),
+                 'LD_EXTRAS' : "-shared -l{0!s}\liblldb.lib".format(self.os.environ["LLDB_IMPLIB_DIR"])}
         if self.TraceOn():
-            print("Building LLDB Library (%s) from sources %s" % (lib_name, sources))
+            print("Building LLDB Library ({0!s}) from sources {1!s}".format(lib_name, sources))
 
         self.buildDefault(dictionary=d)
     
@@ -2156,7 +2154,7 @@ class Base(unittest2.TestCase):
 
     def signBinary(self, binary_path):
         if sys.platform.startswith("darwin"):
-            codesign_cmd = "codesign --force --sign lldb_codesign %s" % (binary_path)
+            codesign_cmd = "codesign --force --sign lldb_codesign {0!s}".format((binary_path))
             call(codesign_cmd, shell=True)
 
     def findBuiltClang(self):
@@ -2201,7 +2199,7 @@ class Base(unittest2.TestCase):
                 libcxxInclude = os.path.join(self.libcxxPath, "include")
                 libcxxLib = os.path.join(self.libcxxPath, "lib")
                 if os.path.isdir(libcxxInclude) and os.path.isdir(libcxxLib):
-                    cflags += "-nostdinc++ -I%s -L%s -Wl,-rpath,%s " % (libcxxInclude, libcxxLib, libcxxLib)
+                    cflags += "-nostdinc++ -I{0!s} -L{1!s} -Wl,-rpath,{2!s} ".format(libcxxInclude, libcxxLib, libcxxLib)
 
         if use_cpp11:
             cflags += "-std="
@@ -2235,7 +2233,7 @@ class Base(unittest2.TestCase):
         existing_library_path = os.environ[self.dylibPath] if self.dylibPath in os.environ else None
         lib_dir = os.environ["LLDB_LIB_DIR"]
         if existing_library_path:
-            return "%s:%s" % (existing_library_path, lib_dir)
+            return "{0!s}:{1!s}".format(existing_library_path, lib_dir)
         elif sys.platform.startswith("darwin"):
             return os.path.join(lib_dir, 'LLDB.framework')
         else:
@@ -2428,11 +2426,11 @@ class TestBase(Base):
                     # TODO: Make it working on Windows when we need it for remote debugging support
                     # TODO: Replace the heuristic to remove the files with a logic what collects the
                     # list of files we have to remove during test runs.
-                    shell_cmd = lldb.SBPlatformShellCommand("rm %s/*" % remote_test_dir)
+                    shell_cmd = lldb.SBPlatformShellCommand("rm {0!s}/*".format(remote_test_dir))
                     lldb.remote_platform.Run(shell_cmd)
                 self.addTearDownHook(clean_working_directory)
             else:
-                print("error: making remote directory '%s': %s" % (remote_test_dir, error))
+                print("error: making remote directory '{0!s}': {1!s}".format(remote_test_dir, error))
     
     def registerSharedLibrariesWithTarget(self, target, shlibs):
         '''If we are remotely running the test suite, register the shared libraries with the target so they get uploaded, otherwise do nothing
@@ -2450,7 +2448,7 @@ class TestBase(Base):
         shlib_extension = '.' + self.platformContext.shlib_extension
 
         working_dir = self.get_process_working_directory()
-        environment = ['%s=%s' % (shlib_environment_var, working_dir)]
+        environment = ['{0!s}={1!s}'.format(shlib_environment_var, working_dir)]
         # Add any shared libraries to our target if remote so they get
         # uploaded into the working directory on the remote side
         for name in shlibs:
@@ -2550,12 +2548,12 @@ class TestBase(Base):
         from .lldbutil import stop_reason_to_str
         self.runCmd('thread list')
         output = self.res.GetOutput()
-        thread_line_pattern = re.compile("^[ *] thread #([0-9]+):.*stop reason = %s" %
-                                         stop_reason_to_str(stop_reason))
+        thread_line_pattern = re.compile("^[ *] thread #([0-9]+):.*stop reason = {0!s}".format(
+                                         stop_reason_to_str(stop_reason)))
         for line in output.splitlines():
             matched = thread_line_pattern.match(line)
             if matched:
-                self.runCmd('thread select %s' % matched.group(1))
+                self.runCmd('thread select {0!s}'.format(matched.group(1)))
 
     def runCmd(self, cmd, msg=None, check=True, trace=False, inHistory=False):
         """
@@ -2631,7 +2629,7 @@ class TestBase(Base):
             match_object = re.search(pattern, output)
             matched = bool(match_object)
             with recording(self, trace) as sbuf:
-                print("%s pattern: %s" % (heading, pattern), file=sbuf)
+                print("{0!s} pattern: {1!s}".format(heading, pattern), file=sbuf)
                 print("Matched" if matched else "Not matched", file=sbuf)
             if matched:
                 break
@@ -2697,7 +2695,7 @@ class TestBase(Base):
 
         if startstr:
             with recording(self, trace) as sbuf:
-                print("%s start string: %s" % (heading, startstr), file=sbuf)
+                print("{0!s} start string: {1!s}".format(heading, startstr), file=sbuf)
                 print("Matched" if matched else "Not matched", file=sbuf)
 
         # Look for endstr, if specified.
@@ -2705,7 +2703,7 @@ class TestBase(Base):
         if endstr:
             matched = output.endswith(endstr)
             with recording(self, trace) as sbuf:
-                print("%s end string: %s" % (heading, endstr), file=sbuf)
+                print("{0!s} end string: {1!s}".format(heading, endstr), file=sbuf)
                 print("Matched" if matched else "Not matched", file=sbuf)
 
         # Look for sub strings, if specified.
@@ -2714,7 +2712,7 @@ class TestBase(Base):
             for str in substrs:
                 matched = output.find(str) != -1
                 with recording(self, trace) as sbuf:
-                    print("%s sub string: %s" % (heading, str), file=sbuf)
+                    print("{0!s} sub string: {1!s}".format(heading, str), file=sbuf)
                     print("Matched" if matched else "Not matched", file=sbuf)
                 keepgoing = matched if matching else not matched
                 if not keepgoing:
@@ -2727,7 +2725,7 @@ class TestBase(Base):
                 # Match Objects always have a boolean value of True.
                 matched = bool(re.search(pattern, output))
                 with recording(self, trace) as sbuf:
-                    print("%s pattern: %s" % (heading, pattern), file=sbuf)
+                    print("{0!s} pattern: {1!s}".format(heading, pattern), file=sbuf)
                     print("Matched" if matched else "Not matched", file=sbuf)
                 keepgoing = matched if matching else not matched
                 if not keepgoing:
@@ -2763,7 +2761,7 @@ class TestBase(Base):
         elif self.debug_info == "dwo":
             return self.buildDwo(architecture, compiler, dictionary, clean)
         else:
-            self.fail("Can't build for debug info: %s" % self.debug_info)
+            self.fail("Can't build for debug info: {0!s}".format(self.debug_info))
 
     # =================================================
     # Misc. helper methods for debugging test execution

--- a/packages/Python/lldbsuite/test/lldbutil.py
+++ b/packages/Python/lldbsuite/test/lldbutil.py
@@ -323,12 +323,12 @@ def run_break_set_by_file_and_line (test, file_name, line_number, extra_options 
     If loc_exact is true, we check that there is one location, and that location must be at the input file and line number."""
 
     if file_name == None:
-        command = 'breakpoint set -l %d'%(line_number)
+        command = 'breakpoint set -l {0:d}'.format((line_number))
     else:
-        command = 'breakpoint set -f "%s" -l %d'%(file_name, line_number)
+        command = 'breakpoint set -f "{0!s}" -l {1:d}'.format(file_name, line_number)
 
     if module_name:
-        command += " --shlib '%s'" % (module_name)
+        command += " --shlib '{0!s}'".format((module_name))
 
     if extra_options:
         command += " " + extra_options
@@ -346,10 +346,10 @@ def run_break_set_by_symbol (test, symbol, extra_options = None, num_expected_lo
     """Set a breakpoint by symbol name.  Common options are the same as run_break_set_by_file_and_line.
 
     If sym_exact is true, then the output symbol must match the input exactly, otherwise we do a substring match."""
-    command = 'breakpoint set -n "%s"'%(symbol)
+    command = 'breakpoint set -n "{0!s}"'.format((symbol))
 
     if module_name:
-        command += " --shlib '%s'" % (module_name)
+        command += " --shlib '{0!s}'".format((module_name))
 
     if extra_options:
         command += " " + extra_options
@@ -366,10 +366,10 @@ def run_break_set_by_symbol (test, symbol, extra_options = None, num_expected_lo
 def run_break_set_by_selector (test, selector, extra_options = None, num_expected_locations = -1, module_name=None):
     """Set a breakpoint by selector.  Common options are the same as run_break_set_by_file_and_line."""
 
-    command = 'breakpoint set -S "%s"' % (selector)
+    command = 'breakpoint set -S "{0!s}"'.format((selector))
 
     if module_name:
-        command += ' --shlib "%s"' % (module_name)
+        command += ' --shlib "{0!s}"'.format((module_name))
 
     if extra_options:
         command += " " + extra_options
@@ -386,7 +386,7 @@ def run_break_set_by_selector (test, selector, extra_options = None, num_expecte
 def run_break_set_by_regexp (test, regexp, extra_options=None, num_expected_locations=-1):
     """Set a breakpoint by regular expression match on symbol name.  Common options are the same as run_break_set_by_file_and_line."""
 
-    command = 'breakpoint set -r "%s"'%(regexp)
+    command = 'breakpoint set -r "{0!s}"'.format((regexp))
     if extra_options:
         command += " " + extra_options
     
@@ -398,7 +398,7 @@ def run_break_set_by_regexp (test, regexp, extra_options=None, num_expected_loca
 
 def run_break_set_by_source_regexp (test, regexp, extra_options=None, num_expected_locations=-1):
     """Set a breakpoint by source regular expression.  Common options are the same as run_break_set_by_file_and_line."""
-    command = 'breakpoint set -p "%s"'%(regexp)
+    command = 'breakpoint set -p "{0!s}"'.format((regexp))
     if extra_options:
         command += " " + extra_options
     
@@ -470,20 +470,20 @@ def check_breakpoint_result (test, break_results, file_name=None, line_number=-1
     if num_locations == -1:
         test.assertTrue (out_num_locations > 0, "Expecting one or more locations, got none.")
     else:
-        test.assertTrue (num_locations == out_num_locations, "Expecting %d locations, got %d."%(num_locations, out_num_locations))
+        test.assertTrue (num_locations == out_num_locations, "Expecting {0:d} locations, got {1:d}.".format(num_locations, out_num_locations))
 
     if file_name:
         out_file_name = ""
         if 'file' in break_results:
             out_file_name = break_results['file']
-        test.assertTrue (file_name == out_file_name, "Breakpoint file name '%s' doesn't match resultant name '%s'."%(file_name, out_file_name))
+        test.assertTrue (file_name == out_file_name, "Breakpoint file name '{0!s}' doesn't match resultant name '{1!s}'.".format(file_name, out_file_name))
 
     if line_number != -1:
         out_line_number = -1
         if 'line_no' in break_results:
             out_line_number = break_results['line_no']
 
-        test.assertTrue (line_number == out_line_number, "Breakpoint line number %s doesn't match resultant line %s."%(line_number, out_line_number))
+        test.assertTrue (line_number == out_line_number, "Breakpoint line number {0!s} doesn't match resultant line {1!s}.".format(line_number, out_line_number))
 
     if symbol_name:
         out_symbol_name = ""
@@ -494,16 +494,16 @@ def check_breakpoint_result (test, break_results, file_name=None, line_number=-1
             out_symbol_name = break_results['symbol']
 
         if symbol_match_exact:
-            test.assertTrue(symbol_name == out_symbol_name, "Symbol name '%s' doesn't match resultant symbol '%s'."%(symbol_name, out_symbol_name))
+            test.assertTrue(symbol_name == out_symbol_name, "Symbol name '{0!s}' doesn't match resultant symbol '{1!s}'.".format(symbol_name, out_symbol_name))
         else:
-            test.assertTrue(out_symbol_name.find(symbol_name) != -1, "Symbol name '%s' isn't in resultant symbol '%s'."%(symbol_name, out_symbol_name))
+            test.assertTrue(out_symbol_name.find(symbol_name) != -1, "Symbol name '{0!s}' isn't in resultant symbol '{1!s}'.".format(symbol_name, out_symbol_name))
 
     if module_name:
         out_module_name = None
         if 'module' in break_results:
             out_module_name = break_results['module']
         
-        test.assertTrue (module_name.find(out_module_name) != -1, "Symbol module name '%s' isn't in expected module name '%s'."%(out_module_name, module_name))
+        test.assertTrue (module_name.find(out_module_name) != -1, "Symbol module name '{0!s}' isn't in expected module name '{1!s}'.".format(out_module_name, module_name))
 
 # ==================================================
 # Utility functions related to Threads and Processes
@@ -713,7 +713,7 @@ def print_stacktrace(thread, string_buffer = False):
         else:
             print("  frame #{num}: {addr:#016x} {mod}`{func} at {file}:{line} {args}".format(
                 num=i, addr=load_addr, mod=mods[i],
-                func='%s [inlined]' % funcs[i] if frame.IsInlined() else funcs[i],
+                func='{0!s} [inlined]'.format(funcs[i]) if frame.IsInlined() else funcs[i],
                 file=files[i], line=lines[i],
                 args=get_args_as_string(frame, showFuncName=False) if not frame.IsInlined() else '()'), file=output)
 
@@ -742,8 +742,8 @@ def expect_state_changes(test, listener, states, timeout = 5):
         def get_next_event():
             event = lldb.SBEvent()
             if not listener.WaitForEvent(timeout, event):
-                test.fail("Timed out while waiting for a transition to state %s" %
-                    lldb.SBDebugger.StateAsCString(expected_state))
+                test.fail("Timed out while waiting for a transition to state {0!s}".format(
+                    lldb.SBDebugger.StateAsCString(expected_state)))
             return event
 
         event = get_next_event()
@@ -787,7 +787,7 @@ def get_args_as_string(frame, showFuncName=True):
     vars = frame.GetVariables(True, False, False, True) # type of SBValueList
     args = [] # list of strings
     for var in vars:
-        args.append("(%s)%s=%s" % (var.GetTypeName(),
+        args.append("({0!s}){1!s}={2!s}".format(var.GetTypeName(),
                                    var.GetName(),
                                    var.GetValue()))
     if frame.GetFunction():
@@ -797,9 +797,9 @@ def get_args_as_string(frame, showFuncName=True):
     else:
         name = ""
     if showFuncName:
-        return "%s(%s)" % (name, ", ".join(args))
+        return "{0!s}({1!s})".format(name, ", ".join(args))
     else:
-        return "(%s)" % (", ".join(args))
+        return "({0!s})".format((", ".join(args)))
         
 def print_registers(frame, string_buffer = False):
     """Prints all the register sets of the frame."""
@@ -809,12 +809,12 @@ def print_registers(frame, string_buffer = False):
     print("Register sets for " + str(frame), file=output)
 
     registerSet = frame.GetRegisters() # Return type of SBValueList.
-    print("Frame registers (size of register set = %d):" % registerSet.GetSize(), file=output)
+    print("Frame registers (size of register set = {0:d}):".format(registerSet.GetSize()), file=output)
     for value in registerSet:
         #print(value, file=output)
-        print("%s (number of children = %d):" % (value.GetName(), value.GetNumChildren()), file=output)
+        print("{0!s} (number of children = {1:d}):".format(value.GetName(), value.GetNumChildren()), file=output)
         for child in value:
-            print("Name: %s, Value: %s" % (child.GetName(), child.GetValue()), file=output)
+            print("Name: {0!s}, Value: {1!s}".format(child.GetName(), child.GetValue()), file=output)
 
     if string_buffer:
         return output.getvalue()
@@ -887,7 +887,7 @@ class BasicFormatter(object):
         if val == None:
             val = value.GetValue()
         if val == None and value.GetNumChildren() > 0:
-            val = "%s (location)" % value.GetLocation()
+            val = "{0!s} (location)".format(value.GetLocation())
         print("{indentation}({type}) {name} = {value}".format(
             indentation = ' ' * indent,
             type = value.GetTypeName(),
@@ -947,27 +947,27 @@ class RecursiveDecentFormatter(BasicFormatter):
         return output.getvalue()
 
 def check_variable (test, valobj, use_dynamic = False, summary = None, value = None, typename = None, num_children = None,use_synthetic=True):
-    test.assertTrue(valobj.IsValid(), "variable %s is not valid" % (valobj.GetName() if valobj else "<unknown>"))
+    test.assertTrue(valobj.IsValid(), "variable {0!s} is not valid".format((valobj.GetName() if valobj else "<unknown>")))
     if use_dynamic:
             valobj = valobj.GetDynamicValue(lldb.eDynamicCanRunTarget)
-            test.assertTrue(valobj.IsValid(), "dynamic value of %s is not valid" % (valobj.GetName() if valobj else "<unknown>"))
-            test.assertTrue(valobj.IsDynamic(), "dynamic value of %s is not dynamic" % (valobj.GetName() if valobj else "<unknown>"))
+            test.assertTrue(valobj.IsValid(), "dynamic value of {0!s} is not valid".format((valobj.GetName() if valobj else "<unknown>")))
+            test.assertTrue(valobj.IsDynamic(), "dynamic value of {0!s} is not dynamic".format((valobj.GetName() if valobj else "<unknown>")))
     if use_synthetic: valobj.SetPreferSyntheticValue(True)
     if summary:
-            test.assertTrue(valobj.GetSummary() == summary, "expected summary: '%s' - actual summary: '%s'" % (summary,valobj.GetSummary() if valobj else "<unknown>"))
+            test.assertTrue(valobj.GetSummary() == summary, "expected summary: '{0!s}' - actual summary: '{1!s}'".format(summary, valobj.GetSummary() if valobj else "<unknown>"))
     if value:
-            test.assertTrue(valobj.GetValue() == value, "expected value: '%s' - actual value: '%s'" % (value,valobj.GetValue() if valobj else "<unknown>"))
+            test.assertTrue(valobj.GetValue() == value, "expected value: '{0!s}' - actual value: '{1!s}'".format(value, valobj.GetValue() if valobj else "<unknown>"))
     if typename:
-            test.assertTrue(valobj.GetTypeName() == typename, "expected typename: '%s' - actual typename: '%s'" % (typename,valobj.GetTypeName() if valobj else "<unknown>"))
+            test.assertTrue(valobj.GetTypeName() == typename, "expected typename: '{0!s}' - actual typename: '{1!s}'".format(typename, valobj.GetTypeName() if valobj else "<unknown>"))
     if num_children:
-            test.assertTrue(valobj.GetNumChildren() == num_children, "expected num children: '%s' - actual num children: '%s'" % (num_children,valobj.GetNumChildren() if valobj else "<unknown>"))
+            test.assertTrue(valobj.GetNumChildren() == num_children, "expected num children: '{0!s}' - actual num children: '{1!s}'".format(num_children, valobj.GetNumChildren() if valobj else "<unknown>"))
 
 def check_children (test, valobj, thecallable):
-    test.assertTrue(valobj.IsValid(), "variable %s is not valid" % (valobj.GetName() if valobj else "<unknown>"))
+    test.assertTrue(valobj.IsValid(), "variable {0!s} is not valid".format((valobj.GetName() if valobj else "<unknown>")))
     i = 0
     while i < valobj.GetNumChildren():
         child = valobj.GetChildAtIndex(i)
-        test.assertTrue(thecallable(child,i), "child %d failed the test" % (i))
+        test.assertTrue(thecallable(child,i), "child {0:d} failed the test".format((i)))
         i = i + 1
 
 # ===========================================================
@@ -1012,10 +1012,10 @@ class PrintableRegex(object):
         return self.regex.match(str)
     
     def __str__(self):
-        return "%s" % (self.text)
+        return "{0!s}".format((self.text))
     
     def __repr__(self):
-        return "re.compile(%s) -> %s" % (self.text, self.regex)
+        return "re.compile({0!s}) -> {1!s}".format(self.text, self.regex)
 
 def skip_if_callable(test, mycallable, reason):
     if six.callable(mycallable):
@@ -1037,4 +1037,4 @@ def skip_if_library_missing(test, target, library):
         return True
     def find_library_callable(test):
         return find_library(target, library)
-    return skip_if_callable(test, find_library_callable, "could not find library matching '%s' in target %s" % (library, target))
+    return skip_if_callable(test, find_library_callable, "could not find library matching '{0!s}' in target {1!s}".format(library, target))

--- a/packages/Python/lldbsuite/test/logging/TestLogging.py
+++ b/packages/Python/lldbsuite/test/logging/TestLogging.py
@@ -34,7 +34,7 @@ class LogTestCase(TestBase):
         self.expect("file " + exe,
                     patterns = [ "Current executable set to .*a.out" ])
 
-        log_file = os.path.join (os.getcwd(), "lldb-commands-log-%s-%s-%s.txt" % (type,
+        log_file = os.path.join (os.getcwd(), "lldb-commands-log-{0!s}-{1!s}-{2!s}.txt".format(type,
                                                                                   os.path.basename(self.getCompiler()),
                                                                                   self.getArchitecture()))
 
@@ -44,7 +44,7 @@ class LogTestCase(TestBase):
         # By default, Debugger::EnableLog() will set log options to
         # PREPEND_THREAD_NAME + OPTION_THREADSAFE. We don't want the
         # threadnames here, so we enable just threadsafe (-t).
-        self.runCmd ("log enable -t -f '%s' lldb commands" % (log_file))
+        self.runCmd ("log enable -t -f '{0!s}' lldb commands".format((log_file)))
         
         self.runCmd ("command alias bp breakpoint")
                      
@@ -74,7 +74,7 @@ class LogTestCase(TestBase):
             for i in range(1, 1000):
                 f.write("bacon\n")
 
-        self.runCmd ("log enable -t -f '%s' lldb commands" % (self.truncate_log_file))
+        self.runCmd ("log enable -t -f '{0!s}' lldb commands".format((self.truncate_log_file)))
         self.runCmd ("help log")
         self.runCmd ("log disable lldb")
 
@@ -95,7 +95,7 @@ class LogTestCase(TestBase):
         with open(self.append_log_file, "w") as f:
             f.write("bacon\n")
 
-        self.runCmd ("log enable -t -a -f '%s' lldb commands" % (self.append_log_file))
+        self.runCmd ("log enable -t -a -f '{0!s}' lldb commands".format((self.append_log_file)))
         self.runCmd ("help log")
         self.runCmd ("log disable lldb")
 

--- a/packages/Python/lldbsuite/test/macosx/debug-info/apple_types/TestAppleTypesIsProduced.py
+++ b/packages/Python/lldbsuite/test/macosx/debug-info/apple_types/TestAppleTypesIsProduced.py
@@ -37,7 +37,7 @@ class AppleTypesTestCase(TestBase):
         if not self.TraceOn():
             self.HideStdout()
 
-        print("Number of modules for the target: %d" % target.GetNumModules())
+        print("Number of modules for the target: {0:d}".format(target.GetNumModules()))
         for module in target.module_iter():
             print(module)
 
@@ -47,7 +47,7 @@ class AppleTypesTestCase(TestBase):
         dwarf_section = exe_module.FindSection("__DWARF")
         self.assertTrue(dwarf_section)
         print("__DWARF section:", dwarf_section)
-        print("Number of sub-sections: %d" % dwarf_section.GetNumSubSections())
+        print("Number of sub-sections: {0:d}".format(dwarf_section.GetNumSubSections()))
         INDENT = ' ' * 4
         for subsec in dwarf_section:
             print(INDENT + str(subsec))

--- a/packages/Python/lldbsuite/test/macosx/queues/TestQueues.py
+++ b/packages/Python/lldbsuite/test/macosx/queues/TestQueues.py
@@ -31,14 +31,14 @@ class TestQueues(TestBase):
         self.main_source = "main.c"
 
     def check_queue_for_valid_queue_id(self, queue):
-        self.assertTrue(queue.GetQueueID() != 0, "Check queue %s for valid QueueID (got 0x%x)" % (queue.GetName(), queue.GetQueueID()))
+        self.assertTrue(queue.GetQueueID() != 0, "Check queue {0!s} for valid QueueID (got 0x{1:x})".format(queue.GetName(), queue.GetQueueID()))
 
     def check_running_and_pending_items_on_queue(self, queue, expected_running, expected_pending):
-        self.assertTrue(queue.GetNumPendingItems() == expected_pending, "queue %s should have %d pending items, instead has %d pending items" % (queue.GetName(), expected_pending, (queue.GetNumPendingItems())))
-        self.assertTrue(queue.GetNumRunningItems() == expected_running, "queue %s should have %d running items, instead has %d running items" % (queue.GetName(), expected_running, (queue.GetNumRunningItems())))
+        self.assertTrue(queue.GetNumPendingItems() == expected_pending, "queue {0!s} should have {1:d} pending items, instead has {2:d} pending items".format(queue.GetName(), expected_pending, (queue.GetNumPendingItems())))
+        self.assertTrue(queue.GetNumRunningItems() == expected_running, "queue {0!s} should have {1:d} running items, instead has {2:d} running items".format(queue.GetName(), expected_running, (queue.GetNumRunningItems())))
 
     def check_number_of_threads_owned_by_queue(self, queue, number_threads):
-        self.assertTrue(queue.GetNumThreads() == number_threads, "queue %s should have %d thread executing, but has %d" % (queue.GetName(), number_threads, queue.GetNumThreads()))
+        self.assertTrue(queue.GetNumThreads() == number_threads, "queue {0!s} should have {1:d} thread executing, but has {2:d}".format(queue.GetName(), number_threads, queue.GetNumThreads()))
 
     def check_queue_kind (self, queue, kind):
         expected_kind_string = "Unknown"
@@ -51,15 +51,15 @@ class TestQueues(TestBase):
             actual_kind_string = "Serial queue"
         if queue.GetKind() == lldb.eQueueKindConcurrent:
             actual_kind_string = "Concurrent queue"
-        self.assertTrue(queue.GetKind() == kind, "queue %s is expected to be a %s but it is actually a %s" % (queue.GetName(), expected_kind_string, actual_kind_string))
+        self.assertTrue(queue.GetKind() == kind, "queue {0!s} is expected to be a {1!s} but it is actually a {2!s}".format(queue.GetName(), expected_kind_string, actual_kind_string))
 
     def check_queues_threads_match_queue(self, queue):
         for idx in range(0, queue.GetNumThreads()):
             t = queue.GetThreadAtIndex(idx)
-            self.assertTrue(t.IsValid(), "Queue %s's thread #%d must be valid" % (queue.GetName(), idx))
-            self.assertTrue(t.GetQueueID() == queue.GetQueueID(), "Queue %s has a QueueID of %d but its thread #%d has a QueueID of %d" % (queue.GetName(), queue.GetQueueID(), idx, t.GetQueueID()))
-            self.assertTrue(t.GetQueueName() == queue.GetName(), "Queue %s has a QueueName of %s but its thread #%d has a QueueName of %s" % (queue.GetName(), queue.GetName(), idx, t.GetQueueName()))
-            self.assertTrue(t.GetQueue().GetQueueID() == queue.GetQueueID(), "Thread #%d's Queue's QueueID of %d is not the same as the QueueID of its owning queue %d" % (idx, t.GetQueue().GetQueueID(), queue.GetQueueID()))
+            self.assertTrue(t.IsValid(), "Queue {0!s}'s thread #{1:d} must be valid".format(queue.GetName(), idx))
+            self.assertTrue(t.GetQueueID() == queue.GetQueueID(), "Queue {0!s} has a QueueID of {1:d} but its thread #{2:d} has a QueueID of {3:d}".format(queue.GetName(), queue.GetQueueID(), idx, t.GetQueueID()))
+            self.assertTrue(t.GetQueueName() == queue.GetName(), "Queue {0!s} has a QueueName of {1!s} but its thread #{2:d} has a QueueName of {3!s}".format(queue.GetName(), queue.GetName(), idx, t.GetQueueName()))
+            self.assertTrue(t.GetQueue().GetQueueID() == queue.GetQueueID(), "Thread #{0:d}'s Queue's QueueID of {1:d} is not the same as the QueueID of its owning queue {2:d}".format(idx, t.GetQueue().GetQueueID(), queue.GetQueueID()))
 
     def queues(self):
         """Test queues inspection SB APIs without libBacktraceRecording."""
@@ -91,7 +91,7 @@ class TestQueues(TestBase):
           if q.GetName() == "com.apple.work_performer_3":
             queue_performer_3 = q
 
-        self.assertTrue(queue_submittor_1.IsValid() and queue_performer_1.IsValid() and queue_performer_2.IsValid() and queue_performer_3.IsValid(), "Got all four expected queues: %s %s %s %s" % (queue_submittor_1.IsValid(), queue_performer_1.IsValid(), queue_performer_2.IsValid(), queue_performer_3.IsValid()))
+        self.assertTrue(queue_submittor_1.IsValid() and queue_performer_1.IsValid() and queue_performer_2.IsValid() and queue_performer_3.IsValid(), "Got all four expected queues: {0!s} {1!s} {2!s} {3!s}".format(queue_submittor_1.IsValid(), queue_performer_1.IsValid(), queue_performer_2.IsValid(), queue_performer_3.IsValid()))
 
         self.check_queue_for_valid_queue_id (queue_submittor_1)
         self.check_queue_for_valid_queue_id (queue_performer_1)
@@ -208,7 +208,7 @@ class TestQueues(TestBase):
           if q.GetName() == "com.apple.work_performer_3":
             queue_performer_3 = q
 
-        self.assertTrue(queue_submittor_1.IsValid() and queue_performer_1.IsValid() and queue_performer_2.IsValid() and queue_performer_3.IsValid(), "Got all four expected queues: %s %s %s %s" % (queue_submittor_1.IsValid(), queue_performer_1.IsValid(), queue_performer_2.IsValid(), queue_performer_3.IsValid()))
+        self.assertTrue(queue_submittor_1.IsValid() and queue_performer_1.IsValid() and queue_performer_2.IsValid() and queue_performer_3.IsValid(), "Got all four expected queues: {0!s} {1!s} {2!s} {3!s}".format(queue_submittor_1.IsValid(), queue_performer_1.IsValid(), queue_performer_2.IsValid(), queue_performer_3.IsValid()))
 
         self.check_queue_for_valid_queue_id (queue_submittor_1)
         self.check_queue_for_valid_queue_id (queue_performer_1)

--- a/packages/Python/lldbsuite/test/macosx/universal/TestUniversal.py
+++ b/packages/Python/lldbsuite/test/macosx/universal/TestUniversal.py
@@ -99,7 +99,7 @@ class UniversalTestCase(TestBase):
 
         pointerSize = self.invoke(process, 'GetAddressByteSize')
         self.assertTrue(pointerSize == 4,
-                        "AddressByteSize of 32-bit process should be 4, got %d instead." % pointerSize)
+                        "AddressByteSize of 32-bit process should be 4, got {0:d} instead.".format(pointerSize))
 
         frame = process.GetThreadAtIndex(0).GetFrameAtIndex(0)
         registers = print_registers(frame, string_buffer=True)

--- a/packages/Python/lldbsuite/test/plugins/builder_base.py
+++ b/packages/Python/lldbsuite/test/plugins/builder_base.py
@@ -78,7 +78,7 @@ def getCCSpec(compiler):
             return (" CC=" + cc + " SWIFTCC=" + swiftcc + " SWIFTLIBS=\"" + swift.getSwiftLibraryPath() +
                 "\" SWIFTSDKROOT=\"" + swift.getSwiftSDKRoot() + "\"")
         else:
-            return "CC=\"%s\"" % cc
+            return "CC=\"{0!s}\"".format(cc)
     return ""
 
 def getCmdLine(d):

--- a/packages/Python/lldbsuite/test/python_api/disassemble-raw-data/TestDisassembleRawData.py
+++ b/packages/Python/lldbsuite/test/python_api/disassemble-raw-data/TestDisassembleRawData.py
@@ -33,7 +33,7 @@ class DisassembleRawDataTestCase(TestBase):
         if self.TraceOn():
             print()
             print("Raw bytes:    ", [hex(x) for x in raw_bytes])
-            print("Disassembled%s" % str(inst))
+            print("Disassembled{0!s}".format(str(inst)))
  
         self.assertTrue (inst.GetMnemonic(target) == "movq")
         self.assertTrue (inst.GetOperands(target) == '%' + "rsp, " + '%' + "rbp")

--- a/packages/Python/lldbsuite/test/python_api/disassemble-raw-data/TestDisassemble_VST1_64.py
+++ b/packages/Python/lldbsuite/test/python_api/disassemble-raw-data/TestDisassemble_VST1_64.py
@@ -36,7 +36,7 @@ class Disassemble_VST1_64(TestBase):
         if self.TraceOn():
             print()
             for i in insts:
-                print("Disassembled%s" % str(i))
+                print("Disassembled{0!s}".format(str(i)))
 
         # Remove the following return statement when the radar is fixed.
         return
@@ -53,6 +53,6 @@ class Disassemble_VST1_64(TestBase):
         if self.TraceOn():
             print()
             print("Raw bytes:    ", [hex(x) for x in raw_bytes])
-            print("Disassembled%s" % str(inst))
+            print("Disassembled{0!s}".format(str(inst)))
  
         self.assertTrue (inst.GetMnemonic(target) == "vst1.64")

--- a/packages/Python/lldbsuite/test/python_api/frame/TestFrames.py
+++ b/packages/Python/lldbsuite/test/python_api/frame/TestFrames.py
@@ -70,10 +70,10 @@ class FrameAPITestCase(TestBase):
                 valList = frame.GetVariables(True, False, False, True)
                 argList = []
                 for val in valList:
-                    argList.append("(%s)%s=%s" % (val.GetTypeName(),
+                    argList.append("({0!s}){1!s}={2!s}".format(val.GetTypeName(),
                                                   val.GetName(),
                                                   val.GetValue()))
-                print("%s(%s)" % (name, ", ".join(argList)), file=session)
+                print("{0!s}({1!s})".format(name, ", ".join(argList)), file=session)
                 
                 # Also check the generic pc & stack pointer.  We can't test their absolute values,
                 # but they should be valid.  Uses get_GPRs() from the lldbutil module.

--- a/packages/Python/lldbsuite/test/python_api/frame/inlines/TestInlinedFrame.py
+++ b/packages/Python/lldbsuite/test/python_api/frame/inlines/TestInlinedFrame.py
@@ -64,8 +64,8 @@ class InlinedFrameAPITestCase(TestBase):
         if frame0.IsInlined():
             filename = frame0.GetLineEntry().GetFileSpec().GetFilename()
             self.assertTrue(filename == self.source)
-            self.expect(stack_traces1, "First stop at %s:%d" % (self.source, self.first_stop), exe=False,
-                        substrs = ['%s:%d' % (self.source, self.first_stop)])
+            self.expect(stack_traces1, "First stop at {0!s}:{1:d}".format(self.source, self.first_stop), exe=False,
+                        substrs = ['{0!s}:{1:d}'.format(self.source, self.first_stop)])
 
             # Expect to break again for the second time.
             process.Continue()
@@ -75,5 +75,5 @@ class InlinedFrameAPITestCase(TestBase):
             if self.TraceOn():
                 print("Full stack traces when stopped on the breakpoint 'inner_inline' for the second time:")
                 print(stack_traces2)
-                self.expect(stack_traces2, "Second stop at %s:%d" % (self.source, self.second_stop), exe=False,
-                            substrs = ['%s:%d' % (self.source, self.second_stop)])
+                self.expect(stack_traces2, "Second stop at {0!s}:{1:d}".format(self.source, self.second_stop), exe=False,
+                            substrs = ['{0!s}:{1:d}'.format(self.source, self.second_stop)])

--- a/packages/Python/lldbsuite/test/python_api/hello_world/TestHelloWorld.py
+++ b/packages/Python/lldbsuite/test/python_api/hello_world/TestHelloWorld.py
@@ -100,7 +100,7 @@ class HelloWorldTestCase(TestBase):
         import lldbsuite.test.lldbutil as lldbutil
         stacktraces = lldbutil.print_stacktraces(process, string_buffer=True)
         self.expect(stacktraces, exe=False,
-            substrs = ['main.c:%d' % self.line2,
+            substrs = ['main.c:{0:d}'.format(self.line2),
                        '(int)argc=3'])
 
     @add_test_categories(['pyapi'])
@@ -143,5 +143,5 @@ class HelloWorldTestCase(TestBase):
         import lldbsuite.test.lldbutil as lldbutil
         stacktraces = lldbutil.print_stacktraces(process, string_buffer=True)
         self.expect(stacktraces, exe=False,
-            substrs = ['main.c:%d' % self.line2,
+            substrs = ['main.c:{0:d}'.format(self.line2),
                        '(int)argc=3'])

--- a/packages/Python/lldbsuite/test/python_api/interpreter/TestCommandInterpreterAPI.py
+++ b/packages/Python/lldbsuite/test/python_api/interpreter/TestCommandInterpreterAPI.py
@@ -45,7 +45,7 @@ class CommandInterpreterAPICase(TestBase):
         self.assertTrue(ci.AliasExists("bt"))
 
         res = lldb.SBCommandReturnObject()
-        ci.HandleCommand("breakpoint set -f main.c -l %d" % self.line, res)
+        ci.HandleCommand("breakpoint set -f main.c -l {0:d}".format(self.line), res)
         self.assertTrue(res.Succeeded())
         ci.HandleCommand("process launch", res)
         self.assertTrue(res.Succeeded())

--- a/packages/Python/lldbsuite/test/python_api/lldbutil/frame/TestFrameUtils.py
+++ b/packages/Python/lldbsuite/test/python_api/lldbutil/frame/TestFrameUtils.py
@@ -55,5 +55,5 @@ class FrameUtilsTestCase(TestBase):
         self.assertTrue(frame0_args and parent_args and "(int)val=1" in frame0_args)
         if self.TraceOn():
             lldbutil.print_stacktrace(thread)
-            print("Current frame: %s" % frame0_args)
-            print("Parent frame: %s" % parent_args)
+            print("Current frame: {0!s}".format(frame0_args))
+            print("Parent frame: {0!s}".format(parent_args))

--- a/packages/Python/lldbsuite/test/python_api/lldbutil/iter/TestLLDBIterator.py
+++ b/packages/Python/lldbsuite/test/python_api/lldbutil/iter/TestLLDBIterator.py
@@ -51,8 +51,8 @@ class LLDBIteratorTestCase(TestBase):
         self.assertTrue(len(yours) == len(mine))
         for i in range(len(yours)):
             if self.TraceOn():
-                print("yours[%d]='%s'" % (i, get_description(yours[i])))
-                print("mine[%d]='%s'" % (i, get_description(mine[i])))
+                print("yours[{0:d}]='{1!s}'".format(i, get_description(yours[i])))
+                print("mine[{0:d}]='{1!s}'".format(i, get_description(mine[i])))
             self.assertTrue(yours[i] == mine[i],
                             "UUID+FileSpec of yours[{0}] and mine[{0}] matches".format(i))
 
@@ -83,8 +83,8 @@ class LLDBIteratorTestCase(TestBase):
         self.assertTrue(len(yours) == len(mine))
         for i in range(len(yours)):
             if self.TraceOn():
-                print("yours[%d]='%s'" % (i, get_description(yours[i])))
-                print("mine[%d]='%s'" % (i, get_description(mine[i])))
+                print("yours[{0:d}]='{1!s}'".format(i, get_description(yours[i])))
+                print("mine[{0:d}]='{1!s}'".format(i, get_description(mine[i])))
             self.assertTrue(yours[i] == mine[i],
                             "ID of yours[{0}] and mine[{0}] matches".format(i))
 

--- a/packages/Python/lldbsuite/test/python_api/lldbutil/iter/TestRegistersIterator.py
+++ b/packages/Python/lldbsuite/test/python_api/lldbutil/iter/TestRegistersIterator.py
@@ -51,30 +51,30 @@ class RegistersIteratorTestCase(TestBase):
                     REGs = lldbutil.get_GPRs(frame)
                     num = len(REGs)
                     if self.TraceOn():
-                        print("\nNumber of general purpose registers: %d" % num)
+                        print("\nNumber of general purpose registers: {0:d}".format(num))
                     for reg in REGs:
                         self.assertTrue(reg)
                         if self.TraceOn():
-                            print("%s => %s" % (reg.GetName(), reg.GetValue()))
+                            print("{0!s} => {1!s}".format(reg.GetName(), reg.GetValue()))
 
                     REGs = lldbutil.get_FPRs(frame)
                     num = len(REGs)
                     if self.TraceOn():
-                        print("\nNumber of floating point registers: %d" % num)
+                        print("\nNumber of floating point registers: {0:d}".format(num))
                     for reg in REGs:
                         self.assertTrue(reg)
                         if self.TraceOn():
-                            print("%s => %s" % (reg.GetName(), reg.GetValue()))
+                            print("{0!s} => {1!s}".format(reg.GetName(), reg.GetValue()))
 
                     REGs = lldbutil.get_ESRs(frame)
                     if self.platformIsDarwin():
                         num = len(REGs)
                         if self.TraceOn():
-                            print("\nNumber of exception state registers: %d" % num)
+                            print("\nNumber of exception state registers: {0:d}".format(num))
                         for reg in REGs:
                             self.assertTrue(reg)
                             if self.TraceOn():
-                                print("%s => %s" % (reg.GetName(), reg.GetValue()))
+                                print("{0!s} => {1!s}".format(reg.GetName(), reg.GetValue()))
                     else:
                         self.assertIsNone(REGs)
 

--- a/packages/Python/lldbsuite/test/python_api/module_section/TestModuleAndSection.py
+++ b/packages/Python/lldbsuite/test/python_api/module_section/TestModuleAndSection.py
@@ -32,31 +32,31 @@ class ModuleAndSectionAPIsTestCase(TestBase):
         if not self.TraceOn():
             self.HideStdout()
 
-        print("Number of modules for the target: %d" % target.GetNumModules())
+        print("Number of modules for the target: {0:d}".format(target.GetNumModules()))
         for module in target.module_iter():
             print(module)
 
         # Get the executable module at index 0.
         exe_module = target.GetModuleAtIndex(0)
 
-        print("Exe module: %s" % str(exe_module))
-        print("Number of sections: %d" % exe_module.GetNumSections())
+        print("Exe module: {0!s}".format(str(exe_module)))
+        print("Number of sections: {0:d}".format(exe_module.GetNumSections()))
         INDENT = ' ' * 4
         INDENT2 = INDENT * 2
         for sec in exe_module.section_iter():
             print(sec)
-            print(INDENT + "Number of subsections: %d" % sec.GetNumSubSections())
+            print(INDENT + "Number of subsections: {0:d}".format(sec.GetNumSubSections()))
             if sec.GetNumSubSections() == 0:
                 for sym in exe_module.symbol_in_section_iter(sec):
                     print(INDENT + str(sym))
-                    print(INDENT + "symbol type: %s" % symbol_type_to_str(sym.GetType()))
+                    print(INDENT + "symbol type: {0!s}".format(symbol_type_to_str(sym.GetType())))
             else:
                 for subsec in sec:
                     print(INDENT + str(subsec))
                     # Now print the symbols belonging to the subsection....
                     for sym in exe_module.symbol_in_section_iter(subsec):
                         print(INDENT2 + str(sym))
-                        print(INDENT2 + "symbol type: %s" % symbol_type_to_str(sym.GetType()))
+                        print(INDENT2 + "symbol type: {0!s}".format(symbol_type_to_str(sym.GetType())))
 
     @add_test_categories(['pyapi'])
     def test_module_and_section_boundary_condition(self):
@@ -72,15 +72,15 @@ class ModuleAndSectionAPIsTestCase(TestBase):
         if not self.TraceOn():
             self.HideStdout()
 
-        print("Number of modules for the target: %d" % target.GetNumModules())
+        print("Number of modules for the target: {0:d}".format(target.GetNumModules()))
         for module in target.module_iter():
             print(module)
 
         # Get the executable module at index 0.
         exe_module = target.GetModuleAtIndex(0)
 
-        print("Exe module: %s" % str(exe_module))
-        print("Number of sections: %d" % exe_module.GetNumSections())
+        print("Exe module: {0!s}".format(str(exe_module)))
+        print("Number of sections: {0:d}".format(exe_module.GetNumSections()))
 
         # Boundary condition testings.  Should not crash lldb!
         exe_module.FindFirstType(None)
@@ -113,15 +113,15 @@ class ModuleAndSectionAPIsTestCase(TestBase):
         if not self.TraceOn():
             self.HideStdout()
 
-        print("Number of modules for the target: %d" % target.GetNumModules())
+        print("Number of modules for the target: {0:d}".format(target.GetNumModules()))
         for module in target.module_iter():
             print(module)
 
         # Get the executable module at index 0.
         exe_module = target.GetModuleAtIndex(0)
 
-        print("Exe module: %s" % str(exe_module))
-        print("Number of compile units: %d" % exe_module.GetNumCompileUnits())
+        print("Exe module: {0!s}".format(str(exe_module)))
+        print("Number of compile units: {0:d}".format(exe_module.GetNumCompileUnits()))
         INDENT = ' ' * 4
         INDENT2 = INDENT * 2
         for cu in exe_module.compile_unit_iter():

--- a/packages/Python/lldbsuite/test/python_api/process/TestProcessAPI.py
+++ b/packages/Python/lldbsuite/test/python_api/process/TestProcessAPI.py
@@ -285,5 +285,5 @@ class ProcessAPITestCase(TestBase):
         error = lldb.SBError();
         num = process.GetNumSupportedHardwareWatchpoints(error)
         if self.TraceOn() and error.Success():
-            print("Number of supported hardware watchpoints: %d" % num)
+            print("Number of supported hardware watchpoints: {0:d}".format(num))
 

--- a/packages/Python/lldbsuite/test/python_api/process/io/TestProcessIO.py
+++ b/packages/Python/lldbsuite/test/python_api/process/io/TestProcessIO.py
@@ -195,12 +195,12 @@ class ProcessIOTestCase(TestBase):
             # once "input line=>1" appears in stdout.
             # See also main.c.
         if self.TraceOn():
-            print("output = '%s'" % output)
-            print("error = '%s'" % error)
+            print("output = '{0!s}'".format(output))
+            print("error = '{0!s}'".format(error))
         
         for line in self.lines:
-            check_line = 'input line to stdout: %s' % (line)
+            check_line = 'input line to stdout: {0!s}'.format((line))
             self.assertTrue(check_line in output, "verify stdout line shows up in STDOUT")
         for line in self.lines:
-            check_line = 'input line to stderr: %s' % (line)
+            check_line = 'input line to stderr: {0!s}'.format((line))
             self.assertTrue(check_line in error, "verify stderr line shows up in STDERR")

--- a/packages/Python/lldbsuite/test/python_api/sbdata/TestSBData.py
+++ b/packages/Python/lldbsuite/test/python_api/sbdata/TestSBData.py
@@ -342,7 +342,7 @@ class SBDataAPICase(TestBase):
             stream = lldb.SBStream()
             error.GetDescription(stream)
             self.assertTrue(error.Success(),
-                            "%s(error, %s) did not succeed: %s" % (func.__name__,
+                            "{0!s}(error, {1!s}) did not succeed: {2!s}".format(func.__name__,
                                                                    arg,
                                                                    stream.GetData()))
-        self.assertTrue(expected == result, "%s(error, %s) == %s != %s" % (func.__name__, arg, result, expected))
+        self.assertTrue(expected == result, "{0!s}(error, {1!s}) == {2!s} != {3!s}".format(func.__name__, arg, result, expected))

--- a/packages/Python/lldbsuite/test/python_api/sbvalue_persist/TestSBValuePersist.py
+++ b/packages/Python/lldbsuite/test/python_api/sbvalue_persist/TestSBValuePersist.py
@@ -71,4 +71,4 @@ class SBValuePersistTestCase(TestBase):
         self.assertTrue(barPersist.GetPointeeData().sint32[0] == 4, "barPersist != 4")
         self.assertTrue(bazPersist.GetSummary() == '"85"', "bazPersist != 85")
         
-        self.expect("expr *(%s)" % (barPersist.GetName()), substrs = ['= 4'])
+        self.expect("expr *({0!s})".format((barPersist.GetName())), substrs = ['= 4'])

--- a/packages/Python/lldbsuite/test/python_api/type/TestTypeList.py
+++ b/packages/Python/lldbsuite/test/python_api/type/TestTypeList.py
@@ -54,7 +54,7 @@ class TypeAndTypeListTestCase(TestBase):
         # Get the type 'Task'.
         type_list = target.FindTypes('Task')
         if self.TraceOn():
-            print("Size of type_list from target.FindTypes('Task') query: %d" % type_list.GetSize())
+            print("Size of type_list from target.FindTypes('Task') query: {0:d}".format(type_list.GetSize()))
         self.assertTrue(len(type_list) >= 1) # a second Task make be scared up by the Objective-C runtime
         for type in type_list:
             self.assertTrue(type)

--- a/packages/Python/lldbsuite/test/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
+++ b/packages/Python/lldbsuite/test/python_api/watchpoint/watchlocation/TestTargetWatchAddress.py
@@ -127,4 +127,4 @@ class TargetWatchAddressAPITestCase(TestBase):
         watchpoint = target.WatchAddress(value.GetValueAsUnsigned(), 365, False, True, error)
         self.assertFalse(watchpoint)
         self.expect(error.GetCString(), exe=False,
-            substrs = ['watch size of %d is not supported' % 365])
+            substrs = ['watch size of {0:d} is not supported'.format(365)])

--- a/packages/Python/lldbsuite/test/redo.py
+++ b/packages/Python/lldbsuite/test/redo.py
@@ -180,15 +180,15 @@ def main():
     filters = " -f ".join(redo_specs)
     compilers = ''
     for comp in comp_specs:
-        compilers += " -C %s" % (comp)
+        compilers += " -C {0!s}".format((comp))
     archs = ''
     for arch in arch_specs:
-        archs += "--arch %s " % (arch)
+        archs += "--arch {0!s} ".format((arch))
 
-    command = "./dotest.py %s %s -v %s %s -f " % (compilers, archs, "" if no_trace else "-t", "-d" if do_delay else "")
+    command = "./dotest.py {0!s} {1!s} -v {2!s} {3!s} -f ".format(compilers, archs, "" if no_trace else "-t", "-d" if do_delay else "")
 
 
-    print("Running %s" % (command + filters))
+    print("Running {0!s}".format((command + filters)))
     os.system(command + filters)
 
 if __name__ == '__main__':

--- a/packages/Python/lldbsuite/test/result_formatter.py
+++ b/packages/Python/lldbsuite/test/result_formatter.py
@@ -1292,7 +1292,7 @@ class RawPickledFormatter(ResultsFormatter):
         # Send it as {serialized_length_of_serialized_bytes}{serialized_bytes}
         import struct
         msg = cPickle.dumps(test_event)
-        packet = struct.pack("!I%ds" % len(msg), len(msg), msg)
+        packet = struct.pack("!I{0:d}s".format(len(msg)), len(msg), msg)
         self.out_file.send(packet)
 
 

--- a/packages/Python/lldbsuite/test/settings/TestSettings.py
+++ b/packages/Python/lldbsuite/test/settings/TestSettings.py
@@ -125,7 +125,7 @@ class SettingsCommandTestCase(TestBase):
         self.runCmd("file " + exe, CURRENT_EXECUTABLE_SET)
 
         def cleanup():
-            self.runCmd("settings set frame-format %s" % self.format_string, check=False)
+            self.runCmd("settings set frame-format {0!s}".format(self.format_string), check=False)
 
         # Execute the cleanup function during test case tear down.
         self.addTearDownHook(cleanup)
@@ -139,7 +139,7 @@ class SettingsCommandTestCase(TestBase):
 
         # Change the default format to print function.name rather than function.name-with-args
         format_string = "frame #${frame.index}: ${frame.pc}{ ${module.file.basename}`${function.name}{${function.pc-offset}}}{ at ${line.file.fullpath}:${line.number}}{, lang=${language}}\n"
-        self.runCmd("settings set frame-format %s" % format_string)
+        self.runCmd("settings set frame-format {0!s}".format(format_string))
 
         # Immediately test the setting.
         self.expect("settings show frame-format", SETTING_MSG("frame-format"),
@@ -393,10 +393,10 @@ class SettingsCommandTestCase(TestBase):
         # file
         path1 = os.path.join(os.getcwd(), "path1.txt")
         path2 = os.path.join(os.getcwd(), "path2.txt")
-        self.runCmd ("settings set target.output-path %s" % path1)   # Set to known value
+        self.runCmd ("settings set target.output-path {0!s}".format(path1))   # Set to known value
         self.expect ("settings show target.output-path", SETTING_MSG("target.output-path"),
             startstr = 'target.output-path (file) = ', substrs=[path1])
-        self.runCmd ("settings set target.output-path %s " % path2) # Set to new value with trailing whitespaces
+        self.runCmd ("settings set target.output-path {0!s} ".format(path2)) # Set to new value with trailing whitespaces
         self.expect ("settings show target.output-path", SETTING_MSG("target.output-path"),
             startstr = 'target.output-path (file) = ', substrs=[path2])
         self.runCmd("settings clear target.output-path", check=False)

--- a/packages/Python/lldbsuite/test/source-manager/TestSourceManager.py
+++ b/packages/Python/lldbsuite/test/source-manager/TestSourceManager.py
@@ -63,7 +63,7 @@ class SourceManagerTestCase(TestBase):
         #    6    }
         self.expect(stream.GetData(), "Source code displayed correctly",
                     exe=False,
-            patterns = ['=> %d.*Hello world' % self.line])
+            patterns = ['=> {0:d}.*Hello world'.format(self.line)])
 
         # Boundary condition testings for SBStream().  LLDB should not crash!
         stream.Print(None)
@@ -88,7 +88,7 @@ class SourceManagerTestCase(TestBase):
         self.addTearDownHook(lambda: os.rename(main_c_hidden, main_c))
 
         # Set target.source-map settings.
-        self.runCmd("settings set target.source-map %s %s" % (os.getcwd(), os.path.join(os.getcwd(), "hidden")))
+        self.runCmd("settings set target.source-map {0!s} {1!s}".format(os.getcwd(), os.path.join(os.getcwd(), "hidden")))
         # And verify that the settings work.
         self.expect("settings show target.source-map",
             substrs = [os.getcwd(), os.path.join(os.getcwd(), "hidden")])
@@ -110,18 +110,18 @@ class SourceManagerTestCase(TestBase):
         # The stop reason of the thread should be breakpoint.
         self.expect("thread list", STOPPED_DUE_TO_BREAKPOINT,
             substrs = ['stopped',
-                       'main.c:%d' % self.line,
+                       'main.c:{0:d}'.format(self.line),
                        'stop reason = breakpoint'])
 
         # Display some source code.
-        self.expect("source list -f main.c -l %d" % self.line, SOURCE_DISPLAYED_CORRECTLY,
+        self.expect("source list -f main.c -l {0:d}".format(self.line), SOURCE_DISPLAYED_CORRECTLY,
             substrs = ['Hello world'])
 
         # The '-b' option shows the line table locations from the debug information
         # that indicates valid places to set source level breakpoints.
 
         # The file to display is implicit in this case.
-        self.runCmd("source list -l %d -c 3 -b" % self.line)
+        self.runCmd("source list -l {0:d} -c 3 -b".format(self.line))
         output = self.res.GetOutput().splitlines()[0]
 
         # If the breakpoint set command succeeded, we should expect a positive number
@@ -168,5 +168,5 @@ class SourceManagerTestCase(TestBase):
             self.addTearDownHook(restore_file)
 
         # Display the source code again.  We should see the updated line.
-        self.expect("source list -f main.c -l %d" % self.line, SOURCE_DISPLAYED_CORRECTLY,
+        self.expect("source list -f main.c -l {0:d}".format(self.line), SOURCE_DISPLAYED_CORRECTLY,
             substrs = ['Hello lldb'])

--- a/packages/Python/lldbsuite/test/terminal/TestSTTYBeforeAndAfter.py
+++ b/packages/Python/lldbsuite/test/terminal/TestSTTYBeforeAndAfter.py
@@ -67,7 +67,7 @@ class TestSTTYBeforeAndAfter(TestBase):
         child.logfile_read = None
 
         # Invoke the lldb command.
-        child.sendline('%s %s' % (lldbtest_config.lldbExec, self.lldbOption))
+        child.sendline('{0!s} {1!s}'.format(lldbtest_config.lldbExec, self.lldbOption))
         child.expect_exact(lldb_prompt)
 
         # Immediately quit.
@@ -114,7 +114,7 @@ class TestSTTYBeforeAndAfter(TestBase):
         zipped = list(zip(stty_output1_lines, stty_output2_lines))
         for tuple in zipped:
             if self.TraceOn():
-                print("tuple->%s" % str(tuple))
+                print("tuple->{0!s}".format(str(tuple)))
             # Every line should compare equal until the first blank line.
             if len(tuple[0]) == 0:
                 break

--- a/packages/Python/lldbsuite/test/test_result.py
+++ b/packages/Python/lldbsuite/test/test_result.py
@@ -78,13 +78,13 @@ class LLDBTestResult(unittest2.TextTestResult):
     def _config_string(self, test):
         compiler = getattr(test, "getCompiler", None)
         arch = getattr(test, "getArchitecture", None)
-        return "%s-%s" % (compiler() if compiler else "", arch() if arch else "")
+        return "{0!s}-{1!s}".format(compiler() if compiler else "", arch() if arch else "")
 
     def _exc_info_to_string(self, err, test):
         """Overrides superclass TestResult's method in order to append
         our test config info string to the exception info string."""
         if hasattr(test, "getArchitecture") and hasattr(test, "getCompiler"):
-            return '%sConfig=%s-%s' % (super(LLDBTestResult, self)._exc_info_to_string(err, test),
+            return '{0!s}Config={1!s}-{2!s}'.format(super(LLDBTestResult, self)._exc_info_to_string(err, test),
                                                         test.getArchitecture(),
                                                         test.getCompiler())
         else:
@@ -119,7 +119,7 @@ class LLDBTestResult(unittest2.TextTestResult):
     def startTest(self, test):
         if configuration.shouldSkipBecauseOfCategories(self.getCategoriesForTest(test)):
             self.hardMarkAsSkipped(test)
-        configuration.setCrashInfoHook("%s at %s" % (str(test),inspect.getfile(test.__class__)))
+        configuration.setCrashInfoHook("{0!s} at {1!s}".format(str(test), inspect.getfile(test.__class__)))
         self.counter += 1
         #if self.counter == 4:
         #    import crashinfo
@@ -135,7 +135,7 @@ class LLDBTestResult(unittest2.TextTestResult):
     def addSuccess(self, test):
         super(LLDBTestResult, self).addSuccess(test)
         if configuration.parsable:
-            self.stream.write("PASS: LLDB (%s) :: %s\n" % (self._config_string(test), str(test)))
+            self.stream.write("PASS: LLDB ({0!s}) :: {1!s}\n".format(self._config_string(test), str(test)))
         if self.results_formatter:
             self.results_formatter.handle_event(
                 EventBuilder.event_for_success(test))
@@ -147,7 +147,7 @@ class LLDBTestResult(unittest2.TextTestResult):
         if method:
             method()
         if configuration.parsable:
-            self.stream.write("FAIL: LLDB (%s) :: %s\n" % (self._config_string(test), str(test)))
+            self.stream.write("FAIL: LLDB ({0!s}) :: {1!s}\n".format(self._config_string(test), str(test)))
         if self.results_formatter:
             self.results_formatter.handle_event(
                 EventBuilder.event_for_error(test, err))
@@ -159,7 +159,7 @@ class LLDBTestResult(unittest2.TextTestResult):
         if method:
             method()
         if configuration.parsable:
-            self.stream.write("CLEANUP ERROR: LLDB (%s) :: %s\n" % (self._config_string(test), str(test)))
+            self.stream.write("CLEANUP ERROR: LLDB ({0!s}) :: {1!s}\n".format(self._config_string(test), str(test)))
         if self.results_formatter:
             self.results_formatter.handle_event(
                 EventBuilder.event_for_cleanup_error(
@@ -172,7 +172,7 @@ class LLDBTestResult(unittest2.TextTestResult):
         if method:
             method()
         if configuration.parsable:
-            self.stream.write("FAIL: LLDB (%s) :: %s\n" % (self._config_string(test), str(test)))
+            self.stream.write("FAIL: LLDB ({0!s}) :: {1!s}\n".format(self._config_string(test), str(test)))
         if configuration.useCategories:
             test_categories = self.getCategoriesForTest(test)
             for category in test_categories:
@@ -192,7 +192,7 @@ class LLDBTestResult(unittest2.TextTestResult):
         if method:
             method(err, bugnumber)
         if configuration.parsable:
-            self.stream.write("XFAIL: LLDB (%s) :: %s\n" % (self._config_string(test), str(test)))
+            self.stream.write("XFAIL: LLDB ({0!s}) :: {1!s}\n".format(self._config_string(test), str(test)))
         if self.results_formatter:
             self.results_formatter.handle_event(
                 EventBuilder.event_for_expected_failure(
@@ -205,7 +205,7 @@ class LLDBTestResult(unittest2.TextTestResult):
         if method:
             method()
         if configuration.parsable:
-            self.stream.write("UNSUPPORTED: LLDB (%s) :: %s (%s) \n" % (self._config_string(test), str(test), reason))
+            self.stream.write("UNSUPPORTED: LLDB ({0!s}) :: {1!s} ({2!s}) \n".format(self._config_string(test), str(test), reason))
         if self.results_formatter:
             self.results_formatter.handle_event(
                 EventBuilder.event_for_skip(test, reason))
@@ -217,7 +217,7 @@ class LLDBTestResult(unittest2.TextTestResult):
         if method:
             method(bugnumber)
         if configuration.parsable:
-            self.stream.write("XPASS: LLDB (%s) :: %s\n" % (self._config_string(test), str(test)))
+            self.stream.write("XPASS: LLDB ({0!s}) :: {1!s}\n".format(self._config_string(test), str(test)))
         if self.results_formatter:
             self.results_formatter.handle_event(
                 EventBuilder.event_for_unexpected_success(

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiExit.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiExit.py
@@ -21,7 +21,7 @@ class MiExitTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -45,7 +45,7 @@ class MiExitTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -68,7 +68,7 @@ class MiExitTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiFile.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiFile.py
@@ -21,7 +21,7 @@ class MiFileTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Test that -file-exec-and-symbols works for filename
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run
@@ -39,7 +39,7 @@ class MiFileTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test that -file-exec-and-symbols works for absolute path
         import os
         path = os.path.join(os.getcwd(), self.myexe)
-        self.runCmd("-file-exec-and-symbols \"%s\"" % path)
+        self.runCmd("-file-exec-and-symbols \"{0!s}\"".format(path))
         self.expect("\^done")
 
         # Run
@@ -55,8 +55,8 @@ class MiFileTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Test that -file-exec-and-symbols works for relative path
-        path = "./%s" % self.myexe
-        self.runCmd("-file-exec-and-symbols %s" % path)
+        path = "./{0!s}".format(self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(path))
         self.expect("\^done")
 
         # Run
@@ -72,6 +72,6 @@ class MiFileTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Test that -file-exec-and-symbols fails on unknown path
-        path = "unknown_dir/%s" % self.myexe
-        self.runCmd("-file-exec-and-symbols %s" % path)
+        path = "unknown_dir/{0!s}".format(self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(path))
         self.expect("\^error")

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiGdbSetShow.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiGdbSetShow.py
@@ -54,7 +54,7 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
         self.expect("\^done,value=\"on\"")
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Test that program is executed in async mode
@@ -76,7 +76,7 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
         self.expect("\^done,value=\"off\"")
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Test that program is executed in async mode
@@ -84,7 +84,7 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
         unexpected = [ "\*running" ] # "\*running" is async notification
         it = self.expect(unexpected + [ "@\"argc=1\\\\r\\\\n" ])
         if it < len(unexpected):
-            self.fail("unexpected found: %s" % unexpected[it])
+            self.fail("unexpected found: {0!s}".format(unexpected[it]))
 
     @expectedFailureWindows("llvm.org/pr22274: need a pexpect replacement for windows")
     @skipIfFreeBSD # llvm.org/pr22411: Failure presumably due to known thread races
@@ -105,7 +105,7 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -151,12 +151,12 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to BP_printf
         line = line_number('main.cpp', '// BP_printf')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running");

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiLibraryLoaded.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiLibraryLoaded.py
@@ -21,7 +21,7 @@ class MiLibraryLoadedTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Test =library-loaded
@@ -29,5 +29,5 @@ class MiLibraryLoadedTestCase(lldbmi_testcase.MiTestCaseBase):
         path = os.path.join(os.getcwd(), self.myexe)
         symbols_path = os.path.join(path + ".dSYM", "Contents", "Resources", "DWARF", self.myexe)
         def add_slashes(x): return x.replace("\\", "\\\\").replace("\"", "\\\"").replace("\'", "\\\'").replace("\0", "\\\0")
-        self.expect([ "=library-loaded,id=\"%s\",target-name=\"%s\",host-name=\"%s\",symbols-loaded=\"1\",symbols-path=\"%s\",loaded_addr=\"-\",size=\"[0-9]+\"" % (add_slashes(path), add_slashes(path), add_slashes(path), add_slashes(symbols_path)),
-                      "=library-loaded,id=\"%s\",target-name=\"%s\",host-name=\"%s\",symbols-loaded=\"0\",loaded_addr=\"-\",size=\"[0-9]+\"" % (add_slashes(path), add_slashes(path), add_slashes(path)) ])
+        self.expect([ "=library-loaded,id=\"{0!s}\",target-name=\"{1!s}\",host-name=\"{2!s}\",symbols-loaded=\"1\",symbols-path=\"{3!s}\",loaded_addr=\"-\",size=\"[0-9]+\"".format(add_slashes(path), add_slashes(path), add_slashes(path), add_slashes(symbols_path)),
+                      "=library-loaded,id=\"{0!s}\",target-name=\"{1!s}\",host-name=\"{2!s}\",symbols-loaded=\"0\",loaded_addr=\"-\",size=\"[0-9]+\"".format(add_slashes(path), add_slashes(path), add_slashes(path)) ])

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiPrompt.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/TestMiPrompt.py
@@ -26,7 +26,7 @@ class MiPromptTestCase(lldbmi_testcase.MiTestCaseBase):
         self.expect(self.child_prompt, exactly = True)
 
         # Test that lldb-mi is ready after -file-exec-and-symbols
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
         self.expect(self.child_prompt, exactly = True)
 

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/breakpoint/TestMiBreak.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/breakpoint/TestMiBreak.py
@@ -21,7 +21,7 @@ class MiBreakTestCase(lldbmi_testcase.MiTestCaseBase):
 
         self.spawnLldbMi(args = None)
 
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         self.runCmd("-break-insert -f printf")
@@ -44,7 +44,7 @@ class MiBreakTestCase(lldbmi_testcase.MiTestCaseBase):
 
         self.spawnLldbMi(args = None)
 
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         self.runCmd("-break-insert -f main")
@@ -105,15 +105,15 @@ class MiBreakTestCase(lldbmi_testcase.MiTestCaseBase):
 
         self.spawnLldbMi(args = None)
 
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Find the line number to break inside main() and set
         # pending BP
         line = line_number('main.cpp', '// BP_return')
-        self.runCmd("-break-insert -f main.cpp:%d" % line)
-        self.expect("\^done,bkpt={number=\"1\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"(?!0xffffffffffffffff)0x[0-9a-f]+\",func=\"main\",file=\"main\.cpp\",fullname=\".+?main\.cpp\",line=\"%d\",pending=\[\"main.cpp:%d\"\],times=\"0\",original-location=\"main.cpp:%d\"}" % (line, line, line))
-        self.expect("=breakpoint-modified,bkpt={number=\"1\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"(?!0xffffffffffffffff)0x[0-9a-f]+\",func=\"main\",file=\"main\.cpp\",fullname=\".+?main\.cpp\",line=\"%d\",pending=\[\"main.cpp:%d\"\],times=\"0\",original-location=\"main.cpp:%d\"}" % (line, line, line))
+        self.runCmd("-break-insert -f main.cpp:{0:d}".format(line))
+        self.expect("\^done,bkpt={{number=\"1\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"(?!0xffffffffffffffff)0x[0-9a-f]+\",func=\"main\",file=\"main\.cpp\",fullname=\".+?main\.cpp\",line=\"{0:d}\",pending=\[\"main.cpp:{1:d}\"\],times=\"0\",original-location=\"main.cpp:{2:d}\"}}".format(line, line, line))
+        self.expect("=breakpoint-modified,bkpt={{number=\"1\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"(?!0xffffffffffffffff)0x[0-9a-f]+\",func=\"main\",file=\"main\.cpp\",fullname=\".+?main\.cpp\",line=\"{0:d}\",pending=\[\"main.cpp:{1:d}\"\],times=\"0\",original-location=\"main.cpp:{2:d}\"}}".format(line, line, line))
 
         self.runCmd("-exec-run")
         self.expect("\^running")
@@ -126,7 +126,7 @@ class MiBreakTestCase(lldbmi_testcase.MiTestCaseBase):
 
         self.spawnLldbMi(args = None)
 
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         self.runCmd("-break-insert -f main")
@@ -138,9 +138,9 @@ class MiBreakTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Test that -break-insert can set non-pending BP
         line = line_number('main.cpp', '// BP_return')
-        self.runCmd("-break-insert main.cpp:%d" % line)
-        self.expect("\^done,bkpt={number=\"2\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"(?!0xffffffffffffffff)0x[0-9a-f]+\",func=\"main\",file=\"main\.cpp\",fullname=\".+?main\.cpp\",line=\"%d\",times=\"0\",original-location=\"main.cpp:%d\"}" % (line, line))
-        self.expect("=breakpoint-modified,bkpt={number=\"2\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"(?!0xffffffffffffffff)0x[0-9a-f]+\",func=\"main\",file=\"main\.cpp\",fullname=\".+?main\.cpp\",line=\"%d\",times=\"0\",original-location=\"main.cpp:%d\"}" % (line, line))
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
+        self.expect("\^done,bkpt={{number=\"2\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"(?!0xffffffffffffffff)0x[0-9a-f]+\",func=\"main\",file=\"main\.cpp\",fullname=\".+?main\.cpp\",line=\"{0:d}\",times=\"0\",original-location=\"main.cpp:{1:d}\"}}".format(line, line))
+        self.expect("=breakpoint-modified,bkpt={{number=\"2\",type=\"breakpoint\",disp=\"keep\",enabled=\"y\",addr=\"(?!0xffffffffffffffff)0x[0-9a-f]+\",func=\"main\",file=\"main\.cpp\",fullname=\".+?main\.cpp\",line=\"{0:d}\",times=\"0\",original-location=\"main.cpp:{1:d}\"}}".format(line, line))
 
         # Test that -break-insert fails if non-pending BP can't be resolved
         self.runCmd("-break-insert unknown_file:1")
@@ -159,7 +159,7 @@ class MiBreakTestCase(lldbmi_testcase.MiTestCaseBase):
 
         self.spawnLldbMi(args = None)
 
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         self.runCmd("-break-insert -f main")
@@ -172,7 +172,7 @@ class MiBreakTestCase(lldbmi_testcase.MiTestCaseBase):
         import os
         path = os.path.join(os.getcwd(), "main.cpp")
         line = line_number('main.cpp', '// BP_return')
-        self.runCmd("-break-insert %s:%d" % (path, line))
+        self.runCmd("-break-insert {0!s}:{1:d}".format(path, line))
         self.expect("\^done,bkpt={number=\"2\"")
 
         self.runCmd("-exec-continue")
@@ -187,32 +187,32 @@ class MiBreakTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Set target.move-to-nearest-code=off and try to set BP #1 that shouldn't be hit
         self.runCmd("-interpreter-exec console \"settings set target.move-to-nearest-code off\"")
         self.expect("\^done")
         line = line_number('main.cpp', '// BP_before_main')
-        self.runCmd("-break-insert -f main.cpp:%d" % line)
+        self.runCmd("-break-insert -f main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
 
         # Test that non-pending BP will not be set on non-existing line if target.move-to-nearest-code=off
         # Note: this increases the BP number by 1 even though BP #2 is invalid.
-        self.runCmd("-break-insert main.cpp:%d" % line)
-        self.expect("\^error,msg=\"Command 'break-insert'. Breakpoint location 'main.cpp:%d' not found\"" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
+        self.expect("\^error,msg=\"Command 'break-insert'. Breakpoint location 'main.cpp:{0:d}' not found\"".format(line))
 
         # Set target.move-to-nearest-code=on and target.skip-prologue=on and set BP #3
         self.runCmd("-interpreter-exec console \"settings set target.move-to-nearest-code on\"")
         self.runCmd("-interpreter-exec console \"settings set target.skip-prologue on\"")
         self.expect("\^done")
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"3\"")
 
         # Set target.skip-prologue=off and set BP #4
         self.runCmd("-interpreter-exec console \"settings set target.skip-prologue off\"")
         self.expect("\^done")
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"4\"")
 
         # Test that BP #4 is located before BP #3

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/control/TestMiExec.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/control/TestMiExec.py
@@ -22,7 +22,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Test that program is stopped at entry
@@ -44,7 +44,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.expect("\^error,msg=\"Command 'exec-abort'\. Invalid process during debug session\"")
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Set arguments
@@ -89,7 +89,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Set arguments
@@ -131,7 +131,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Set arguments
@@ -159,7 +159,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -211,7 +211,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -264,7 +264,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -332,7 +332,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Warning: the following is sensitive to the lines in the
@@ -393,7 +393,7 @@ class MiExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Set BP at g_MyFunction and run to BP

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/data/TestMiData.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/data/TestMiData.py
@@ -22,7 +22,7 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -38,12 +38,12 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         addr = int(self.child.after.split("\"")[1].split(" ")[0], 16)
 
         # Test -data-disassemble: try to disassemble some address
-        self.runCmd("-data-disassemble -s %#x -e %#x -- 0" % (addr, addr + 0x10))
-        self.expect("\^done,asm_insns=\[{address=\"0x0*%x\",func-name=\"main\",offset=\"0\",size=\"[1-9]+\",inst=\".+?\"}," % addr)
+        self.runCmd("-data-disassemble -s {0:#x} -e {1:#x} -- 0".format(addr, addr + 0x10))
+        self.expect("\^done,asm_insns=\[{{address=\"0x0*{0:x}\",func-name=\"main\",offset=\"0\",size=\"[1-9]+\",inst=\".+?\"}},".format(addr))
         
         # Test -data-disassemble without "--"
-        self.runCmd("-data-disassemble -s %#x -e %#x 0" % (addr, addr + 0x10))
-        self.expect("\^done,asm_insns=\[{address=\"0x0*%x\",func-name=\"main\",offset=\"0\",size=\"[1-9]+\",inst=\".+?\"}," % addr)
+        self.runCmd("-data-disassemble -s {0:#x} -e {1:#x} 0".format(addr, addr + 0x10))
+        self.expect("\^done,asm_insns=\[{{address=\"0x0*{0:x}\",func-name=\"main\",offset=\"0\",size=\"[1-9]+\",inst=\".+?\"}},".format(addr))
 
         # Run to hello_world
         self.runCmd("-break-insert -f hello_world")
@@ -58,7 +58,7 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         addr = int(self.child.after.split("\"")[1].split(" ")[0], 16)
 
         # Test -data-disassemble: try to disassemble some address
-        self.runCmd("-data-disassemble -s %#x -e %#x -- 0" % (addr, addr + 0x10))
+        self.runCmd("-data-disassemble -s {0:#x} -e {1:#x} -- 0".format(addr, addr + 0x10))
 
         # This matches a line similar to:
         # Darwin: {address="0x0000000100000f18",func-name="hello_world()",offset="8",size="7",inst="leaq 0x65(%rip), %rdi; \"Hello, World!\\n\""},
@@ -77,7 +77,7 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -94,8 +94,8 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         size = 5
 
         # Test that -data-read-memory-bytes works for char[] type (global)
-        self.runCmd("-data-read-memory-bytes %#x %d" % (addr, size))
-        self.expect("\^done,memory=\[{begin=\"0x0*%x\",offset=\"0x0+\",end=\"0x0*%x\",contents=\"1112131400\"}\]" % (addr, addr + size))
+        self.runCmd("-data-read-memory-bytes {0:#x} {1:d}".format(addr, size))
+        self.expect("\^done,memory=\[{{begin=\"0x0*{0:x}\",offset=\"0x0+\",end=\"0x0*{1:x}\",contents=\"1112131400\"}}\]".format(addr, addr + size))
 
         # Get address of static char[]
         self.runCmd("-data-evaluate-expression &s_CharArray")
@@ -104,8 +104,8 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         size = 5
 
         # Test that -data-read-memory-bytes works for static char[] type
-        self.runCmd("-data-read-memory-bytes %#x %d" % (addr, size))
-        self.expect("\^done,memory=\[{begin=\"0x0*%x\",offset=\"0x0+\",end=\"0x0*%x\",contents=\"1112131400\"}\]" % (addr, addr + size))
+        self.runCmd("-data-read-memory-bytes {0:#x} {1:d}".format(addr, size))
+        self.expect("\^done,memory=\[{{begin=\"0x0*{0:x}\",offset=\"0x0+\",end=\"0x0*{1:x}\",contents=\"1112131400\"}}\]".format(addr, addr + size))
 
     @skipIfWindows #llvm.org/pr24452: Get lldb-mi tests working on Windows
     @skipIfFreeBSD # llvm.org/pr22411: Failure presumably due to known thread races
@@ -115,12 +115,12 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd('-file-exec-and-symbols %s' % self.myexe)
+        self.runCmd('-file-exec-and-symbols {0!s}'.format(self.myexe))
         self.expect(r'\^done')
 
         # Run to BP_local_array_test_inner
         line = line_number('main.cpp', '// BP_local_array_test_inner')
-        self.runCmd('-break-insert main.cpp:%d' % line)
+        self.runCmd('-break-insert main.cpp:{0:d}'.format(line))
         self.expect(r'\^done,bkpt=\{number="1"')
         self.runCmd('-exec-run')
         self.expect(r'\^running')
@@ -133,16 +133,16 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         size = 4
 
         # Test that an unquoted hex literal address works
-        self.runCmd('-data-read-memory-bytes %#x %d' % (addr, size))
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="01020304"\}\]' % (addr, addr + size))
+        self.runCmd('-data-read-memory-bytes {0:#x} {1:d}'.format(addr, size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="01020304"\}}\]'.format(addr, addr + size))
 
         # Test that a double-quoted hex literal address works
-        self.runCmd('-data-read-memory-bytes "%#x" %d' % (addr, size))
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="01020304"\}\]' % (addr, addr + size))
+        self.runCmd('-data-read-memory-bytes "{0:#x}" {1:d}'.format(addr, size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="01020304"\}}\]'.format(addr, addr + size))
 
         # Test that unquoted expressions work
-        self.runCmd('-data-read-memory-bytes &array %d' % size)
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="01020304"\}\]' % (addr, addr + size))
+        self.runCmd('-data-read-memory-bytes &array {0:d}'.format(size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="01020304"\}}\]'.format(addr, addr + size))
 
         # This doesn't work, and perhaps that makes sense, but it does work on GDB
         self.runCmd('-data-read-memory-bytes array 4')
@@ -150,28 +150,28 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         #self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="01020304"\}\]' % (addr, addr + size))
 
         self.runCmd('-data-read-memory-bytes &array[2] 2')
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="0304"\}\]' % (addr + 2, addr + size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="0304"\}}\]'.format(addr + 2, addr + size))
 
-        self.runCmd('-data-read-memory-bytes first_element_ptr %d' % size)
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="01020304"\}\]' % (addr, addr + size))
+        self.runCmd('-data-read-memory-bytes first_element_ptr {0:d}'.format(size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="01020304"\}}\]'.format(addr, addr + size))
 
         # Test that double-quoted expressions work
-        self.runCmd('-data-read-memory-bytes "&array" %d' % size)
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="01020304"\}\]' % (addr, addr + size))
+        self.runCmd('-data-read-memory-bytes "&array" {0:d}'.format(size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="01020304"\}}\]'.format(addr, addr + size))
 
         self.runCmd('-data-read-memory-bytes "&array[0] + 1" 3')
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="020304"\}\]' % (addr + 1, addr + size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="020304"\}}\]'.format(addr + 1, addr + size))
 
         self.runCmd('-data-read-memory-bytes "first_element_ptr + 1" 3')
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="020304"\}\]' % (addr + 1, addr + size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="020304"\}}\]'.format(addr + 1, addr + size))
 
         # Test the -o (offset) option
         self.runCmd('-data-read-memory-bytes -o 1 &array 3')
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="020304"\}\]' % (addr + 1, addr + size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="020304"\}}\]'.format(addr + 1, addr + size))
 
         # Test the --thread option
         self.runCmd('-data-read-memory-bytes --thread 1 &array 4')
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="01020304"\}\]' % (addr, addr + size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="01020304"\}}\]'.format(addr, addr + size))
 
         # Test the --thread option with an invalid value
         self.runCmd('-data-read-memory-bytes --thread 999 &array 4')
@@ -179,7 +179,7 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Test the --frame option (current frame)
         self.runCmd('-data-read-memory-bytes --frame 0 &array 4')
-        self.expect(r'\^done,memory=\[\{begin="0x0*%x",offset="0x0+",end="0x0*%x",contents="01020304"\}\]' % (addr, addr + size))
+        self.expect(r'\^done,memory=\[\{{begin="0x0*{0:x}",offset="0x0+",end="0x0*{1:x}",contents="01020304"\}}\]'.format(addr, addr + size))
 
         # Test the --frame option (outer frame)
         self.runCmd('-data-read-memory-bytes --frame 1 &array 4')
@@ -224,7 +224,7 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -250,7 +250,7 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -276,7 +276,7 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -293,12 +293,12 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         line = line_number('main.cpp', '// FUNC_main')
 
         # Test that -data-info-line works for address
-        self.runCmd("-data-info-line *%#x" % addr)
-        self.expect("\^done,start=\"0x0*%x\",end=\"0x[0-9a-f]+\",file=\".+?main.cpp\",line=\"%d\"" % (addr, line))
+        self.runCmd("-data-info-line *{0:#x}".format(addr))
+        self.expect("\^done,start=\"0x0*{0:x}\",end=\"0x[0-9a-f]+\",file=\".+?main.cpp\",line=\"{1:d}\"".format(addr, line))
 
         # Test that -data-info-line works for file:line
-        self.runCmd("-data-info-line main.cpp:%d" % line)
-        self.expect("\^done,start=\"0x0*%x\",end=\"0x[0-9a-f]+\",file=\".+?main.cpp\",line=\"%d\"" % (addr, line))
+        self.runCmd("-data-info-line main.cpp:{0:d}".format(line))
+        self.expect("\^done,start=\"0x0*{0:x}\",end=\"0x[0-9a-f]+\",file=\".+?main.cpp\",line=\"{1:d}\"".format(addr, line))
 
         # Test that -data-info-line fails when invalid address is specified
         self.runCmd("-data-info-line *0x0")
@@ -322,11 +322,11 @@ class MiDataTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         line = line_number('main.cpp', '// BP_local_2d_array_test')
-        self.runCmd('-break-insert main.cpp:%d' % line)
+        self.runCmd('-break-insert main.cpp:{0:d}'.format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiCliSupport.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiCliSupport.py
@@ -21,7 +21,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Test that "target create" loads executable
-        self.runCmd("target create \"%s\"" % self.myexe)
+        self.runCmd("target create \"{0!s}\"".format(self.myexe))
         self.expect("\^done")
 
         # Test that executable was loaded properly
@@ -40,7 +40,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Test that "breakpoint set" sets a breakpoint
@@ -68,7 +68,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
         self.expect("\^done")
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run
@@ -87,7 +87,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Test that "settings set target.run-args" passes arguments to executable
@@ -111,7 +111,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Set breakpoint
@@ -134,7 +134,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -164,7 +164,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -189,7 +189,7 @@ class MiCliSupportTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiInterpreterExec.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/interpreter/TestMiInterpreterExec.py
@@ -21,7 +21,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Test that "target create" loads executable
-        self.runCmd("-interpreter-exec console \"target create \\\"%s\\\"\"" % self.myexe)
+        self.runCmd("-interpreter-exec console \"target create \\\"{0!s}\\\"\"".format(self.myexe))
         self.expect("\^done")
 
         # Test that executable was loaded properly
@@ -39,7 +39,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Test that "breakpoint set" sets a breakpoint
@@ -67,7 +67,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.expect("\^done")
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run
@@ -94,7 +94,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Test that "settings set target.run-args" passes arguments to executable
@@ -104,7 +104,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Run to BP_printf
         line = line_number('main.cpp', '// BP_printf')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running");
@@ -112,7 +112,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Run to BP_return
         line = line_number('main.cpp', '// BP_return')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"2\"")
         self.runCmd("-exec-continue")
         self.expect("\^running");
@@ -136,7 +136,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Set breakpoint
@@ -158,7 +158,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -187,7 +187,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -212,7 +212,7 @@ class MiInterpreterExecTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/lldbmi_testcase.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/lldbmi_testcase.py
@@ -29,7 +29,7 @@ class MiTestCaseBase(Base):
 
     def tearDown(self):
         if self.TraceOn():
-            print("\n\nContents of %s:" % self.mylog)
+            print("\n\nContents of {0!s}:".format(self.mylog))
             try:
                 print(open(self.mylog, "r").read())
             except IOError:
@@ -38,7 +38,7 @@ class MiTestCaseBase(Base):
 
     def spawnLldbMi(self, args=None):
         import pexpect
-        self.child = pexpect.spawn("%s --interpreter %s" % (
+        self.child = pexpect.spawn("{0!s} --interpreter {1!s}".format(
             self.lldbMiExec, args if args else ""))
         self.child.setecho(True)
         self.child.logfile_read = open(self.mylog, "w")

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/signal/TestMiSignal.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/signal/TestMiSignal.py
@@ -21,7 +21,7 @@ class MiSignalTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -58,7 +58,7 @@ class MiSignalTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run with stop-at-entry flag
@@ -93,7 +93,7 @@ class MiSignalTestCase(lldbmi_testcase.MiTestCaseBase):
         import random
         port = 12000 + random.randint(0,3999) # the same as GdbRemoteTestCaseBase.get_next_port
         import pexpect
-        debugserver_child = pexpect.spawn("%s %s:%d" % (debugserver_exe, hostname, port))
+        debugserver_child = pexpect.spawn("{0!s} {1!s}:{2:d}".format(debugserver_exe, hostname, port))
         self.addTearDownHook(lambda: debugserver_child.terminate(force = True))
 
         self.spawnLldbMi(args = None)
@@ -101,9 +101,9 @@ class MiSignalTestCase(lldbmi_testcase.MiTestCaseBase):
         # Connect to debugserver
         self.runCmd("-interpreter-exec command \"platform select remote-macosx --sysroot /\"")
         self.expect("\^done")
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
-        self.runCmd("-interpreter-exec command \"process connect connect://%s:%d\"" % (hostname, port))
+        self.runCmd("-interpreter-exec command \"process connect connect://{0!s}:{1:d}\"".format(hostname, port))
         self.expect("\^done")
 
         # Run with stop-at-entry flag
@@ -126,7 +126,7 @@ class MiSignalTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -162,7 +162,7 @@ class MiSignalTestCase(lldbmi_testcase.MiTestCaseBase):
         import random
         port = 12000 + random.randint(0,3999) # the same as GdbRemoteTestCaseBase.get_next_port
         import pexpect
-        debugserver_child = pexpect.spawn("%s %s:%d" % (debugserver_exe, hostname, port))
+        debugserver_child = pexpect.spawn("{0!s} {1!s}:{2:d}".format(debugserver_exe, hostname, port))
         self.addTearDownHook(lambda: debugserver_child.terminate(force = True))
 
         self.spawnLldbMi(args = None)
@@ -170,9 +170,9 @@ class MiSignalTestCase(lldbmi_testcase.MiTestCaseBase):
         # Connect to debugserver
         self.runCmd("-interpreter-exec command \"platform select remote-macosx --sysroot /\"")
         self.expect("\^done")
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
-        self.runCmd("-interpreter-exec command \"process connect connect://%s:%d\"" % (hostname, port))
+        self.runCmd("-interpreter-exec command \"process connect connect://{0!s}:{1:d}\"".format(hostname, port))
         self.expect("\^done")
 
         # Run to main

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/stack/TestMiStack.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/stack/TestMiStack.py
@@ -21,7 +21,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -82,7 +82,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -95,7 +95,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test int local variables:
         # Run to BP_local_int_test
         line = line_number('main.cpp', '// BP_local_int_test')
-        self.runCmd("-break-insert --file main.cpp:%d" % line)
+        self.runCmd("-break-insert --file main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"2\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -122,7 +122,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test struct local variable:
         # Run to BP_local_struct_test
         line = line_number('main.cpp', '// BP_local_struct_test')
-        self.runCmd("-break-insert --file main.cpp:%d" % line)
+        self.runCmd("-break-insert --file main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"3\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -149,7 +149,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test array local variable:
         # Run to BP_local_array_test
         line = line_number('main.cpp', '// BP_local_array_test')
-        self.runCmd("-break-insert --file main.cpp:%d" % line)
+        self.runCmd("-break-insert --file main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"4\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -176,7 +176,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test pointers as local variable:
         # Run to BP_local_pointer_test
         line = line_number('main.cpp', '// BP_local_pointer_test')
-        self.runCmd("-break-insert --file main.cpp:%d" % line)
+        self.runCmd("-break-insert --file main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"5\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -208,7 +208,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -221,7 +221,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test int local variables:
         # Run to BP_local_int_test
         line = line_number('main.cpp', '// BP_local_int_test_with_args')
-        self.runCmd("-break-insert --file main.cpp:%d" % line)
+        self.runCmd("-break-insert --file main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"2\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -248,7 +248,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test struct local variable:
         # Run to BP_local_struct_test
         line = line_number('main.cpp', '// BP_local_struct_test_with_args')
-        self.runCmd("-break-insert --file main.cpp:%d" % line)
+        self.runCmd("-break-insert --file main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"3\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -275,7 +275,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test array local variable:
         # Run to BP_local_array_test
         line = line_number('main.cpp', '// BP_local_array_test_with_args')
-        self.runCmd("-break-insert --file main.cpp:%d" % line)
+        self.runCmd("-break-insert --file main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"4\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -302,7 +302,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test pointers as local variable:
         # Run to BP_local_pointer_test
         line = line_number('main.cpp', '// BP_local_pointer_test_with_args')
-        self.runCmd("-break-insert --file main.cpp:%d" % line)
+        self.runCmd("-break-insert --file main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"5\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -334,7 +334,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -372,7 +372,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         self.expect("\^error,msg=\"Command 'stack-info-frame'\. Invalid process during debug session\"")
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -407,7 +407,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -429,7 +429,7 @@ class MiStackTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/startup_options/TestMiStartupOptions.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/startup_options/TestMiStartupOptions.py
@@ -18,10 +18,10 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
     def test_lldbmi_executable_option_file(self):
         """Test that 'lldb-mi --interpreter %s' loads executable file."""
 
-        self.spawnLldbMi(args = "%s" % self.myexe)
+        self.spawnLldbMi(args = "{0!s}".format(self.myexe))
 
         # Test that the executable is loaded when file was specified
-        self.expect("-file-exec-and-symbols \"%s\"" % self.myexe)
+        self.expect("-file-exec-and-symbols \"{0!s}\"".format(self.myexe))
         self.expect("\^done")
 
         # Test that lldb-mi is ready when executable was loaded
@@ -47,11 +47,11 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         # Prepare path to executable
         path = "unknown_file"
 
-        self.spawnLldbMi(args = "%s" % path)
+        self.spawnLldbMi(args = "{0!s}".format(path))
 
         # Test that the executable isn't loaded when unknown file was specified
-        self.expect("-file-exec-and-symbols \"%s\"" % path)
-        self.expect("\^error,msg=\"Command 'file-exec-and-symbols'. Target binary '%s' is invalid. error: unable to find executable for '%s'\"" % (path, path))
+        self.expect("-file-exec-and-symbols \"{0!s}\"".format(path))
+        self.expect("\^error,msg=\"Command 'file-exec-and-symbols'. Target binary '{0!s}' is invalid. error: unable to find executable for '{1!s}'\"".format(path, path))
 
         # Test that lldb-mi is ready when executable was loaded
         self.expect(self.child_prompt, exactly = True)
@@ -65,10 +65,10 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         import os
         path = os.path.join(os.getcwd(), self.myexe)
 
-        self.spawnLldbMi(args = "%s" % path)
+        self.spawnLldbMi(args = "{0!s}".format(path))
 
         # Test that the executable is loaded when file was specified using absolute path
-        self.expect("-file-exec-and-symbols \"%s\"" % path)
+        self.expect("-file-exec-and-symbols \"{0!s}\"".format(path))
         self.expect("\^done")
 
         # Test that lldb-mi is ready when executable was loaded
@@ -85,12 +85,12 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         """Test that 'lldb-mi --interpreter %s' loads executable which is specified via relative path."""
 
         # Prepare path to executable
-        path = "./%s" % self.myexe
+        path = "./{0!s}".format(self.myexe)
 
-        self.spawnLldbMi(args = "%s" % path)
+        self.spawnLldbMi(args = "{0!s}".format(path))
 
         # Test that the executable is loaded when file was specified using relative path
-        self.expect("-file-exec-and-symbols \"%s\"" % path)
+        self.expect("-file-exec-and-symbols \"{0!s}\"".format(path))
         self.expect("\^done")
 
         # Test that lldb-mi is ready when executable was loaded
@@ -107,13 +107,13 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         """Test that 'lldb-mi --interpreter %s' fails on executable file which is specified via unknown path."""
 
         # Prepare path to executable
-        path = "unknown_dir/%s" % self.myexe
+        path = "unknown_dir/{0!s}".format(self.myexe)
 
-        self.spawnLldbMi(args = "%s" % path)
+        self.spawnLldbMi(args = "{0!s}".format(path))
 
         # Test that the executable isn't loaded when file was specified using unknown path
-        self.expect("-file-exec-and-symbols \"%s\"" % path)
-        self.expect("\^error,msg=\"Command 'file-exec-and-symbols'. Target binary '%s' is invalid. error: unable to find executable for '%s'\"" % (path, path))
+        self.expect("-file-exec-and-symbols \"{0!s}\"".format(path))
+        self.expect("\^error,msg=\"Command 'file-exec-and-symbols'. Target binary '{0!s}' is invalid. error: unable to find executable for '{1!s}'\"".format(path, path))
 
         # Test that lldb-mi is ready when executable was loaded
         self.expect(self.child_prompt, exactly = True)
@@ -127,10 +127,10 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         # Prepared source file
         sourceFile = "start_script"
 
-        self.spawnLldbMi(args = "--source %s" % sourceFile)
+        self.spawnLldbMi(args = "--source {0!s}".format(sourceFile))
 
         # After '-file-exec-and-symbols a.out'
-        self.expect("-file-exec-and-symbols %s" % self.myexe)
+        self.expect("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # After '-break-insert -f main'
@@ -144,7 +144,7 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # After '-break-insert main.cpp:BP_return'
         line = line_number('main.cpp', '//BP_return')
-        self.expect("-break-insert main.cpp:%d" % line)
+        self.expect("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"2\"")
 
         # After '-exec-continue'
@@ -169,10 +169,10 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         # Prepared source file
         sourceFile = "start_script_exit"
 
-        self.spawnLldbMi(args = "--source %s" % sourceFile)
+        self.spawnLldbMi(args = "--source {0!s}".format(sourceFile))
 
         # After '-file-exec-and-symbols a.out'
-        self.expect("-file-exec-and-symbols %s" % self.myexe)
+        self.expect("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # After '-break-insert -f main'
@@ -186,7 +186,7 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # After '-break-insert main.cpp:BP_return'
         line = line_number('main.cpp', '//BP_return')
-        self.expect("-break-insert main.cpp:%d" % line)
+        self.expect("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"2\"")
 
         # After '-exec-continue'
@@ -211,10 +211,10 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         # Prepared source file
         sourceFile = "start_script_error"
 
-        self.spawnLldbMi(args = "--source %s" % sourceFile)
+        self.spawnLldbMi(args = "--source {0!s}".format(sourceFile))
 
         # After '-file-exec-and-symbols a.out'
-        self.expect("-file-exec-and-symbols %s" % self.myexe)
+        self.expect("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # After '-break-ins -f main'
@@ -230,10 +230,10 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         """Test that 'lldb-mi --log' creates a log file in the current directory."""
     
         logDirectory = "."
-        self.spawnLldbMi(args = "%s --log" % self.myexe)
+        self.spawnLldbMi(args = "{0!s} --log".format(self.myexe))
 
         # Test that the executable is loaded when file was specified
-        self.expect("-file-exec-and-symbols \"%s\"" % self.myexe)
+        self.expect("-file-exec-and-symbols \"{0!s}\"".format(self.myexe))
         self.expect("\^done")
 
         # Test that lldb-mi is ready when executable was loaded
@@ -264,10 +264,10 @@ class MiStartupOptionsTestCase(lldbmi_testcase.MiTestCaseBase):
         import tempfile
         logDirectory = tempfile.gettempdir()
 
-        self.spawnLldbMi(args = "%s --log --log-dir=%s" % (self.myexe,logDirectory))
+        self.spawnLldbMi(args = "{0!s} --log --log-dir={1!s}".format(self.myexe, logDirectory))
 
         # Test that the executable is loaded when file was specified
-        self.expect("-file-exec-and-symbols \"%s\"" % self.myexe)
+        self.expect("-file-exec-and-symbols \"{0!s}\"".format(self.myexe))
         self.expect("\^done")
 
         # Test that lldb-mi is ready when executable was loaded

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/symbol/TestMiSymbol.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/symbol/TestMiSymbol.py
@@ -22,7 +22,7 @@ class MiSymbolTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -40,7 +40,7 @@ class MiSymbolTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Test that -symbol-list-lines works on valid data
         self.runCmd("-symbol-list-lines main.cpp")
-        self.expect("\^done,lines=\[\{pc=\"0x0*%x\",line=\"%d\"\}(,\{pc=\"0x[0-9a-f]+\",line=\"\d+\"\})+\]" % (addr, line))
+        self.expect("\^done,lines=\[\{{pc=\"0x0*{0:x}\",line=\"{1:d}\"\}}(,\{{pc=\"0x[0-9a-f]+\",line=\"\d+\"\}})+\]".format(addr, line))
 
         # Test that -symbol-list-lines doesn't include lines from other sources
         # by checking the first and last line, and making sure the other lines
@@ -48,7 +48,7 @@ class MiSymbolTestCase(lldbmi_testcase.MiTestCaseBase):
         sline = line_number('symbol_list_lines_inline_test2.cpp', '// FUNC_gfunc2')
         eline = line_number('symbol_list_lines_inline_test2.cpp', '// END_gfunc2')
         self.runCmd("-symbol-list-lines symbol_list_lines_inline_test2.cpp")
-        self.expect("\^done,lines=\[\{pc=\"0x[0-9a-f]+\",line=\"%d\"\}(,\{pc=\"0x[0-9a-f]+\",line=\"3\d\"\})*,\{pc=\"0x[0-9a-f]+\",line=\"%d\"\}(,\{pc=\"0x[0-9a-f]+\",line=\"3\d\"\})*\]" % (sline, eline))
+        self.expect("\^done,lines=\[\{{pc=\"0x[0-9a-f]+\",line=\"{0:d}\"\}}(,\{{pc=\"0x[0-9a-f]+\",line=\"3\d\"\}})*,\{{pc=\"0x[0-9a-f]+\",line=\"{1:d}\"\}}(,\{{pc=\"0x[0-9a-f]+\",line=\"3\d\"\}})*\]".format(sline, eline))
         ##FIXME: This doesn't work for symbol_list_lines_inline_test.cpp due to clang bug llvm.org/pr24716 (fixed in newer versions of clang)
         ##sline = line_number('symbol_list_lines_inline_test.cpp', '// FUNC_gfunc')
         ##eline = line_number('symbol_list_lines_inline_test.cpp', '// STRUCT_s')
@@ -60,7 +60,7 @@ class MiSymbolTestCase(lldbmi_testcase.MiTestCaseBase):
         sline = line_number('symbol_list_lines_inline_test.h', '// FUNC_ifunc')
         eline = line_number('symbol_list_lines_inline_test.h', '// FUNC_mfunc')
         self.runCmd("-symbol-list-lines symbol_list_lines_inline_test.h")
-        self.expect("\^done,lines=\[\{pc=\"0x[0-9a-f]+\",line=\"%d\"\}(,\{pc=\"0x[0-9a-f]+\",line=\"\d\"\})*(,\{pc=\"0x[0-9a-f]+\",line=\"1\d\"\})*,\{pc=\"0x[0-9a-f]+\",line=\"%d\"\}(,\{pc=\"0x[0-9a-f]+\",line=\"2\d\"\})*\]" % (sline, eline))
+        self.expect("\^done,lines=\[\{{pc=\"0x[0-9a-f]+\",line=\"{0:d}\"\}}(,\{{pc=\"0x[0-9a-f]+\",line=\"\d\"\}})*(,\{{pc=\"0x[0-9a-f]+\",line=\"1\d\"\}})*,\{{pc=\"0x[0-9a-f]+\",line=\"{1:d}\"\}}(,\{{pc=\"0x[0-9a-f]+\",line=\"2\d\"\}})*\]".format(sline, eline))
 
         # Test that -symbol-list-lines fails when file doesn't exist
         self.runCmd("-symbol-list-lines unknown_file")
@@ -73,8 +73,8 @@ class MiSymbolTestCase(lldbmi_testcase.MiTestCaseBase):
         # Test that -symbol-list-lines works when file is specified using absolute path
         import os
         path = os.path.join(os.getcwd(), "main.cpp")
-        self.runCmd("-symbol-list-lines \"%s\"" % path)
-        self.expect("\^done,lines=\[\{pc=\"0x0*%x\",line=\"%d\"\}(,\{pc=\"0x[0-9a-f]+\",line=\"\d+\"\})+\]" % (addr, line))
+        self.runCmd("-symbol-list-lines \"{0!s}\"".format(path))
+        self.expect("\^done,lines=\[\{{pc=\"0x0*{0:x}\",line=\"{1:d}\"\}}(,\{{pc=\"0x[0-9a-f]+\",line=\"\d+\"\}})+\]".format(addr, line))
 
         # Test that -symbol-list-lines fails when file doesn't exist
         self.runCmd("-symbol-list-lines unknown_dir/main.cpp")

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/syntax/TestMiSyntax.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/syntax/TestMiSyntax.py
@@ -21,7 +21,7 @@ class MiSyntaxTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("000-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("000-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("000\^done")
 
         # Run to main
@@ -50,10 +50,10 @@ class MiSyntaxTestCase(lldbmi_testcase.MiTestCaseBase):
         os.symlink(self.myexe, complicated_myexe)
         self.addTearDownHook(lambda: os.unlink(complicated_myexe))
 
-        self.spawnLldbMi(args = "\"%s\"" % complicated_myexe)
+        self.spawnLldbMi(args = "\"{0!s}\"".format(complicated_myexe))
 
         # Test that the executable was loaded
-        self.expect("-file-exec-and-symbols \"%s\"" % complicated_myexe, exactly = True)
+        self.expect("-file-exec-and-symbols \"{0!s}\"".format(complicated_myexe), exactly = True)
         self.expect("\^done")
 
         # Check that it was loaded correctly
@@ -72,7 +72,7 @@ class MiSyntaxTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/target/TestMiTarget.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/target/TestMiTarget.py
@@ -29,11 +29,11 @@ class MiTargetTestCase(lldbmi_testcase.MiTestCaseBase):
         
         # Load executable
         # FIXME: -file-exec-and-sybmols is not required for target attach, but the test will not pass without this
-        self.runCmd("-file-exec-and-symbols %s" % exeName)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(exeName))
         self.expect("\^done")
         
         # Set up attach
-        self.runCmd("-target-attach -n %s --waitfor" % exeName)
+        self.runCmd("-target-attach -n {0!s} --waitfor".format(exeName))
         time.sleep(4) # Give attach time to setup
               
         # Start target process
@@ -43,7 +43,7 @@ class MiTargetTestCase(lldbmi_testcase.MiTestCaseBase):
         
         # Set breakpoint on printf
         line = line_number('test_attach.cpp', '// BP_i++')
-        self.runCmd("-break-insert -f test_attach.cpp:%d" % line)
+        self.runCmd("-break-insert -f test_attach.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         
         # Continue to breakpoint
@@ -73,12 +73,12 @@ class MiTargetTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
         
         # Set up atatch
-        self.runCmd("-target-attach -n %s" % exeName)
+        self.runCmd("-target-attach -n {0!s}".format(exeName))
         self.expect("\^done")
         
         # Set breakpoint on printf
         line = line_number('test_attach.cpp', '// BP_i++')
-        self.runCmd("-break-insert -f test_attach.cpp:%d" % line)
+        self.runCmd("-break-insert -f test_attach.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         
         # Continue to breakpoint
@@ -108,12 +108,12 @@ class MiTargetTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
         
         # Set up atatch
-        self.runCmd("-target-attach %d" % targetProcess.pid)
+        self.runCmd("-target-attach {0:d}".format(targetProcess.pid))
         self.expect("\^done")
         
         # Set breakpoint on printf
         line = line_number('test_attach.cpp', '// BP_i++')
-        self.runCmd("-break-insert -f test_attach.cpp:%d" % line)
+        self.runCmd("-break-insert -f test_attach.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         
         # Continue to breakpoint

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/variable/TestMiGdbSetShowPrint.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/variable/TestMiGdbSetShowPrint.py
@@ -16,14 +16,14 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
 
     # evaluates array when char-array-as-string is off
     def eval_and_check_array(self, var, typ, length):
-        self.runCmd("-var-create - * %s" % var)
-        self.expect('\^done,name="var\d+",numchild="%d",value="\[%d\]",type="%s \[%d\]",thread-id="1",has_more="0"' % (length, length, typ, length))
+        self.runCmd("-var-create - * {0!s}".format(var))
+        self.expect('\^done,name="var\d+",numchild="{0:d}",value="\[{1:d}\]",type="{2!s} \[{3:d}\]",thread-id="1",has_more="0"'.format(length, length, typ, length))
 
     # evaluates any type which can be represented as string of characters
     def eval_and_match_string(self, var, value, typ):
         value=value.replace("\\", "\\\\").replace("\"", "\\\"")
         self.runCmd("-var-create - * " + var)
-        self.expect('\^done,name="var\d+",numchild="[0-9]+",value="%s",type="%s",thread-id="1",has_more="0"' % (value, typ))
+        self.expect('\^done,name="var\d+",numchild="[0-9]+",value="{0!s}",type="{1!s}",thread-id="1",has_more="0"'.format(value, typ))
 
     @skipIfWindows #llvm.org/pr24452: Get lldb-mi working on Windows
     @skipIfFreeBSD # llvm.org/pr22411: Failure presumably due to known thread races
@@ -34,12 +34,12 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to BP_gdb_set_show_print_char_array_as_string_test
         line = line_number('main.cpp', '// BP_gdb_set_show_print_char_array_as_string_test')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")
@@ -116,12 +116,12 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to BP_gdb_set_show_print_expand_aggregates
         line = line_number('main.cpp', '// BP_gdb_set_show_print_expand_aggregates')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")
@@ -175,12 +175,12 @@ class MiGdbSetShowTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to BP_gdb_set_show_print_aggregate_field_names
         line = line_number('main.cpp', '// BP_gdb_set_show_print_aggregate_field_names')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")

--- a/packages/Python/lldbsuite/test/tools/lldb-mi/variable/TestMiVar.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-mi/variable/TestMiVar.py
@@ -21,12 +21,12 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to program return
         line = line_number('main.cpp', '// BP_return')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")
@@ -115,11 +115,11 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Print argument "argv[0]"
         self.runCmd("-data-evaluate-expression \"argv[0]\"")
-        self.expect("\^done,value=\"0x[0-9a-f]+ \\\\\\\".*?%s\\\\\\\"\"" % self.myexe)
+        self.expect("\^done,value=\"0x[0-9a-f]+ \\\\\\\".*?{0!s}\\\\\\\"\"".format(self.myexe))
         self.runCmd("-var-create var6 * \"argv[0]\"")
-        self.expect("\^done,name=\"var6\",numchild=\"1\",value=\"0x[0-9a-f]+ \\\\\\\".*?%s\\\\\\\"\",type=\"const char \*\",thread-id=\"1\",has_more=\"0\"" % self.myexe)
+        self.expect("\^done,name=\"var6\",numchild=\"1\",value=\"0x[0-9a-f]+ \\\\\\\".*?{0!s}\\\\\\\"\",type=\"const char \*\",thread-id=\"1\",has_more=\"0\"".format(self.myexe))
         self.runCmd("-var-evaluate-expression var6")
-        self.expect("\^done,value=\"0x[0-9a-f]+ \\\\\\\".*?%s\\\\\\\"\"" % self.myexe)
+        self.expect("\^done,value=\"0x[0-9a-f]+ \\\\\\\".*?{0!s}\\\\\\\"\"".format(self.myexe))
         self.runCmd("-var-show-attributes var6")
         self.expect("\^done,status=\"editable\"")
         self.runCmd("-var-list-children --all-values var6")
@@ -135,12 +135,12 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to BP_var_update_test_init
         line = line_number('main.cpp', '// BP_var_update_test_init')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")
@@ -156,7 +156,7 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Go to BP_var_update_test_l
         line = line_number('main.cpp', '// BP_var_update_test_l')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"2\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -168,7 +168,7 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Go to BP_var_update_test_complx
         line = line_number('main.cpp', '// BP_var_update_test_complx')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"3\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -180,7 +180,7 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
 
         # Go to BP_var_update_test_complx_array
         line = line_number('main.cpp', '// BP_var_update_test_complx_array')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"4\"")
         self.runCmd("-exec-continue")
         self.expect("\^running")
@@ -198,7 +198,7 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to main
@@ -217,7 +217,7 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
         # Note that message is different in Darwin and Linux:
         # Darwin: "^done,name=\"var_reg\",numchild=\"0\",value=\"0x[0-9a-f]+\",type=\"unsigned long\",thread-id=\"1\",has_more=\"0\"
         # Linux:  "^done,name=\"var_reg\",numchild=\"0\",value=\"0x[0-9a-f]+\",type=\"unsigned int\",thread-id=\"1\",has_more=\"0\"
-        self.runCmd("-var-create var_reg * $%s" % register_name)
+        self.runCmd("-var-create var_reg * ${0!s}".format(register_name))
         self.expect("\^done,name=\"var_reg\",numchild=\"0\",value=\"0x[0-9a-f]+\",type=\"unsigned (long|int)\",thread-id=\"1\",has_more=\"0\"")
 
         # Assign value to variable
@@ -238,12 +238,12 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to BP_var_list_children_test
         line = line_number('main.cpp', '// BP_var_list_children_test')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")
@@ -339,12 +339,12 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to BP_gdb_set_show_print_char_array_as_string_test
         line = line_number('main.cpp', '// BP_cpp_stl_types_test')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")
@@ -363,12 +363,12 @@ class MiVarTestCase(lldbmi_testcase.MiTestCaseBase):
         self.spawnLldbMi(args = None)
 
         # Load executable
-        self.runCmd("-file-exec-and-symbols %s" % self.myexe)
+        self.runCmd("-file-exec-and-symbols {0!s}".format(self.myexe))
         self.expect("\^done")
 
         # Run to breakpoint
         line = line_number('main.cpp', '// BP_unnamed_objects_test')
-        self.runCmd("-break-insert main.cpp:%d" % line)
+        self.runCmd("-break-insert main.cpp:{0:d}".format(line))
         self.expect("\^done,bkpt={number=\"1\"")
         self.runCmd("-exec-run")
         self.expect("\^running")

--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestGDBRemoteMemoryRead.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestGDBRemoteMemoryRead.py
@@ -34,8 +34,8 @@ class MemoryReadTestCase(TestBase):
             error = lldb.SBError()
             memory = process.ReadMemory(pc, size, error)
             self.assertTrue(error.Success())
-            self.match("process plugin packet send x%x,%x" % (pc, size), ["response:", memory])
-            self.match("process plugin packet send m%x,%x" % (pc, size), ["response:", binascii.hexlify(memory)])
+            self.match("process plugin packet send x{0:x},{1:x}".format(pc, size), ["response:", memory])
+            self.match("process plugin packet send m{0:x},{1:x}".format(pc, size), ["response:", binascii.hexlify(memory)])
 
         process.Continue()
         self.assertEqual(process.GetState(), lldb.eStateExited, "Process exited")

--- a/packages/Python/lldbsuite/test/tools/lldb-server/TestLldbGdbServer.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/TestLldbGdbServer.py
@@ -103,7 +103,7 @@ class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         remote_file_spec = lldb.SBFileSpec(remote_path, False)
         err = lldb.remote_platform.Install(lldb.SBFileSpec(exe_path, True), remote_file_spec)
         if err.Fail():
-            raise Exception("remote_platform.Install('%s', '%s') failed: %s" % (exe_path, remote_path, err))
+            raise Exception("remote_platform.Install('{0!s}', '{1!s}') failed: {2!s}".format(exe_path, remote_path, err))
         return [remote_path]
 
     def start_inferior(self):
@@ -114,7 +114,7 @@ class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         self.add_no_ack_remote_stream()
         self.test_sequence.add_log_lines(
-            ["read packet: %s" % lldbgdbserverutils.build_gdbremote_A_packet(launch_args),
+            ["read packet: {0!s}".format(lldbgdbserverutils.build_gdbremote_A_packet(launch_args)),
              "send packet: $OK#9a"],
             True)
         self.expect_gdbremote_sequence()
@@ -167,7 +167,7 @@ class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
         RETVAL = 42
 
         # build launch args
-        launch_args += ["retval:%d" % RETVAL]
+        launch_args += ["retval:{0:d}".format(RETVAL)]
 
         self.add_no_ack_remote_stream()
         self.add_verified_launch_packets(launch_args)
@@ -857,7 +857,7 @@ class LldbGdbServerTestCase(gdbremote_testcase.GdbRemoteTestCaseBase):
 
         # Start up the inferior.
         procs = self.prep_debug_monitor_and_inferior(
-            inferior_args=["set-message:%s" % MEMORY_CONTENTS, "get-data-address-hex:g_message", "sleep:5"])
+            inferior_args=["set-message:{0!s}".format(MEMORY_CONTENTS), "get-data-address-hex:g_message", "sleep:5"])
 
         # Run the process
         self.test_sequence.add_log_lines(

--- a/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/gdbremote_testcase.py
@@ -153,12 +153,12 @@ class GdbRemoteTestCaseBase(TestBase):
         shell_cmd = lldb.SBPlatformShellCommand(cmd)
         err = platform.Run(shell_cmd)
         if err.Fail() or shell_cmd.GetStatus():
-            m = "remote_platform.RunShellCommand('%s') failed:\n" % cmd
-            m += ">>> return code: %d\n" % shell_cmd.GetStatus()
+            m = "remote_platform.RunShellCommand('{0!s}') failed:\n".format(cmd)
+            m += ">>> return code: {0:d}\n".format(shell_cmd.GetStatus())
             if err.Fail():
-                m += ">>> %s\n" % str(err).strip()
-            m += ">>> %s\n" % (shell_cmd.GetOutput() or
-                               "Command generated no output.")
+                m += ">>> {0!s}\n".format(str(err).strip())
+            m += ">>> {0!s}\n".format((shell_cmd.GetOutput() or
+                               "Command generated no output."))
             raise Exception(m)
         return shell_cmd.GetOutput().strip()
 
@@ -171,7 +171,7 @@ class GdbRemoteTestCaseBase(TestBase):
             shell_stat = self.run_shell_cmd("cat /proc/$$/stat")
             # [pid] ([executable]) [state] [*ppid*]
             pid = re.match(r"^\d+ \(.+\) . (\d+)", shell_stat).group(1)
-            ls_output = self.run_shell_cmd("ls -l /proc/%s/exe" % pid)
+            ls_output = self.run_shell_cmd("ls -l /proc/{0!s}/exe".format(pid))
             exe = ls_output.split()[-1]
 
             # If the binary has been deleted, the link name has " (deleted)" appended.
@@ -205,9 +205,9 @@ class GdbRemoteTestCaseBase(TestBase):
     def forward_adb_port(self, source, target, direction, device):
         adb = [ 'adb' ] + ([ '-s', device ] if device else []) + [ direction ]
         def remove_port_forward():
-            subprocess.call(adb + [ "--remove", "tcp:%d" % source])
+            subprocess.call(adb + [ "--remove", "tcp:{0:d}".format(source)])
 
-        subprocess.call(adb + [ "tcp:%d" % source, "tcp:%d" % target])
+        subprocess.call(adb + [ "tcp:{0:d}".format(source), "tcp:{0:d}".format(target)])
         self.addTearDownHook(remove_port_forward)
 
     def create_socket(self):
@@ -254,7 +254,7 @@ class GdbRemoteTestCaseBase(TestBase):
             commandline_args = self.debug_monitor_extra_args + ["localhost:{}".format(self.port)]
 
         if attach_pid:
-            commandline_args += ["--attach=%d" % attach_pid]
+            commandline_args += ["--attach={0:d}".format(attach_pid)]
         if self.named_pipe_path:
             commandline_args += ["--named-pipe", self.named_pipe_path]
         return commandline_args
@@ -336,7 +336,7 @@ class GdbRemoteTestCaseBase(TestBase):
             server.terminate()
 
             # Increment attempts.
-            print("connect to debug monitor on port %d failed, attempt #%d of %d" % (self.port, attempts + 1, MAX_ATTEMPTS))
+            print("connect to debug monitor on port {0:d} failed, attempt #{1:d} of {2:d}".format(self.port, attempts + 1, MAX_ATTEMPTS))
             attempts += 1
 
             # And wait a random length of time before next attempt, to avoid collisions.
@@ -345,7 +345,7 @@ class GdbRemoteTestCaseBase(TestBase):
             # Now grab a new port number.
             self.port = self.get_next_port()
 
-        raise Exception("failed to create a socket to the launched debug monitor after %d tries" % attempts)
+        raise Exception("failed to create a socket to the launched debug monitor after {0:d} tries".format(attempts))
 
     def launch_process_for_attach(self, inferior_args=None, sleep_seconds=3, exe_path=None):
         # We're going to start a child process that the debug monitor stub can later attach to.
@@ -358,7 +358,7 @@ class GdbRemoteTestCaseBase(TestBase):
         if inferior_args:
             args.extend(inferior_args)
         if sleep_seconds:
-            args.append("sleep:%d" % sleep_seconds)
+            args.append("sleep:{0:d}".format(sleep_seconds))
 
         inferior = self.spawnSubprocess(exe_path, args)
         def shutdown_process_for_attach():
@@ -411,7 +411,7 @@ class GdbRemoteTestCaseBase(TestBase):
                 remote_file_spec = lldb.SBFileSpec(remote_path, False)
                 err = lldb.remote_platform.Install(lldb.SBFileSpec(inferior_exe_path, True), remote_file_spec)
                 if err.Fail():
-                    raise Exception("remote_platform.Install('%s', '%s') failed: %s" % (inferior_exe_path, remote_path, err))
+                    raise Exception("remote_platform.Install('{0!s}', '{1!s}') failed: {2!s}".format(inferior_exe_path, remote_path, err))
                 inferior_exe_path = remote_path
 
             launch_args = [inferior_exe_path]
@@ -479,7 +479,7 @@ class GdbRemoteTestCaseBase(TestBase):
 
     def add_verified_launch_packets(self, launch_args):
         self.test_sequence.add_log_lines(
-            ["read packet: %s" % build_gdbremote_A_packet(launch_args),
+            ["read packet: {0!s}".format(build_gdbremote_A_packet(launch_args)),
              "send packet: $OK#00",
              "read packet: $qLaunchSuccess#a5",
              "send packet: $OK#00"],
@@ -763,7 +763,7 @@ class GdbRemoteTestCaseBase(TestBase):
                 supported_dict[key] = supported_type 
             # Ensure we know the supported element
             if not key in self._KNOWN_QSUPPORTED_STUB_FEATURES:
-                raise Exception("unknown qSupported stub feature reported: %s" % key)
+                raise Exception("unknown qSupported stub feature reported: {0!s}".format(key))
 
         return supported_dict
 

--- a/packages/Python/lldbsuite/test/tools/lldb-server/lldbgdbserverutils.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/lldbgdbserverutils.py
@@ -584,7 +584,7 @@ class MultiResponseGdbRemoteEntry(GdbRemoteEntryBase):
 
         # Append the suffix as needed.
         if self._append_iteration_suffix:
-            payload += "%x" % self._iteration
+            payload += "{0:x}".format(self._iteration)
 
         # Keep track of the iteration.
         self._iteration += 1
@@ -623,8 +623,7 @@ class MultiResponseGdbRemoteEntry(GdbRemoteEntryBase):
 
         # Check for a runaway response cycle.
         if len(context[self._save_key]) >= self._runaway_response_count:
-            raise Exception("runaway query/response cycle detected: %d responses captured so far. Last response: %s" %
-                (len(context[self._save_key]), context[self._save_key][-1]))
+            raise Exception("runaway query/response cycle detected: {0:d} responses captured so far. Last response: {1!s}".format(len(context[self._save_key]), context[self._save_key][-1]))
 
         # Flip the mode to send for generating the query.
         self._is_send_to_remote = True
@@ -789,7 +788,7 @@ class GdbRemoteTestSequence(object):
                     capture = line.get("capture", None)
                     self.entries.append(MatchRemoteOutputEntry(regex=regex, regex_mode=regex_mode, capture=capture))
                 else:
-                    raise Exception("unknown entry type \"%s\"" % entry_type)
+                    raise Exception("unknown entry type \"{0!s}\"".format(entry_type))
 
 def process_is_running(pid, unknown_value=True):
     """If possible, validate that the given pid represents a running process on the local system.
@@ -810,7 +809,7 @@ def process_is_running(pid, unknown_value=True):
         return the value provided by the unknown_value arg.
     """
     if not isinstance(pid, six.integer_types):
-        raise Exception("pid must be an integral type (actual type: %s)" % str(type(pid)))
+        raise Exception("pid must be an integral type (actual type: {0!s})".format(str(type(pid))))
 
     process_ids = []
 

--- a/packages/Python/lldbsuite/test/tools/lldb-server/platform-process-connect/TestPlatformProcessConnect.py
+++ b/packages/Python/lldbsuite/test/tools/lldb-server/platform-process-connect/TestPlatformProcessConnect.py
@@ -19,13 +19,13 @@ class TestPlatformProcessConnect(gdbremote_testcase.GdbRemoteTestCaseBase):
         err = lldb.remote_platform.Put(lldb.SBFileSpec(os.path.join(os.getcwd(), "a.out")),
                                        lldb.SBFileSpec(os.path.join(working_dir, "a.out")))
         if err.Fail():
-            raise RuntimeError("Unable copy '%s' to '%s'.\n>>> %s" % (f, wd, err.GetCString()))
+            raise RuntimeError("Unable copy '{0!s}' to '{1!s}'.\n>>> {2!s}".format(f, wd, err.GetCString()))
 
-        port_file = "%s/port" % working_dir
-        commandline_args = ["platform", "--listen", "*:0", "--socket-file", port_file, "--", "%s/a.out" % working_dir, "foo"]
+        port_file = "{0!s}/port".format(working_dir)
+        commandline_args = ["platform", "--listen", "*:0", "--socket-file", port_file, "--", "{0!s}/a.out".format(working_dir), "foo"]
         self.spawnSubprocess(self.debug_monitor_exe, commandline_args, install_remote=False)
         self.addTearDownHook(self.cleanupSubprocesses)
-        new_port = self.run_shell_cmd("while [ ! -f %s ]; do sleep 0.25; done && cat %s" % (port_file, port_file))
+        new_port = self.run_shell_cmd("while [ ! -f {0!s} ]; do sleep 0.25; done && cat {1!s}".format(port_file, port_file))
 
         new_debugger = lldb.SBDebugger.Create()
         new_debugger.SetAsync(False)
@@ -38,10 +38,10 @@ class TestPlatformProcessConnect(gdbremote_testcase.GdbRemoteTestCaseBase):
         new_interpreter = new_debugger.GetCommandInterpreter()
 
         m = re.search("(.*):[0-9]+", configuration.lldb_platform_url)
-        command = "platform connect %s:%s" % (m.group(1), new_port)
+        command = "platform connect {0!s}:{1!s}".format(m.group(1), new_port)
         result = lldb.SBCommandReturnObject()
         new_interpreter.HandleCommand(command, result)
-        self.assertTrue(result.Succeeded(), "platform process connect failed: %s" % result.GetOutput())
+        self.assertTrue(result.Succeeded(), "platform process connect failed: {0!s}".format(result.GetOutput()))
 
         target = new_debugger.GetSelectedTarget()
         process = target.GetProcess()

--- a/packages/Python/lldbsuite/test/tracking.py
+++ b/packages/Python/lldbsuite/test/tracking.py
@@ -32,22 +32,22 @@ def find_session_dir():
     return os.path.join(os.getcwd(),session_dir)
 
 def process_no_bug(path,txt):
-    print 'Failure %s has no bug tracking (says %s) - why?' % (path,txt)
+    print 'Failure {0!s} has no bug tracking (says {1!s}) - why?'.format(path, txt)
 
 def process_llvm_bug(path,pr):
-    print 'Failure %s has an LLVM bug tracking: %s - why no radar?' % (path,pr.group(1))
+    print 'Failure {0!s} has an LLVM bug tracking: {1!s} - why no radar?'.format(path, pr.group(1))
 
 def process_radar_bug(path,rdr):
     rdr = get_radar_details(rdr.group(1))
     if not rdr:
-        print 'Failure %s claims to be tracked by rdar://%s but no such bug exists - consider filing one' % (path,rdr.group(1))
+        print 'Failure {0!s} claims to be tracked by rdar://{1!s} but no such bug exists - consider filing one'.format(path, rdr.group(1))
         return
-    print 'Failure %s has a radar bug tracking: rdar://%s %s - cool' % (path,rdr.id,rdr.title)
+    print 'Failure {0!s} has a radar bug tracking: rdar://{1!s} {2!s} - cool'.format(path, rdr.id, rdr.title)
     if rdr.state != 'Analyze':
         print 'This radar is not in Analyze anymore - Consider filing a new one, or editing the test case'
-    print '  Assignee: %s %s' % (rdr.assignee.firstName,rdr.assignee.lastName)
-    print '  Milestone: %s' % (rdr.milestone[u'name'] if rdr.milestone else 'None')
-    print '  Priority: %s' % (rdr.priority)
+    print '  Assignee: {0!s} {1!s}'.format(rdr.assignee.firstName, rdr.assignee.lastName)
+    print '  Milestone: {0!s}'.format((rdr.milestone[u'name'] if rdr.milestone else 'None'))
+    print '  Priority: {0!s}'.format((rdr.priority))
 
 global_radar_client = None
 

--- a/packages/Python/lldbsuite/test/types/AbstractBase.py
+++ b/packages/Python/lldbsuite/test/types/AbstractBase.py
@@ -11,8 +11,8 @@ from lldbsuite.test.lldbtest import *
 import lldbsuite.test.lldbutil as lldbutil
 
 def Msg(var, val, using_frame_variable):
-    return "'%s %s' matches the output (from compiled code): %s" % (
-        'frame variable --show-types' if using_frame_variable else 'expression' ,var, val)
+    return "'{0!s} {1!s}' matches the output (from compiled code): {2!s}".format(
+        'frame variable --show-types' if using_frame_variable else 'expression' , var, val)
 
 class GenericTester(TestBase):
 
@@ -93,7 +93,7 @@ class GenericTester(TestBase):
     def generic_type_tester(self, exe_name, atoms, quotedDisplay=False, blockCaptured=False):
         """Test that variables with basic types are displayed correctly."""
 
-        self.runCmd("file %s" % exe_name, CURRENT_EXECUTABLE_SET)
+        self.runCmd("file {0!s}".format(exe_name), CURRENT_EXECUTABLE_SET)
 
         # First, capture the golden output emitted by the oracle, i.e., the
         # series of printf statements.
@@ -138,7 +138,7 @@ class GenericTester(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("process status", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = [" at basic_type.cpp:%d" % break_line,
+            substrs = [" at basic_type.cpp:{0:d}".format(break_line),
                        "stop reason = breakpoint"])
 
         #self.runCmd("frame variable --show-types")
@@ -146,7 +146,7 @@ class GenericTester(TestBase):
         # Now iterate through the golden list, comparing against the output from
         # 'frame variable --show-types var'.
         for var, val in gl:
-            self.runCmd("frame variable --show-types %s" % var)
+            self.runCmd("frame variable --show-types {0!s}".format(var))
             output = self.res.GetOutput()
 
             # The input type is in a canonical form as a set of named atoms.
@@ -163,8 +163,7 @@ class GenericTester(TestBase):
 
             # Expect the display type string to contain each and every atoms.
             self.expect(dt,
-                        "Display type: '%s' must contain the type atoms: '%s'" %
-                        (dt, atoms),
+                        "Display type: '{0!s}' must contain the type atoms: '{1!s}'".format(dt, atoms),
                         exe=False,
                 substrs = list(atoms))
 
@@ -177,7 +176,7 @@ class GenericTester(TestBase):
     def generic_type_expr_tester(self, exe_name, atoms, quotedDisplay=False, blockCaptured=False):
         """Test that variable expressions with basic types are evaluated correctly."""
 
-        self.runCmd("file %s" % exe_name, CURRENT_EXECUTABLE_SET)
+        self.runCmd("file {0!s}".format(exe_name), CURRENT_EXECUTABLE_SET)
 
         # First, capture the golden output emitted by the oracle, i.e., the
         # series of printf statements.
@@ -222,7 +221,7 @@ class GenericTester(TestBase):
 
         self.runCmd("run", RUN_SUCCEEDED)
         self.expect("process status", STOPPED_DUE_TO_BREAKPOINT,
-            substrs = [" at basic_type.cpp:%d" % break_line,
+            substrs = [" at basic_type.cpp:{0:d}".format(break_line),
                        "stop reason = breakpoint"])
 
         #self.runCmd("frame variable --show-types")
@@ -230,7 +229,7 @@ class GenericTester(TestBase):
         # Now iterate through the golden list, comparing against the output from
         # 'expr var'.
         for var, val in gl:
-            self.runCmd("expression %s" % var)
+            self.runCmd("expression {0!s}".format(var))
             output = self.res.GetOutput()
 
             # The input type is in a canonical form as a set of named atoms.
@@ -247,8 +246,7 @@ class GenericTester(TestBase):
 
             # Expect the display type string to contain each and every atoms.
             self.expect(dt,
-                        "Display type: '%s' must contain the type atoms: '%s'" %
-                        (dt, atoms),
+                        "Display type: '{0!s}' must contain the type atoms: '{1!s}'".format(dt, atoms),
                         exe=False,
                 substrs = list(atoms))
 

--- a/packages/Python/lldbsuite/test/types/HideTestFailures.py
+++ b/packages/Python/lldbsuite/test/types/HideTestFailures.py
@@ -25,11 +25,11 @@ class DebugIntegerTypesFailures(TestBase):
         try:
             if "test_long_type_with_dsym" in self.id():
                 self.runCmd(
-                    "log enable -n -f %s lldb commands event process state" %
-                    os.environ["DEBUG_LLDB_LOG"])
+                    "log enable -n -f {0!s} lldb commands event process state".format(
+                    os.environ["DEBUG_LLDB_LOG"]))
                 self.runCmd(
-                    "log enable -n -f %s gdb-remote packets process" %
-                    os.environ["DEBUG_GDB_REMOTE_LOG"])
+                    "log enable -n -f {0!s} gdb-remote packets process".format(
+                    os.environ["DEBUG_GDB_REMOTE_LOG"]))
         except:
             pass
 

--- a/packages/Python/lldbsuite/test/warnings/uuid/TestAddDsymCommand.py
+++ b/packages/Python/lldbsuite/test/warnings/uuid/TestAddDsymCommand.py
@@ -66,7 +66,7 @@ class AddDsymCommandCase(TestBase):
             content = f.read()
 
         new_content = content.replace('%ADD_EXTRA_CODE%',
-                                      'printf("This is version %d\\n");' % version)
+                                      'printf("This is version {0:d}\\n");'.format(version))
         src = os.path.join(os.getcwd(), self.source)
         with open(src, 'w') as f:
             f.write(new_content)
@@ -80,11 +80,11 @@ class AddDsymCommandCase(TestBase):
         """Test that the 'add-dsym' command informs the user about failures."""
         self.runCmd("file " + exe_name, CURRENT_EXECUTABLE_SET)
 
-        wrong_path = os.path.join("%s.dSYM" % exe_name, "Contents")
+        wrong_path = os.path.join("{0!s}.dSYM".format(exe_name), "Contents")
         self.expect("add-dsym " + wrong_path, error=True,
             substrs = ['invalid module path'])
 
-        right_path = os.path.join("%s.dSYM" % exe_name, "Contents", "Resources", "DWARF", exe_name)
+        right_path = os.path.join("{0!s}.dSYM".format(exe_name), "Contents", "Resources", "DWARF", exe_name)
         self.expect("add-dsym " + right_path, error=True,
             substrs = ['symbol file', 'does not match'])
 
@@ -93,7 +93,7 @@ class AddDsymCommandCase(TestBase):
         self.runCmd("file " + exe_name, CURRENT_EXECUTABLE_SET)
 
         # This time, the UUID should match and we expect some feedback from lldb.
-        right_path = os.path.join("%s.dSYM" % exe_name, "Contents", "Resources", "DWARF", exe_name)
+        right_path = os.path.join("{0!s}.dSYM".format(exe_name), "Contents", "Resources", "DWARF", exe_name)
         self.expect("add-dsym " + right_path,
             substrs = ['symbol file', 'has been added to'])
 
@@ -102,6 +102,6 @@ class AddDsymCommandCase(TestBase):
         self.runCmd("file " + exe_name, CURRENT_EXECUTABLE_SET)
 
         # This time, the UUID should be found inside the bundle
-        right_path = "%s.dSYM" % exe_name
+        right_path = "{0!s}.dSYM".format(exe_name)
         self.expect("add-dsym " + right_path,
             substrs = ['symbol file', 'has been added to'])

--- a/packages/Python/lldbsuite/test/xunit_formatter.py
+++ b/packages/Python/lldbsuite/test/xunit_formatter.py
@@ -56,7 +56,7 @@ class XunitFormatter(ResultsFormatter):
 
         # Build up an array of range expressions.
         illegal_ranges = [
-            "%s-%s" % (six.unichr(low), six.unichr(high))
+            "{0!s}-{1!s}".format(six.unichr(low), six.unichr(high))
             for (low, high) in illegal_chars_u]
 
         # Compile the regex

--- a/scripts/Python/finishSwigPythonLLDB.py
+++ b/scripts/Python/finishSwigPythonLLDB.py
@@ -162,11 +162,11 @@ def create_py_pkg(vDictArgs, vstrFrameworkPythonDir, vstrPkgDir, vListPkgFiles):
             nPos = strBaseName.find(".")
             if nPos != -1:
                 strBaseName = strBaseName[0 : nPos]
-            strPyScript += "%s\"%s\"" % (strDelimiter, strBaseName)
+            strPyScript += "{0!s}\"{1!s}\"".format(strDelimiter, strBaseName)
             strDelimiter = ","
     strPyScript += "]\n"
     strPyScript += "for x in __all__:\n"
-    strPyScript += "\t__import__('%s.' + x)" % strPkgName
+    strPyScript += "\t__import__('{0!s}.' + x)".format(strPkgName)
 
     if bDbg:
         print((strMsgCreatePyPkgInitFile % strPkgIniFile))
@@ -207,9 +207,9 @@ def copy_lldbpy_file_to_lldb_pkg_dir(vDictArgs, vstrFrameworkPythonDir, vstrCfgB
         shutil.copyfile(strSrc, strDst)
     except IOError as e:
         bOk = False
-        strMsg = "I/O error(%d): %s %s" % (e.errno, e.strerror, strErrMsgCpLldbpy)
+        strMsg = "I/O error({0:d}): {1!s} {2!s}".format(e.errno, e.strerror, strErrMsgCpLldbpy)
         if e.errno == 2:
-            strMsg += " Src:'%s' Dst:'%s'" % (strSrc, strDst)
+            strMsg += " Src:'{0!s}' Dst:'{1!s}'".format(strSrc, strDst)
     except:
         bOk = False
         strMsg = strErrMsgUnexpected % sys.exec_info()[0]
@@ -225,7 +225,7 @@ def copy_lldbpy_file_to_lldb_pkg_dir(vDictArgs, vstrFrameworkPythonDir, vstrCfgB
 # Throws:   None.
 #--
 def make_symlink_windows(vstrSrcPath, vstrTargetPath):
-    print(("Making symlink from %s to %s" % (vstrSrcPath, vstrTargetPath)))
+    print(("Making symlink from {0!s} to {1!s}".format(vstrSrcPath, vstrTargetPath)))
     dbg = utilsDebug.CDebugFnVerbose("Python script make_symlink_windows()")
     bOk = True
     strErrMsg = ""
@@ -239,8 +239,8 @@ def make_symlink_windows(vstrSrcPath, vstrTargetPath):
     except Exception as e:
         if e.errno != 17:
             bOk = False
-            strErrMsg = "WinError(%d): %s %s" % (e.errno, e.strerror, strErrMsgMakeSymlink)
-            strErrMsg += " Src:'%s' Target:'%s'" % (vstrSrcPath, vstrTargetPath)
+            strErrMsg = "WinError({0:d}): {1!s} {2!s}".format(e.errno, e.strerror, strErrMsgMakeSymlink)
+            strErrMsg += " Src:'{0!s}' Target:'{1!s}'".format(vstrSrcPath, vstrTargetPath)
 
     return (bOk, strErrMsg)
 
@@ -261,8 +261,8 @@ def make_symlink_other_platforms(vstrSrcPath, vstrTargetPath):
         os.symlink(vstrSrcPath, vstrTargetPath)
     except OSError as e:
         bOk = False
-        strErrMsg = "OSError(%d): %s %s" % (e.errno, e.strerror, strErrMsgMakeSymlink)
-        strErrMsg += " Src:'%s' Target:'%s'" % (vstrSrcPath, vstrTargetPath)
+        strErrMsg = "OSError({0:d}): {1!s} {2!s}".format(e.errno, e.strerror, strErrMsgMakeSymlink)
+        strErrMsg += " Src:'{0!s}' Target:'{1!s}'".format(vstrSrcPath, vstrTargetPath)
     except:
         bOk = False
         strErrMsg = strErrMsgUnexpected % sys.exec_info()[0]

--- a/scripts/Python/modify-python-lldb.py
+++ b/scripts/Python/modify-python-lldb.py
@@ -74,7 +74,7 @@ def char_to_str_xform(line):
 #
 TWO_SPACES = ' ' * 2
 EIGHT_SPACES = ' ' * 8
-one_liner_docstring_pattern = re.compile('^(%s|%s)""".*"""$' % (TWO_SPACES, EIGHT_SPACES))
+one_liner_docstring_pattern = re.compile('^({0!s}|{1!s})""".*"""$'.format(TWO_SPACES, EIGHT_SPACES))
 
 #
 # lldb_helpers and lldb_iter() should appear before our first SB* class definition.

--- a/scripts/Python/prepare_binding_Python.py
+++ b/scripts/Python/prepare_binding_Python.py
@@ -200,17 +200,17 @@ def do_swig_rebuild(options, dependency_file, config_build_dir, settings):
         "-shadow",
         "-python",
         "-threads",
-        "-I\"%s\"" % os.path.normcase(
-            os.path.join(options.src_root, "include")),
-        "-I\"%s\"" % os.path.normcase("./."),
+        "-I\"{0!s}\"".format(os.path.normcase(
+            os.path.join(options.src_root, "include"))),
+        "-I\"{0!s}\"".format(os.path.normcase("./.")),
         "-D__STDC_LIMIT_MACROS",
         "-D__STDC_CONSTANT_MACROS"]
     if options.generate_dependency_file:
-        command.append("-MMD -MF \"%s\"" % temp_dep_file_path)
+        command.append("-MMD -MF \"{0!s}\"".format(temp_dep_file_path))
     command.extend([
-        "-outdir", "\"%s\"" % config_build_dir,
-        "-o", "\"%s\"" % settings.output_file,
-        "\"%s\"" % settings.input_file
+        "-outdir", "\"{0!s}\"".format(config_build_dir),
+        "-o", "\"{0!s}\"".format(settings.output_file),
+        "\"{0!s}\"".format(settings.input_file)
         ])
     logging.info("running swig with: %s", command)
 
@@ -344,7 +344,7 @@ def run_python_script(script_and_args):
     @param script_and_args the python script to execute, along with
     the command line arguments to pass to it.
     """
-    command_line = "%s %s" % (sys.executable, script_and_args)
+    command_line = "{0!s} {1!s}".format(sys.executable, script_and_args)
     process = subprocess.Popen(command_line, shell=True)
     script_stdout, script_stderr = process.communicate()
     return_code = process.returncode
@@ -374,7 +374,7 @@ def do_modify_python_lldb(options, config_build_dir):
         logging.error("failed to find python script: '%s'", script_path)
         sys.exit(-11)
 
-    script_invocation = "%s %s" % (script_path, config_build_dir)
+    script_invocation = "{0!s} {1!s}".format(script_path, config_build_dir)
     run_python_script(script_invocation)
 
 

--- a/scripts/Python/remote-build.py
+++ b/scripts/Python/remote-build.py
@@ -22,7 +22,7 @@ def normalize_configuration(config_text):
     if config_lower in ["debug", "release"]:
         return config_lower
     else:
-        raise Exception("unknown configuration specified: %s" % config_text)
+        raise Exception("unknown configuration specified: {0!s}".format(config_text))
 
 def parse_args():
     DEFAULT_REMOTE_ROOT_DIR = "/mnt/ssd/work/macosx.sync"
@@ -65,7 +65,7 @@ def parse_args():
     command_line_args = sys.argv[1:]
     if os.path.exists(OPTIONS_FILENAME):
         # Prepend the file so that command line args override the file contents.
-        command_line_args.insert(0, "@%s" % OPTIONS_FILENAME)
+        command_line_args.insert(0, "@{0!s}".format(OPTIONS_FILENAME))
 
     return parser.parse_args(command_line_args)
 
@@ -74,7 +74,7 @@ def maybe_create_remote_root_dir(args):
     commandline = [
         "ssh",
         "-p", args.port,
-        "%s@%s" % (args.user, args.remote_address),
+        "{0!s}@{1!s}".format(args.user, args.remote_address),
         "mkdir",
         "-p",
         args.remote_dir]
@@ -90,7 +90,7 @@ def init_with_args(args):
     args.configuration = normalize_configuration(args.configuration)
     args.remote_build_dir = os.path.join(
         args.remote_dir,
-        "build-%s" % args.configuration)
+        "build-{0!s}".format(args.configuration))
 
     # We assume the local lldb directory is really named 'lldb'.
     # This is because on the remote end, the local lldb root dir
@@ -102,15 +102,15 @@ def init_with_args(args):
             "local lldb root needs to be called 'lldb' but was {} instead"
             .format(os.path.basename(args.local_lldb_dir)))
 
-    args.lldb_dir_relative_regex = re.compile("%s/llvm/tools/lldb/" % args.remote_dir)
-    args.llvm_dir_relative_regex = re.compile("%s/" % args.remote_dir)
+    args.lldb_dir_relative_regex = re.compile("{0!s}/llvm/tools/lldb/".format(args.remote_dir))
+    args.llvm_dir_relative_regex = re.compile("{0!s}/".format(args.remote_dir))
 
     print("Xcode action:", args.xcode_action)
 
     # Ensure the remote directory exists.
     result = maybe_create_remote_root_dir(args)
     if result == 0:
-        print("using remote root dir: %s" % args.remote_dir)
+        print("using remote root dir: {0!s}".format(args.remote_dir))
     else:
         print("remote root dir doesn't exist and could not be created, "
               + "error code:", result)
@@ -125,8 +125,8 @@ def sync_llvm(args):
     commandline.append("--exclude=/llvm/tools/lldb")
     commandline.extend(["-e", "ssh -p {}".format(args.port)])
     commandline.extend([
-        "%s/llvm" % args.local_lldb_dir,
-        "%s@%s:%s" % (args.user, args.remote_address, args.remote_dir)])
+        "{0!s}/llvm".format(args.local_lldb_dir),
+        "{0!s}@{1!s}:{2!s}".format(args.user, args.remote_address, args.remote_dir)])
     if args.debug:
         print("going to execute llvm sync: {}".format(commandline))
     return subprocess.call(commandline)
@@ -140,7 +140,7 @@ def sync_lldb(args):
     commandline.extend(["-e", "ssh -p {}".format(args.port)])
     commandline.extend([
         args.local_lldb_dir,
-        "%s@%s:%s/llvm/tools" % (args.user, args.remote_address, args.remote_dir)])
+        "{0!s}@{1!s}:{2!s}/llvm/tools".format(args.user, args.remote_address, args.remote_dir)])
     if args.debug:
         print("going to execute lldb sync: {}".format(commandline))
     return subprocess.call(commandline)
@@ -168,10 +168,10 @@ def build_cmake_command(args):
         "-DCMAKE_CXX_COMPILER=clang",
         "-DCMAKE_C_COMPILER=clang",
         # "-DCMAKE_CXX_FLAGS=%s" % cxx_flags,
-        "-DCMAKE_SHARED_LINKER_FLAGS=%s" % ld_flags,
-        "-DCMAKE_EXE_LINKER_FLAGS=%s" % ld_flags,
-        "-DCMAKE_INSTALL_PREFIX:PATH=%s" % install_dir,
-        "-DCMAKE_BUILD_TYPE=%s" % build_type_name,
+        "-DCMAKE_SHARED_LINKER_FLAGS={0!s}".format(ld_flags),
+        "-DCMAKE_EXE_LINKER_FLAGS={0!s}".format(ld_flags),
+        "-DCMAKE_INSTALL_PREFIX:PATH={0!s}".format(install_dir),
+        "-DCMAKE_BUILD_TYPE={0!s}".format(build_type_name),
         "-Wno-dev",
         os.path.join("..", "llvm")
         ]
@@ -183,7 +183,7 @@ def maybe_configure(args):
     commandline = [
         "ssh",
         "-p", args.port,
-        "%s@%s" % (args.user, args.remote_address),
+        "{0!s}@{1!s}".format(args.user, args.remote_address),
         "cd", args.remote_dir, "&&",
         "mkdir", "-p", args.remote_build_dir, "&&",
         "cd", args.remote_build_dir, "&&"
@@ -211,7 +211,7 @@ def run_remote_build_command(args, build_command_list):
     commandline = [
         "ssh",
         "-p", args.port,
-        "%s@%s" % (args.user, args.remote_address),
+        "{0!s}@{1!s}".format(args.user, args.remote_address),
         "cd", args.remote_build_dir, "&&"]
     commandline.extend(build_command_list)
 

--- a/scripts/Python/static-binding/lldb.py
+++ b/scripts/Python/static-binding/lldb.py
@@ -67,7 +67,7 @@ def _swig_setattr_nondynamic(self,class_type,name,value,static=1):
     if (not static) or hasattr(self,name):
         self.__dict__[name] = value
     else:
-        raise AttributeError("You cannot add attributes to %s" % self)
+        raise AttributeError("You cannot add attributes to {0!s}".format(self))
 
 def _swig_setattr(self,class_type,name,value):
     return _swig_setattr_nondynamic(self,class_type,name,value,0)
@@ -81,7 +81,7 @@ def _swig_getattr(self,class_type,name):
 def _swig_repr(self):
     try: strthis = "proxy of " + self.this.__repr__()
     except: strthis = ""
-    return "<%s.%s; %s >" % (self.__class__.__module__, self.__class__.__name__, strthis,)
+    return "<{0!s}.{1!s}; {2!s} >".format(self.__class__.__module__, self.__class__.__name__, strthis)
 
 try:
     _object = object
@@ -954,11 +954,11 @@ class SBAddress(_object):
 
     def __oct__(self):
         '''Convert the address to an octal string'''
-        return '%o' % int(self)
+        return '{0:o}'.format(int(self))
 
     def __hex__(self):
         '''Convert the address to an hex string'''
-        return '0x%x' % int(self)
+        return '0x{0:x}'.format(int(self))
 
     __swig_getmethods__["module"] = GetModule
     if _newclass: module = property(GetModule, None, doc='''A read only property that returns an lldb object that represents the module (lldb.SBModule) that this address resides within.''')
@@ -1290,7 +1290,7 @@ class SBBlock(_object):
                 if range_idx < len(self):
                     return [self.sbblock.GetRangeStartAddress(range_idx), self.sbblock.GetRangeEndAddress(range_idx)]
             else:
-                print("error: unsupported item type: %s" % type(key))
+                print("error: unsupported item type: {0!s}".format(type(key)))
             return None
 
     def get_ranges_access_object(self):
@@ -4246,7 +4246,7 @@ class SBFileSpec(_object):
         spec_dir = self.GetDirectory()
         spec_file = self.GetFilename()
         if spec_dir and spec_file:
-            return '%s/%s' % (spec_dir, spec_file)
+            return '{0!s}/{1!s}'.format(spec_dir, spec_file)
         elif spec_dir:
             return spec_dir
         elif spec_file:
@@ -6061,7 +6061,7 @@ class SBModule(_object):
                                 matches.append(symbol)
                 return matches
             else:
-                print("error: unsupported item type: %s" % type(key))
+                print("error: unsupported item type: {0!s}".format(type(key)))
             return None
 
     def get_symbols_access_object(self):
@@ -6111,7 +6111,7 @@ class SBModule(_object):
                             matches.append(section)
                 return matches
             else:
-                print("error: unsupported item type: %s" % type(key))
+                print("error: unsupported item type: {0!s}".format(type(key)))
             return None
 
     class compile_units_access(object):
@@ -6151,7 +6151,7 @@ class SBModule(_object):
                             matches.append(comp_unit)
                 return matches
             else:
-                print("error: unsupported item type: %s" % type(key))
+                print("error: unsupported item type: {0!s}".format(type(key)))
             return None
 
     def get_sections_access_object(self):
@@ -9004,7 +9004,7 @@ class SBTarget(_object):
                         matching_modules.append(module)
                 return matching_modules
             else:
-                print("error: unsupported item type: %s" % type(key))
+                print("error: unsupported item type: {0!s}".format(type(key)))
             return None
 
     def get_modules_access_object(self):
@@ -10460,7 +10460,7 @@ class SBTypeCategory(_object):
             elif isinstance(key,self.regex_type):
                 return self.get_by_name_function(self.sbcategory,SBTypeNameSpecifier(key.pattern,True))
             else:
-                print("error: unsupported item type: %s" % type(key))
+                print("error: unsupported item type: {0!s}".format(type(key)))
             return None
 
     def get_formats_access_object(self):
@@ -12329,7 +12329,7 @@ def command(*args, **kwargs):
         def __init__(self, function, command_name, doc = None):
             if doc:
                 function.__doc__ = doc
-            command = "command script add -f %s.%s %s" % (function.__module__, function.__name__, command_name)
+            command = "command script add -f {0!s}.{1!s} {2!s}".format(function.__module__, function.__name__, command_name)
             lldb.debugger.HandleCommand(command)
             self.function = function
         def __call__(self, *args, **kwargs):
@@ -12392,11 +12392,11 @@ class value(object):
         if type(key) is value:
             key = int(key)
         if type(key) is int:
-            child_sbvalue = (self.sbvalue.GetValueForExpressionPath("[%i]" % key))
+            child_sbvalue = (self.sbvalue.GetValueForExpressionPath("[{0:d}]".format(key)))
             if child_sbvalue and child_sbvalue.IsValid():
                 return value(child_sbvalue)
-            raise IndexError("Index '%d' is out of range" % key)
-        raise TypeError("No array item of type %s" % str(type(key)))
+            raise IndexError("Index '{0:d}' is out of range".format(key))
+        raise TypeError("No array item of type {0!s}".format(str(type(key))))
 
     def __iter__(self):
         return value_iter(self.sbvalue)
@@ -12405,7 +12405,7 @@ class value(object):
         child_sbvalue = self.sbvalue.GetChildMemberWithName (name)
         if child_sbvalue and child_sbvalue.IsValid():
             return value(child_sbvalue)
-        raise AttributeError("Attribute '%s' is not defined" % name)
+        raise AttributeError("Attribute '{0!s}' is not defined".format(name))
 
     def __add__(self, other):
         return int(self) + int(other)
@@ -12544,10 +12544,10 @@ class value(object):
         return float (self.sbvalue.GetValueAsSigned())
         
     def __oct__(self):
-        return '0%o' % self.sbvalue.GetValueAsUnsigned()
+        return '0{0:o}'.format(self.sbvalue.GetValueAsUnsigned())
         
     def __hex__(self):
-        return '0x%x' % self.sbvalue.GetValueAsUnsigned()
+        return '0x{0:x}'.format(self.sbvalue.GetValueAsUnsigned())
 
     def __len__(self):
         return self.sbvalue.GetNumChildren()
@@ -12567,7 +12567,7 @@ class value(object):
                 if other_err.fail:
                         raise ValueError("unable to extract value of other")
                 return self_val == other_val
-        raise TypeError("Unknown type %s, No equality operation defined." % str(type(other)))
+        raise TypeError("Unknown type {0!s}, No equality operation defined.".format(str(type(other))))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/scripts/buildbot.py
+++ b/scripts/buildbot.py
@@ -17,11 +17,11 @@ class BuildError(Exception):
         self.m_inferior_error = inferior_error
     def __str__(self):
         if self.m_path and self.m_string:
-            return "Build error: %s (referring to %s)" % (self.m_string, self.m_path)
+            return "Build error: {0!s} (referring to {1!s})".format(self.m_string, self.m_path)
         if self.m_path:
-            return "Build error (referring to %s)" % (self.m_path)
+            return "Build error (referring to {0!s})".format((self.m_path))
         if self.m_string:
-            return "Build error: %s" % (self.m_string)
+            return "Build error: {0!s}".format((self.m_string))
         return "Build error"
 
 class LLDBBuildBot:
@@ -52,7 +52,7 @@ class LLDBBuildBot:
         cmdline_prefix = []
         
         if self.m_revision != None:
-            cmdline_prefix = ["svn", "-r %s" % (self.m_revision), "co"]
+            cmdline_prefix = ["svn", "-r {0!s}".format((self.m_revision)), "co"]
         else:
             cmdline_prefix = ["svn", "co"]
 

--- a/scripts/finishSwigWrapperClasses.py
+++ b/scripts/finishSwigWrapperClasses.py
@@ -96,7 +96,7 @@ def program_exit_success(vnResult, vMsg):
     strMsg = ""
 
     if vMsg.__len__() != 0:
-        strMsg = "%s: %s (%d)" % (strExitMsgSuccess, vMsg, vnResult)
+        strMsg = "{0!s}: {1!s} ({2:d})".format(strExitMsgSuccess, vMsg, vnResult)
         print(strMsg)
 
     sys.exit(vnResult)
@@ -110,7 +110,7 @@ def program_exit_success(vnResult, vMsg):
 # Throws:   None.
 #--
 def program_exit_on_failure(vnResult, vMsg):
-    print(("%s%s (%d)" % (strExitMsgError, vMsg, vnResult)))
+    print(("{0!s}{1!s} ({2:d})".format(strExitMsgError, vMsg, vnResult)))
     sys.exit(vnResult)
 
 #++---------------------------------------------------------------------------
@@ -141,7 +141,7 @@ def print_out_input_parameters(vDictArgs):
         if val.__len__() != 0:
             strEqs = " ="
             strQ = "\""
-        print(("%s%s%s %s%s%s\n" % (strParameter, arg, strEqs, strQ, val, strQ)))
+        print(("{0!s}{1!s}{2!s} {3!s}{4!s}{5!s}\n".format(strParameter, arg, strEqs, strQ, val, strQ)))
 
 #++---------------------------------------------------------------------------
 # Details:  Validate the arguments passed to the program. This function exits
@@ -259,7 +259,7 @@ def run_post_process_for_each_script_supported(vDictArgs):
     for scriptLang in listDirs:
         # __pycache__ is a magic directory in Python 3 that holds .pyc files
         if scriptLang != "__pycache__" and scriptLang != "swig_bot_lib":
-            dbg.dump_text("Executing language script for \'%s\'" % scriptLang)
+            dbg.dump_text("Executing language script for \'{0!s}\'".format(scriptLang))
             nResult, strStatusMsg = run_post_process(scriptLang, strFinishFileName,
                                                      vDictArgs)
         if nResult < 0:

--- a/scripts/install_custom_python.py
+++ b/scripts/install_custom_python.py
@@ -29,7 +29,7 @@ import sys
 def copy_one_file(dest_dir, source_dir, filename):
     source_path = os.path.join(source_dir, filename)
     dest_path = os.path.join(dest_dir, filename)
-    print 'Copying file %s ==> %s...' % (source_path, dest_path)
+    print 'Copying file {0!s} ==> {1!s}...'.format(source_path, dest_path)
     shutil.copyfile(source_path, dest_path)
 
 def copy_named_files(dest_dir, source_dir, files, extensions, copy_debug_suffix_also):
@@ -41,13 +41,13 @@ def copy_named_files(dest_dir, source_dir, files, extensions, copy_debug_suffix_
 def copy_subdirectory(dest_dir, source_dir, subdir):
     dest_dir = os.path.join(dest_dir, subdir)
     source_dir = os.path.join(source_dir, subdir)
-    print 'Copying directory %s ==> %s...' % (source_dir, dest_dir)
+    print 'Copying directory {0!s} ==> {1!s}...'.format(source_dir, dest_dir)
     shutil.copytree(source_dir, dest_dir)
 
 def copy_distro(dest_dir, dest_subdir, source_dir, source_prefix):
     dest_dir = os.path.join(dest_dir, dest_subdir)
 
-    print 'Copying distribution %s ==> %s' % (source_dir, dest_dir)
+    print 'Copying distribution {0!s} ==> {1!s}'.format(source_dir, dest_dir)
 
     os.mkdir(dest_dir)
     PCbuild_dir = os.path.join(source_dir, 'PCbuild')
@@ -117,10 +117,10 @@ if not os.path.exists(args.source):
 
 if os.path.exists(args.dest):
     if not args.overwrite:
-        print 'The destination directory \'%s\' already exists and --overwrite was not specified.  Exiting...' % args.dest
+        print 'The destination directory \'{0!s}\' already exists and --overwrite was not specified.  Exiting...'.format(args.dest)
         sys.exit(1)
     while not args.silent:
-        print 'Ok to recursively delete \'%s\' and all contents (Y/N)?  Choosing Y will permanently delete the contents.' % args.dest
+        print 'Ok to recursively delete \'{0!s}\' and all contents (Y/N)?  Choosing Y will permanently delete the contents.'.format(args.dest)
         result = str.upper(sys.stdin.read(1))
         if result == 'N':
             print 'Unable to copy files to the destination.  The destination already exists.'

--- a/scripts/utilsDebug.py
+++ b/scripts/utilsDebug.py
@@ -53,7 +53,7 @@ class CDebugFnVerbose(object):
     def dump_object(self, vstrText, vObject):
         if CDebugFnVerbose.bVerboseOn == False:
             return
-        sys.stdout.write("%d%s> Dp: %s" % (CDebugFnVerbose.__nLevel, self.__get_dots(),
+        sys.stdout.write("{0:d}{1!s}> Dp: {2!s}".format(CDebugFnVerbose.__nLevel, self.__get_dots(),
                                            vstrText))
         print(vObject)
 
@@ -67,7 +67,7 @@ class CDebugFnVerbose(object):
     def dump_text(self, vstrText):
         if CDebugFnVerbose.bVerboseOn == False:
             return
-        print(("%d%s> Dp: %s" % (CDebugFnVerbose.__nLevel, self.__get_dots(),
+        print(("{0:d}{1!s}> Dp: {2!s}".format(CDebugFnVerbose.__nLevel, self.__get_dots(),
                                  vstrText)))
 
     # Private methods:
@@ -94,7 +94,7 @@ class CDebugFnVerbose(object):
     #--
     def __indent_back(self):
         if CDebugFnVerbose.bVerboseOn:
-            print(("%d%s< fn: %s" % (CDebugFnVerbose.__nLevel, self.__get_dots(),
+            print(("{0:d}{1!s}< fn: {2!s}".format(CDebugFnVerbose.__nLevel, self.__get_dots(),
                                      self.__strFnName)))
         CDebugFnVerbose.__nLevel -= 1
 
@@ -110,7 +110,7 @@ class CDebugFnVerbose(object):
         CDebugFnVerbose.__nLevel += 1
         self.__strFnName = vstrFnName
         if CDebugFnVerbose.bVerboseOn:
-            print(("%d%s> fn: %s" % (CDebugFnVerbose.__nLevel, self.__get_dots(),
+            print(("{0:d}{1!s}> fn: {2!s}".format(CDebugFnVerbose.__nLevel, self.__get_dots(),
                                      self.__strFnName)))
 
     # Private statics attributes:

--- a/scripts/verify_api.py
+++ b/scripts/verify_api.py
@@ -8,7 +8,7 @@ import re
 import sys
 
 def extract_exe_symbol_names (arch, exe_path, match_str):
-    command = 'dsymutil --arch %s -s "%s" | grep "%s" | colrm 1 69' % (arch, exe_path, match_str)
+    command = 'dsymutil --arch {0!s} -s "{1!s}" | grep "{2!s}" | colrm 1 69'.format(arch, exe_path, match_str)
     (command_exit_status, command_output) = commands.getstatusoutput(command)
     if command_exit_status == 0:
         if command_output:
@@ -16,7 +16,7 @@ def extract_exe_symbol_names (arch, exe_path, match_str):
         else:
             print 'error: command returned no output'
     else:
-        print 'error: command failed with exit status %i\n    command: %s' % (command_exit_status, command)
+        print 'error: command failed with exit status {0:d}\n    command: {1!s}'.format(command_exit_status, command)
     return list()
 
 def verify_api(all_args):
@@ -51,7 +51,7 @@ def verify_api(all_args):
     if options.verbose:
         print "API symbols:"
         for (i, external_symbol) in enumerate(api_external_symbols):
-            print "[%u] %s" % (i, external_symbol)
+            print "[{0:d}] {1!s}".format(i, external_symbol)
     
     api_regex = None
     if options.api_regex_str:
@@ -59,7 +59,7 @@ def verify_api(all_args):
     
     for arch in options.archs:        
         for exe_path in args:
-            print 'Verifying (%s) "%s"...' % (arch, exe_path)
+            print 'Verifying ({0!s}) "{1!s}"...'.format(arch, exe_path)
             exe_errors = 0
             undefined_symbols = extract_exe_symbol_names(arch, exe_path, "(     UNDF EXT)");
             for undefined_symbol in undefined_symbols:
@@ -67,16 +67,16 @@ def verify_api(all_args):
                     match = api_regex.search(undefined_symbol)
                     if not match:
                         if options.verbose:
-                            print 'ignoring symbol: %s' % (undefined_symbol)
+                            print 'ignoring symbol: {0!s}'.format((undefined_symbol))
                         continue
                 if undefined_symbol in api_external_symbols:
                     if options.verbose:
-                        print 'verified symbol: %s' % (undefined_symbol)
+                        print 'verified symbol: {0!s}'.format((undefined_symbol))
                 else:
-                    print 'missing symbol: %s' % (undefined_symbol)
+                    print 'missing symbol: {0!s}'.format((undefined_symbol))
                     exe_errors += 1
             if exe_errors:
-                print 'error: missing %u API symbols from %s' % (exe_errors, options.libraries)
+                print 'error: missing {0:d} API symbols from {1!s}'.format(exe_errors, options.libraries)
             else:
                 print 'success'
         

--- a/source/Interpreter/embedded_interpreter.py
+++ b/source/Interpreter/embedded_interpreter.py
@@ -97,7 +97,7 @@ def run_python_interpreter (local_dict):
     except SystemExit as e:
         global g_builtin_override_called
         if not g_builtin_override_called:
-            print('Script exited with %s' %(e))
+            print('Script exited with {0!s}'.format((e)))
 
 def run_one_line (local_dict, input_string):
     global g_run_one_line_str
@@ -112,4 +112,4 @@ def run_one_line (local_dict, input_string):
     except SystemExit as e:
         global g_builtin_override_called
         if not g_builtin_override_called:
-            print('Script exited with %s' %(e))
+            print('Script exited with {0!s}'.format((e)))

--- a/third_party/Python/module/pexpect-2.4/FSM.py
+++ b/third_party/Python/module/pexpect-2.4/FSM.py
@@ -204,8 +204,7 @@ class FSM:
         elif self.default_transition is not None:
             return self.default_transition
         else:
-            raise ExceptionFSM ('Transition is undefined: (%s, %s).' %
-                (str(input_symbol), str(state)) )
+            raise ExceptionFSM ('Transition is undefined: ({0!s}, {1!s}).'.format(str(input_symbol), str(state)) )
 
     def process (self, input_symbol):
 

--- a/third_party/Python/module/pexpect-2.4/examples/bd_serv.py
+++ b/third_party/Python/module/pexpect-2.4/examples/bd_serv.py
@@ -99,7 +99,7 @@ def daemonize (stdin='/dev/null', stdout='/dev/null', stderr='/dev/null'):
         if pid > 0:
             sys.exit(0)   # Exit first parent.
     except OSError, e: 
-        sys.stderr.write ("fork #1 failed: (%d) %s\n" % (e.errno, e.strerror) )
+        sys.stderr.write ("fork #1 failed: ({0:d}) {1!s}\n".format(e.errno, e.strerror) )
         sys.exit(1)
 
     # Decouple from parent environment.
@@ -113,7 +113,7 @@ def daemonize (stdin='/dev/null', stdout='/dev/null', stderr='/dev/null'):
         if pid > 0:
             sys.exit(0)   # Exit second parent.
     except OSError, e: 
-        sys.stderr.write ("fork #2 failed: (%d) %s\n" % (e.errno, e.strerror) )
+        sys.stderr.write ("fork #2 failed: ({0:d}) {1!s}\n".format(e.errno, e.strerror) )
         sys.exit(1)
 
     # Now I am a daemon!
@@ -165,7 +165,7 @@ def main ():
         port = int(options['--port'])
     if '--username' in options:
         username = options['--username']
-    print "Login for %s@%s:%s" % (username, hostname, port)
+    print "Login for {0!s}@{1!s}:{2!s}".format(username, hostname, port)
     if '--password' in options:
         password = options['--password']
     else:
@@ -176,7 +176,7 @@ def main ():
         daemonize()
         #daemonize('/dev/null','/tmp/daemon.log','/tmp/daemon.log')
     
-    sys.stdout.write ('server started with pid %d\n' % os.getpid() )
+    sys.stdout.write ('server started with pid {0:d}\n'.format(os.getpid()) )
 
     virtual_screen = ANSI.ANSI (24,80) 
     child = pxssh.pxssh()
@@ -236,7 +236,7 @@ def main ():
                 time.sleep(0.2)
                 shell_window = str(virtual_screen)
             elif cmd == ':cursor':
-                shell_window = '%x%x' % (virtual_screen.cur_r, virtual_screen.cur_c)
+                shell_window = '{0:x}{1:x}'.format(virtual_screen.cur_r, virtual_screen.cur_c)
             elif cmd == ':refresh':
                 shell_window = str(virtual_screen)
 

--- a/third_party/Python/module/pexpect-2.4/examples/chess2.py
+++ b/third_party/Python/module/pexpect-2.4/examples/chess2.py
@@ -32,10 +32,10 @@ class Chess:
                 try:
                     k = self.child.read(1, 10)
                 except Exception, e:
-                    print 'EXCEPTION, (r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c)
+                    print 'EXCEPTION, (r,c):({0:d},{1:d})\n'.format(self.term.cur_r, self.term.cur_c)
                     sys.stdout.flush()
                 self.term.process (k)
-                fout.write ('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
+                fout.write ('(r,c):({0:d},{1:d})\n'.format(self.term.cur_r, self.term.cur_c))
                 fout.flush()
                 if e:
                     sys.stdout.write (k)
@@ -57,7 +57,7 @@ class Chess:
             while 1:
                 c = self.child.read(1,10)
                 self.term.process (c)
-                fout.write ('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
+                fout.write ('(r,c):({0:d},{1:d})\n'.format(self.term.cur_r, self.term.cur_c))
                 fout.flush()
                 sys.stdout.write (c)
                 sys.stdout.flush()
@@ -94,7 +94,7 @@ class Chess:
         def set_depth (self, depth):
                 self.child.sendline ('depth')
                 self.child.expect ('depth=')
-                self.child.sendline ('%d' % depth)
+                self.child.sendline ('{0:d}'.format(depth))
 
         def quit(self):
                 self.child.sendline ('quit')

--- a/third_party/Python/module/pexpect-2.4/examples/chess3.py
+++ b/third_party/Python/module/pexpect-2.4/examples/chess3.py
@@ -28,7 +28,7 @@ class Chess:
             while 1:
                 k = self.child.read(1, 10)
                 self.term.process (k)
-                fout.write ('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
+                fout.write ('(r,c):({0:d},{1:d})\n'.format(self.term.cur_r, self.term.cur_c))
                 fout.flush()
                 if self.term.cur_r == r and self.term.cur_c == c:
                     fout.close()
@@ -41,7 +41,7 @@ class Chess:
             while 1:
                 c = self.child.read(1,10)
                 self.term.process (c)
-                fout.write ('(r,c):(%d,%d)\n' %(self.term.cur_r, self.term.cur_c))
+                fout.write ('(r,c):({0:d},{1:d})\n'.format(self.term.cur_r, self.term.cur_c))
                 fout.flush()
                 sys.stdout.write (c)
                 sys.stdout.flush()
@@ -72,7 +72,7 @@ class Chess:
 	def set_depth (self, depth):
 		self.child.sendline ('depth')
 		self.child.expect ('depth=')
-		self.child.sendline ('%d' % depth)
+		self.child.sendline ('{0:d}'.format(depth))
 
 	def quit(self):
 		self.child.sendline ('quit')
@@ -86,7 +86,7 @@ c2 = white.term.get_abs(17,59)
 c3 = white.term.get_abs(17,60)
 c4 = white.term.get_abs(17,61)
 fout = open ('log','a')
-fout.write ('Computer:%s%s%s%s\n' %(c1,c2,c3,c4))
+fout.write ('Computer:{0!s}{1!s}{2!s}{3!s}\n'.format(c1, c2, c3, c4))
 fout.close()
 white.do_move('c2c4')
 white.read_until_cursor (19,60)
@@ -95,7 +95,7 @@ c2 = white.term.get_abs(17,59)
 c3 = white.term.get_abs(17,60)
 c4 = white.term.get_abs(17,61)
 fout = open ('log','a')
-fout.write ('Computer:%s%s%s%s\n' %(c1,c2,c3,c4))
+fout.write ('Computer:{0!s}{1!s}{2!s}{3!s}\n'.format(c1, c2, c3, c4))
 fout.close()
 white.do_scan ()
 

--- a/third_party/Python/module/pexpect-2.4/examples/df.py
+++ b/third_party/Python/module/pexpect-2.4/examples/df.py
@@ -24,7 +24,7 @@ for dummy in range (0, 1000):
 # Print report
 print
 for m in filesystem_list:
-    s = "Filesystem %s is at %s%%" % (m[0], m[1])
+    s = "Filesystem {0!s} is at {1!s}%".format(m[0], m[1])
     # highlight filesystems over 95% capacity
     if int(m[1]) > 95:
         s = '! ' + s

--- a/third_party/Python/module/pexpect-2.4/examples/hive.py
+++ b/third_party/Python/module/pexpect-2.4/examples/hive.py
@@ -165,13 +165,13 @@ def login (args, cli_username=None, cli_password=None):
         elif cli_username is not None:
             username = cli_username
         else:
-            username = raw_input('%s username: ' % hostname)
+            username = raw_input('{0!s} username: '.format(hostname))
         if len(hcd['password']) > 0:
             password = hcd['password']
         elif cli_password is not None:
             password = cli_password
         else:
-            password = getpass.getpass('%s password: ' % hostname)
+            password = getpass.getpass('{0!s} password: '.format(hostname))
         host_names.append(hostname)
         hive_connect_info[hostname] = (hostname, username, password, port)
     # build up the list of hive connections using the connection information.
@@ -257,7 +257,7 @@ def main ():
                     if hive[hostname] is not None:
                         hive[hostname].set_unique_prompt()
                 except Exception, e:
-                    print "Had trouble communicating with %s, so removing it from the target list." % hostname
+                    print "Had trouble communicating with {0!s}, so removing it from the target list.".format(hostname)
                     print str(e)
                     hive[hostname] = None
             continue
@@ -268,7 +268,7 @@ def main ():
                     if hive[hostname] is not None:
                         hive[hostname].send(txt)
                 except Exception, e:
-                    print "Had trouble communicating with %s, so removing it from the target list." % hostname
+                    print "Had trouble communicating with {0!s}, so removing it from the target list.".format(hostname)
                     print str(e)
                     hive[hostname] = None
             continue
@@ -287,7 +287,7 @@ def main ():
                 print '\\-----------------------------------------------------------------------------'
                 print hive[hostname].before
             except Exception, e:
-                print "Had trouble communicating with %s, so removing it from the target list." % hostname
+                print "Had trouble communicating with {0!s}, so removing it from the target list.".format(hostname)
                 print str(e)
                 hive[hostname] = None
             continue
@@ -300,7 +300,7 @@ def main ():
                         hive[hostname].expect(pattern)
                         print hive[hostname].before
             except Exception, e:
-                print "Had trouble communicating with %s, so removing it from the target list." % hostname
+                print "Had trouble communicating with {0!s}, so removing it from the target list.".format(hostname)
                 print str(e)
                 hive[hostname] = None
             continue
@@ -324,7 +324,7 @@ def main ():
                     if hive[hostname] is not None:
                         hive[hostname].sendcontrol(c)
                 except Exception, e:
-                    print "Had trouble communicating with %s, so removing it from the target list." % hostname
+                    print "Had trouble communicating with {0!s}, so removing it from the target list.".format(hostname)
                     print str(e)
                     hive[hostname] = None
             continue
@@ -341,7 +341,7 @@ def main ():
                 if hive[hostname] is not None:
                     hive[hostname].sendline (cmd)
             except Exception, e:
-                print "Had trouble communicating with %s, so removing it from the target list." % hostname
+                print "Had trouble communicating with {0!s}, so removing it from the target list.".format(hostname)
                 print str(e)
                 hive[hostname] = None
 
@@ -362,7 +362,7 @@ def main ():
                         print '\\-----------------------------------------------------------------------------'
                         print hive[hostname].before
                 except Exception, e:
-                    print "Had trouble communicating with %s, so removing it from the target list." % hostname
+                    print "Had trouble communicating with {0!s}, so removing it from the target list.".format(hostname)
                     print str(e)
                     hive[hostname] = None
             print '=============================================================================='

--- a/third_party/Python/module/pexpect-2.4/examples/monitor.py
+++ b/third_party/Python/module/pexpect-2.4/examples/monitor.py
@@ -76,7 +76,7 @@ def main():
     #
     # Login via SSH
     #
-    child = pexpect.spawn('ssh -l %s %s'%(user, host))
+    child = pexpect.spawn('ssh -l {0!s} {1!s}'.format(user, host))
     i = child.expect([pexpect.TIMEOUT, SSH_NEWKEY, COMMAND_PROMPT, '(?i)password'])
     if i == 0: # Timeout
         print 'ERROR! could not login with SSH. Here is what SSH said:'
@@ -147,7 +147,7 @@ def main():
         child.match = re.search('([0-9]+)\s+min',duration)
         mins = str(int(child.match.group(1)))
     print
-    print 'Uptime: %s days, %s users, %s (1 min), %s (5 min), %s (15 min)' % (
+    print 'Uptime: {0!s} days, {1!s} users, {2!s} (1 min), {3!s} (5 min), {4!s} (15 min)'.format(
         duration, users, av1, av5, av15)
     child.expect (COMMAND_PROMPT)
 

--- a/third_party/Python/module/pexpect-2.4/examples/passmass.py
+++ b/third_party/Python/module/pexpect-2.4/examples/passmass.py
@@ -14,7 +14,7 @@ SSH_NEWKEY = r'Are you sure you want to continue connecting \(yes/no\)\?'
 
 def login(host, user, password):
 
-    child = pexpect.spawn('ssh -l %s %s'%(user, host))
+    child = pexpect.spawn('ssh -l {0!s} {1!s}'.format(user, host))
     fout = file ("LOG.TXT","wb")
     child.setlog (fout)
 

--- a/third_party/Python/module/pexpect-2.4/examples/rippy.py
+++ b/third_party/Python/module/pexpect-2.4/examples/rippy.py
@@ -76,7 +76,7 @@ __version__ = '1.2'
 __revision__ = '$Revision: 11 $'
 __all__ = ['main', __version__, __revision__]
 
-GLOBAL_LOGFILE_NAME = "rippy_%d.log" % os.getpid()
+GLOBAL_LOGFILE_NAME = "rippy_{0:d}.log".format(os.getpid())
 GLOBAL_LOGFILE = open (GLOBAL_LOGFILE_NAME, "wb")
 
 ###############################################################################
@@ -208,7 +208,7 @@ Values of 6 to 10 usually adjust quiet DVDs to a comfortable level.""",1),
 #Normally this should be half of the audio sample rate.
 #This improves audio compression and quality.
 #Normally you don't need to change this.""",1),
-'delete_tmp_files_flag':("N","delete temporary files when finished?","""If Y then %s, audio_raw_filename, and 'divx2pass.log' will be deleted at the end."""%GLOBAL_LOGFILE_NAME,1)
+'delete_tmp_files_flag':("N","delete temporary files when finished?","""If Y then {0!s}, audio_raw_filename, and 'divx2pass.log' will be deleted at the end.""".format(GLOBAL_LOGFILE_NAME),1)
 }
 
 ##############################################################################
@@ -239,10 +239,10 @@ def convert (options):
         # and then calculate the length of that. This is because MP4 video is VBR, so
         # you cannot get exact time based on compressed size.
         if options['video_length']=='calc':
-            print "# extract PCM raw audio to %s" % (options['audio_raw_filename'])
+            print "# extract PCM raw audio to {0!s}".format((options['audio_raw_filename']))
             apply_smart (extract_audio, options)
             options['video_length'] = apply_smart (get_length, options)
-            print "# Length of raw audio file : %d seconds (%0.2f minutes)" % (options['video_length'], float(options['video_length'])/60.0)
+            print "# Length of raw audio file : {0:d} seconds ({1:0.2f} minutes)".format(options['video_length'], float(options['video_length'])/60.0)
         if options['video_bitrate']=='calc':
             options['video_bitrate'] = options['video_bitrate_overhead'] * apply_smart (calc_video_bitrate, options) 
         print "# video bitrate : " + str(options['video_bitrate'])
@@ -269,21 +269,21 @@ def convert (options):
     video_actual_size = get_filesize (options['video_final_filename'])
     if options['video_target_size'] != 'none':
         revised_bitrate = calculate_revised_bitrate (options['video_bitrate'], options['video_target_size'], video_actual_size)
-        o.append("# revised video_bitrate : %d\n" % revised_bitrate)
+        o.append("# revised video_bitrate : {0:d}\n".format(revised_bitrate))
     for k,v in options.iteritems():
-        o.append (" %30s : %s\n" % (k, v))
+        o.append (" {0:30!s} : {1!s}\n".format(k, v))
     print '# '.join(o)
     fout = open("rippy.conf","wb").write(''.join(o))
-    print "# final actual video size = %d" % video_actual_size
+    print "# final actual video size = {0:d}".format(video_actual_size)
     if options['video_target_size'] != 'none':
         if video_actual_size > options['video_target_size']:
             print "# FINAL VIDEO SIZE IS GREATER THAN DESIRED TARGET"
-            print "# final video size is %d bytes over target size" % (video_actual_size - options['video_target_size'])
+            print "# final video size is {0:d} bytes over target size".format((video_actual_size - options['video_target_size']))
         else:
-            print "# final video size is %d bytes under target size" % (options['video_target_size'] - video_actual_size)
+            print "# final video size is {0:d} bytes under target size".format((options['video_target_size'] - video_actual_size))
         print "# If you want to run the entire compression process all over again"
         print "# to get closer to the target video size then trying using a revised"
-        print "# video_bitrate of %d" % revised_bitrate
+        print "# video_bitrate of {0:d}".format(revised_bitrate)
 
     return options
 
@@ -330,7 +330,7 @@ def input_option (message, default_value="", help=None, level=0, max_level=0):
     default value is returned automatically without user input.
     """
     if default_value != '':
-        message = "%s [%s] " % (message, default_value)
+        message = "{0!s} [{1!s}] ".format(message, default_value)
     if level > max_level:
         return default_value
     while 1:
@@ -372,7 +372,7 @@ def apply_smart (func, args):
         if func in globals():
             func = globals()[func]
         else:
-            raise NameError("name '%s' is not defined" % func)
+            raise NameError("name '{0!s}' is not defined".format(func))
     if hasattr(func,'im_func'): # Handle case when func is a class method.
         func = func.im_func
     argcount = func.func_code.co_argcount
@@ -415,7 +415,7 @@ def get_aspect_ratio (video_source_filename):
     This function is very lenient. It basically guesses 16/9 whenever
     it cannot figure out the aspect ratio.
     """
-    cmd = "mplayer '%s' -vo png -ao null -frames 1" % video_source_filename
+    cmd = "mplayer '{0!s}' -vo png -ao null -frames 1".format(video_source_filename)
     (command_output, exitstatus) = run(cmd)
     ar = re.findall("Movie-Aspect is ([0-9]+\.?[0-9]*:[0-9]+\.?[0-9]*)", command_output)
     if len(ar)==0:
@@ -440,7 +440,7 @@ def get_aid_list (video_source_filename):
     """This returns a list of audio ids in the source video file.
     TODO: Also extract ID_AID_nnn_LANG to associate language. Not all DVDs include this.
     """
-    cmd = "mplayer '%s' -vo null -ao null -frames 0 -identify" % video_source_filename
+    cmd = "mplayer '{0!s}' -vo null -ao null -frames 0 -identify".format(video_source_filename)
     (command_output, exitstatus) = run(cmd)
     idl = re.findall("ID_AUDIO_ID=([0-9]+)", command_output)
     idl.sort()
@@ -450,7 +450,7 @@ def get_sid_list (video_source_filename):
     """This returns a list of subtitle ids in the source video file.
     TODO: Also extract ID_SID_nnn_LANG to associate language. Not all DVDs include this.
     """
-    cmd = "mplayer '%s' -vo null -ao null -frames 0 -identify" % video_source_filename
+    cmd = "mplayer '{0!s}' -vo null -ao null -frames 0 -identify".format(video_source_filename)
     (command_output, exitstatus) = run(cmd)
     idl = re.findall("ID_SUBTITLE_ID=([0-9]+)", command_output)
     idl.sort()
@@ -462,7 +462,7 @@ def extract_audio (video_source_filename, audio_id=128, verbose_flag=0, dry_run_
         At this time there is no way to set the output audio name.
     """
     #cmd = "mplayer %(video_source_filename)s -vc null -vo null -aid %(audio_id)s -ao pcm:fast -noframedrop" % locals()
-    cmd = "mplayer -quiet '%(video_source_filename)s' -vc dummy -vo null -aid %(audio_id)s -ao pcm:fast -noframedrop" % locals()
+    cmd = "mplayer -quiet '{video_source_filename!s}' -vc dummy -vo null -aid {audio_id!s} -ao pcm:fast -noframedrop".format(**locals())
     if verbose_flag: print cmd
     if not dry_run_flag:
         run(cmd)
@@ -471,7 +471,7 @@ def extract_audio (video_source_filename, audio_id=128, verbose_flag=0, dry_run_
 def extract_subtitles (video_source_filename, subtitle_id=0, verbose_flag=0, dry_run_flag=0):
     """This extracts the given subtitle_id track as VOBSUB format from the given source video.
     """
-    cmd = "mencoder -quiet '%(video_source_filename)s' -o /dev/null -nosound -ovc copy -vobsubout subtitles -vobsuboutindex 0 -sid %(subtitle_id)s" % locals()
+    cmd = "mencoder -quiet '{video_source_filename!s}' -o /dev/null -nosound -ovc copy -vobsubout subtitles -vobsuboutindex 0 -sid {subtitle_id!s}".format(**locals())
     if verbose_flag: print cmd
     if not dry_run_flag:
         run(cmd)
@@ -485,7 +485,7 @@ def get_length (audio_raw_filename):
     Weird...
     This returns -1 if it cannot get the length of the given file.
     """
-    cmd = "mplayer %s -vo null -ao null -frames 0 -identify" % audio_raw_filename
+    cmd = "mplayer {0!s} -vo null -ao null -frames 0 -identify".format(audio_raw_filename)
     (command_output, exitstatus) = run(cmd)
     idl = re.findall("ID_LENGTH=([0-9.]*)", command_output)
     idl.sort()
@@ -539,11 +539,11 @@ def crop_detect (video_source_filename, video_length, dry_run_flag=0):
     """
     skip = int(video_length/9) # offset to skip (-ss option in mencoder)
     sample_length = 10
-    cmd1 = "mencoder '%s' -quiet -ss %d -endpos %d -o /dev/null -nosound -ovc lavc -vf cropdetect" % (video_source_filename,   skip, sample_length)
-    cmd2 = "mencoder '%s' -quiet -ss %d -endpos %d -o /dev/null -nosound -ovc lavc -vf cropdetect" % (video_source_filename, 2*skip, sample_length)
-    cmd3 = "mencoder '%s' -quiet -ss %d -endpos %d -o /dev/null -nosound -ovc lavc -vf cropdetect" % (video_source_filename, 4*skip, sample_length)
-    cmd4 = "mencoder '%s' -quiet -ss %d -endpos %d -o /dev/null -nosound -ovc lavc -vf cropdetect" % (video_source_filename, 6*skip, sample_length)
-    cmd5 = "mencoder '%s' -quiet -ss %d -endpos %d -o /dev/null -nosound -ovc lavc -vf cropdetect" % (video_source_filename, 8*skip, sample_length)
+    cmd1 = "mencoder '{0!s}' -quiet -ss {1:d} -endpos {2:d} -o /dev/null -nosound -ovc lavc -vf cropdetect".format(video_source_filename, skip, sample_length)
+    cmd2 = "mencoder '{0!s}' -quiet -ss {1:d} -endpos {2:d} -o /dev/null -nosound -ovc lavc -vf cropdetect".format(video_source_filename, 2*skip, sample_length)
+    cmd3 = "mencoder '{0!s}' -quiet -ss {1:d} -endpos {2:d} -o /dev/null -nosound -ovc lavc -vf cropdetect".format(video_source_filename, 4*skip, sample_length)
+    cmd4 = "mencoder '{0!s}' -quiet -ss {1:d} -endpos {2:d} -o /dev/null -nosound -ovc lavc -vf cropdetect".format(video_source_filename, 6*skip, sample_length)
+    cmd5 = "mencoder '{0!s}' -quiet -ss {1:d} -endpos {2:d} -o /dev/null -nosound -ovc lavc -vf cropdetect".format(video_source_filename, 8*skip, sample_length)
     if dry_run_flag:
         return "0:0:0:0"
     (command_output1, exitstatus1) = run(cmd1)
@@ -569,7 +569,7 @@ def build_compression_command (video_source_filename, video_final_filename, vide
     #
     video_filter = ''
     if video_crop_area and video_crop_area.lower()!='none':
-        video_filter = video_filter + 'crop=%s' % video_crop_area
+        video_filter = video_filter + 'crop={0!s}'.format(video_crop_area)
     if video_deinterlace_flag:
         if video_filter != '':
             video_filter = video_filter + ','
@@ -577,7 +577,7 @@ def build_compression_command (video_source_filename, video_final_filename, vide
     if video_scale and video_scale.lower()!='none':
         if video_filter != '':
             video_filter = video_filter + ','
-        video_filter = video_filter + 'scale=%s' % video_scale
+        video_filter = video_filter + 'scale={0!s}'.format(video_scale)
     # optional video rotation -- were you holding your camera sideways?
     #if video_filter != '':
     #    video_filter = video_filter + ','
@@ -589,7 +589,7 @@ def build_compression_command (video_source_filename, video_final_filename, vide
     # build chapter argument
     #
     if video_chapter is not None:
-        chapter = '-chapter %d-%d' %(video_chapter,video_chapter)
+        chapter = '-chapter {0:d}-{1:d}'.format(video_chapter, video_chapter)
     else:
         chapter = ''
 #    chapter = '-chapter 2-2'
@@ -601,11 +601,11 @@ def build_compression_command (video_source_filename, video_final_filename, vide
     if audio_sample_rate:
         if audio_filter != '':
             audio_filter = audio_filter + ','
-        audio_filter = audio_filter + 'lavcresample=%s' % audio_sample_rate 
+        audio_filter = audio_filter + 'lavcresample={0!s}'.format(audio_sample_rate) 
     if audio_volume_boost is not None:
         if audio_filter != '':
             audio_filter = audio_filter + ','
-        audio_filter = audio_filter + 'volume=%0.1f:1'%audio_volume_boost
+        audio_filter = audio_filter + 'volume={0:0.1f}:1'.format(audio_volume_boost)
     if audio_filter != '':
         audio_filter = '-af ' + audio_filter
     #
@@ -616,18 +616,18 @@ def build_compression_command (video_source_filename, video_final_filename, vide
     # build lavcopts argument
     #
     #lavcopts = '-lavcopts vcodec=%s:vbitrate=%d:mbd=2:aspect=%s:acodec=%s:abitrate=%d:vpass=1' % (video_codec,video_bitrate,audio_codec,audio_bitrate)
-    lavcopts = '-lavcopts vcodec=%(video_codec)s:vbitrate=%(video_bitrate)d:mbd=2:aspect=%(video_aspect_ratio)s:acodec=%(audio_codec)s:abitrate=%(audio_bitrate)d:vpass=1' % (locals())
+    lavcopts = '-lavcopts vcodec={video_codec!s}:vbitrate={video_bitrate:d}:mbd=2:aspect={video_aspect_ratio!s}:acodec={audio_codec!s}:abitrate={audio_bitrate:d}:vpass=1'.format(**(locals()))
     if video_gray_flag:
         lavcopts = lavcopts + ':gray'
 
     seek_filter = ''
     if seek_skip is not None:
-        seek_filter = '-ss %s' % (str(seek_skip))
+        seek_filter = '-ss {0!s}'.format((str(seek_skip)))
     if seek_length is not None:
-        seek_filter = seek_filter + ' -endpos %s' % (str(seek_length))
+        seek_filter = seek_filter + ' -endpos {0!s}'.format((str(seek_length)))
 
 #    cmd = "mencoder -quiet -info comment='Arkivist' '%(video_source_filename)s' %(seek_filter)s %(chapter)s -aid %(audio_id)s -o '%(video_final_filename)s' -ffourcc %(video_fourcc_override)s -ovc lavc -oac lavc %(lavcopts)s %(video_filter)s %(audio_filter)s" % locals()
-    cmd = "mencoder -quiet -info comment='Arkivist' '%(video_source_filename)s' %(seek_filter)s %(chapter)s -aid %(audio_id)s -o '%(video_final_filename)s' -ffourcc %(video_fourcc_override)s -ovc lavc -oac mp3lame %(lavcopts)s %(video_filter)s %(audio_filter)s" % locals()
+    cmd = "mencoder -quiet -info comment='Arkivist' '{video_source_filename!s}' {seek_filter!s} {chapter!s} -aid {audio_id!s} -o '{video_final_filename!s}' -ffourcc {video_fourcc_override!s} -ovc lavc -oac mp3lame {lavcopts!s} {video_filter!s} {audio_filter!s}".format(**locals())
     return cmd
 
 def compression_estimate (video_length, video_source_filename, video_final_filename, video_target_size, audio_id=128, video_bitrate=1000, video_codec='mpeg4', audio_codec='mp3', video_fourcc_override='FMP4', video_gray_flag=0, video_crop_area=None, video_aspect_ratio='16/9', video_scale=None, video_encode_passes=2, video_deinterlace_flag=0, audio_volume_boost=None, audio_sample_rate=None, audio_bitrate=None):
@@ -718,7 +718,7 @@ def mux (video_final_filename, video_transcoded_filename, audio_compressed_filen
 
 def mux_mkv (video_final_filename, video_transcoded_filename, audio_compressed_filename, verbose_flag=0, dry_run_flag=0):
     """This is depricated."""
-    cmd = 'mkvmerge -o %s --noaudio %s %s' % (video_final_filename, video_transcoded_filename, audio_compressed_filename)
+    cmd = 'mkvmerge -o {0!s} --noaudio {1!s} {2!s}'.format(video_final_filename, video_transcoded_filename, audio_compressed_filename)
     if verbose_flag: print cmd
     if not dry_run_flag:
         run(cmd)
@@ -809,7 +809,7 @@ def interactive_convert ():
                     default_id = 'None'
             options[k] = input_option (prompts[k][1], default_id, prompts[k][2], prompts[k][3], max_prompt_level)
         elif k == 'audio_lowpass_filter':
-            lowpass_default =  "%.1f" % (math.floor(float(options['audio_sample_rate']) / 2.0))
+            lowpass_default =  "{0:.1f}".format((math.floor(float(options['audio_sample_rate']) / 2.0)))
             options[k] = input_option (prompts[k][1], lowpass_default, prompts[k][2], prompts[k][3], max_prompt_level)
         elif k == 'video_bitrate':
             if options['video_length'].lower() == 'none':
@@ -833,7 +833,7 @@ def interactive_convert ():
     print
     print "The following options will be used:"
     for k,v in options.iteritems():
-        print "%27s : %s" % (k, v)
+        print "{0:27!s} : {1!s}".format(k, v)
 
     print
     c = input_option("Continue?", "Y")

--- a/third_party/Python/module/pexpect-2.4/examples/script.py
+++ b/third_party/Python/module/pexpect-2.4/examples/script.py
@@ -62,7 +62,7 @@ def main():
         command = "sh"
 
     # Begin log with date/time in the form CCCCyymm.hhmmss
-    fout.write ('# %4d%02d%02d.%02d%02d%02d \n' % time.localtime()[:-3])
+    fout.write ('# {0:4d}{1:02d}{2:02d}.{3:02d}{4:02d}{5:02d} \n'.format(*time.localtime()[:-3]))
     
     ######################################################################
     # Start the interactive session

--- a/third_party/Python/module/pexpect-2.4/examples/ssh_session.py
+++ b/third_party/Python/module/pexpect-2.4/examples/ssh_session.py
@@ -75,18 +75,16 @@ class ssh_session:
 
     def ssh(self, command):
 
-        return self.__exec("ssh -l %s %s \"%s\"" \
-                                             % (self.user,self.host,command))
+        return self.__exec("ssh -l {0!s} {1!s} \"{2!s}\"".format(self.user, self.host, command))
 
     def scp(self, src, dst):
 
-        return self.__exec("scp %s %s@%s:%s" \
-                                             % (src, session.user, session.host, dst))
+        return self.__exec("scp {0!s} {1!s}@{2!s}:{3!s}".format(src, session.user, session.host, dst))
 
     def exists(self, file):
 
         "Retrieve file permissions of specified remote file."
-        seen = self.ssh("/bin/ls -ld %s" % file)
+        seen = self.ssh("/bin/ls -ld {0!s}".format(file))
         if string.find(seen, "No such file") > -1:
             return None # File doesn't exist
         else:

--- a/third_party/Python/module/pexpect-2.4/examples/sshls.py
+++ b/third_party/Python/module/pexpect-2.4/examples/sshls.py
@@ -18,7 +18,7 @@ connect to a new host and ssh asks you if you want to accept the public key
 fingerprint and continue connecting. """
 
     ssh_newkey = 'Are you sure you want to continue connecting'
-    child = pexpect.spawn('ssh -l %s %s %s'%(user, host, command))
+    child = pexpect.spawn('ssh -l {0!s} {1!s} {2!s}'.format(user, host, command))
     i = child.expect([pexpect.TIMEOUT, ssh_newkey, 'password: '])
     if i == 0: # Timeout
         print 'ERROR!'

--- a/third_party/Python/module/pexpect-2.4/examples/topip.py
+++ b/third_party/Python/module/pexpect-2.4/examples/topip.py
@@ -86,7 +86,7 @@ def send_alert (message, subject, addr_from, addr_to, smtp_server='localhost'):
     """This sends an email alert.
     """
 
-    message = 'From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n' % (addr_from, addr_to, subject) + message
+    message = 'From: {0!s}\r\nTo: {1!s}\r\nSubject: {2!s}\r\n\r\n'.format(addr_from, addr_to, subject) + message
     server = smtplib.SMTP(smtp_server)
     server.sendmail(addr_from, addr_to, message)
     server.quit()
@@ -237,13 +237,13 @@ def main():
         if verbose: print 'The maxip has been above trigger for two consecutive samples.'
         if alert_flag:
             if verbose: print 'SENDING ALERT EMAIL'
-            send_alert(str(s), 'ALERT on %s' % hostname, alert_addr_from, alert_addr_to)
+            send_alert(str(s), 'ALERT on {0!s}'.format(hostname), alert_addr_from, alert_addr_to)
         if log_flag:
             if verbose: print 'LOGGING THIS EVENT'
             fout = file(TOPIP_LOG_FILE,'a')
             #dts = time.strftime('%Y:%m:%d:%H:%M:%S', time.localtime())
             dts = time.asctime()
-            fout.write ('%s - %d connections from %s\n' % (dts,s['maxip'][1],str(s['maxip'][0])))
+            fout.write ('{0!s} - {1:d} connections from {2!s}\n'.format(dts, s['maxip'][1], str(s['maxip'][0])))
             fout.close()
 
     # save state to TOPIP_LAST_RUN_STATS

--- a/third_party/Python/module/pexpect-2.4/examples/uptime.py
+++ b/third_party/Python/module/pexpect-2.4/examples/uptime.py
@@ -53,5 +53,5 @@ if 'min' in duration:
 
 # Print the parsed fields in CSV format.
 print 'days, hours, minutes, users, cpu avg 1 min, cpu avg 5 min, cpu avg 15 min'
-print '%s, %s, %s, %s, %s, %s, %s' % (days, hours, mins, users, av1, av5, av15)
+print '{0!s}, {1!s}, {2!s}, {3!s}, {4!s}, {5!s}, {6!s}'.format(days, hours, mins, users, av1, av5, av15)
 

--- a/third_party/Python/module/pexpect-2.4/fdpexpect.py
+++ b/third_party/Python/module/pexpect-2.4/fdpexpect.py
@@ -41,7 +41,7 @@ class fdspawn (spawn):
         self.child_fd = fd
         self.own_fd = False
         self.closed = False
-        self.name = '<file descriptor %d>' % fd
+        self.name = '<file descriptor {0:d}>'.format(fd)
 
     def __del__ (self):
 

--- a/third_party/Python/module/pexpect-2.4/pexpect.py
+++ b/third_party/Python/module/pexpect-2.4/pexpect.py
@@ -514,7 +514,7 @@ class spawn (object):
 
         command_with_path = which(self.command)
         if command_with_path is None:
-            raise ExceptionPexpect ('The command was not found or was not executable: %s.' % self.command)
+            raise ExceptionPexpect ('The command was not found or was not executable: {0!s}.'.format(self.command))
         self.command = command_with_path
         self.args[0] = self.command
 
@@ -870,7 +870,7 @@ class spawn (object):
         # worry about if I have to later modify read() or expect().
         # Note, it's OK if size==-1 in the regex. That just means it
         # will never match anything in which case we stop only on EOF.
-        cre = re.compile('.{%d}' % size, re.DOTALL)
+        cre = re.compile('.{{{0:d}}}'.format(size), re.DOTALL)
         index = self.expect ([cre, self.delimiter]) # delimiter default is EOF
         if index == 0:
             return self.after ### self.before should be ''. Should I assert this?
@@ -1231,7 +1231,7 @@ class spawn (object):
             elif type(p) is type(re.compile('')):
                 compiled_pattern_list.append(p)
             else:
-                raise TypeError ('Argument must be one of StringTypes, EOF, TIMEOUT, SRE_Pattern, or a list of those type. %s' % str(type(p)))
+                raise TypeError ('Argument must be one of StringTypes, EOF, TIMEOUT, SRE_Pattern, or a list of those type. {0!s}'.format(str(type(p))))
 
         return compiled_pattern_list
 
@@ -1616,12 +1616,12 @@ class searcher_string (object):
         """This returns a human-readable string that represents the state of
         the object."""
 
-        ss =  [ (ns[0],'    %d: "%s"' % ns) for ns in self._strings ]
+        ss =  [ (ns[0],'    {0:d}: "{1!s}"'.format(*ns)) for ns in self._strings ]
         ss.append((-1,'searcher_string:'))
         if self.eof_index >= 0:
-            ss.append ((self.eof_index,'    %d: EOF' % self.eof_index))
+            ss.append ((self.eof_index,'    {0:d}: EOF'.format(self.eof_index)))
         if self.timeout_index >= 0:
-            ss.append ((self.timeout_index,'    %d: TIMEOUT' % self.timeout_index))
+            ss.append ((self.timeout_index,'    {0:d}: TIMEOUT'.format(self.timeout_index)))
         ss.sort()
         ss = zip(*ss)[1]
         return '\n'.join(ss)
@@ -1714,12 +1714,12 @@ class searcher_re (object):
         """This returns a human-readable string that represents the state of
         the object."""
 
-        ss =  [ (n,'    %d: re.compile("%s")' % (n,str(s.pattern))) for n,s in self._searches]
+        ss =  [ (n,'    {0:d}: re.compile("{1!s}")'.format(n, str(s.pattern))) for n,s in self._searches]
         ss.append((-1,'searcher_re:'))
         if self.eof_index >= 0:
-            ss.append ((self.eof_index,'    %d: EOF' % self.eof_index))
+            ss.append ((self.eof_index,'    {0:d}: EOF'.format(self.eof_index)))
         if self.timeout_index >= 0:
-            ss.append ((self.timeout_index,'    %d: TIMEOUT' % self.timeout_index))
+            ss.append ((self.timeout_index,'    {0:d}: TIMEOUT'.format(self.timeout_index)))
         ss.sort()
         ss = zip(*ss)[1]
         return '\n'.join(ss)

--- a/third_party/Python/module/pexpect-2.4/pxssh.py
+++ b/third_party/Python/module/pexpect-2.4/pxssh.py
@@ -187,8 +187,8 @@ class pxssh (spawn):
         if self.force_password:
             ssh_options = ssh_options + ' ' + self.SSH_OPTS
         if port is not None:
-            ssh_options = ssh_options + ' -p %s'%(str(port))
-        cmd = "ssh %s -l %s %s" % (ssh_options, username, server)
+            ssh_options = ssh_options + ' -p {0!s}'.format((str(port)))
+        cmd = "ssh {0!s} -l {1!s} {2!s}".format(ssh_options, username, server)
 
         # This does not distinguish between a remote server 'password' prompt
         # and a local ssh 'passphrase' prompt (for unlocking a private key).

--- a/third_party/Python/module/six/six.py
+++ b/third_party/Python/module/six/six.py
@@ -496,7 +496,7 @@ def remove_move(name):
         try:
             del moves.__dict__[name]
         except KeyError:
-            raise AttributeError("no such move, %r" % (name,))
+            raise AttributeError("no such move, {0!r}".format(name))
 
 
 if PY3:

--- a/third_party/Python/module/unittest2/unittest2/case.py
+++ b/third_party/Python/module/unittest2/unittest2/case.py
@@ -130,7 +130,7 @@ class _AssertRaisesContext(object):
             except AttributeError:
                 exc_name = str(self.expected)
             raise self.failureException(
-                "%s not raised" % (exc_name,))
+                "{0!s} not raised".format(exc_name))
         if not issubclass(exc_type, self.expected):
             # let unexpected exceptions pass through
             return False
@@ -142,8 +142,7 @@ class _AssertRaisesContext(object):
         if isinstance(expected_regexp, six.string_types):
             expected_regexp = re.compile(expected_regexp)
         if not expected_regexp.search(str(exc_value)):
-            raise self.failureException('"%s" does not match "%s"' %
-                     (expected_regexp.pattern, str(exc_value)))
+            raise self.failureException('"{0!s}" does not match "{1!s}"'.format(expected_regexp.pattern, str(exc_value)))
         return True
 
 
@@ -222,8 +221,7 @@ class TestCase(unittest.TestCase):
         try:
             testMethod = getattr(self, methodName)
         except AttributeError:
-            raise ValueError("no such test method in %s: %s" % \
-                  (self.__class__, methodName))
+            raise ValueError("no such test method in {0!s}: {1!s}".format(self.__class__, methodName))
         self._testMethodDoc = testMethod.__doc__
         self._cleanups = []
 
@@ -296,7 +294,7 @@ class TestCase(unittest.TestCase):
 
 
     def id(self):
-        return "%s.%s" % (strclass(self.__class__), self._testMethodName)
+        return "{0!s}.{1!s}".format(strclass(self.__class__), self._testMethodName)
 
     def __eq__(self, other):
         if type(self) is not type(other):
@@ -311,11 +309,10 @@ class TestCase(unittest.TestCase):
         return hash((type(self), self._testMethodName))
 
     def __str__(self):
-        return "%s (%s)" % (self._testMethodName, strclass(self.__class__))
+        return "{0!s} ({1!s})".format(self._testMethodName, strclass(self.__class__))
 
     def __repr__(self):
-        return "<%s testMethod=%s>" % \
-               (strclass(self.__class__), self._testMethodName)
+        return "<{0!s} testMethod={1!s}>".format(strclass(self.__class__), self._testMethodName)
     
     def _addSkip(self, result, reason):
         addSkip = getattr(result, 'addSkip', None)
@@ -452,13 +449,13 @@ class TestCase(unittest.TestCase):
     def assertFalse(self, expr, msg=None):
         "Fail the test if the expression is true."
         if expr:
-            msg = self._formatMessage(msg, "%s is not False" % safe_repr(expr))
+            msg = self._formatMessage(msg, "{0!s} is not False".format(safe_repr(expr)))
             raise self.failureException(msg)
 
     def assertTrue(self, expr, msg=None):
         """Fail the test unless the expression is true."""
         if not expr:
-            msg = self._formatMessage(msg, "%s is not True" % safe_repr(expr))
+            msg = self._formatMessage(msg, "{0!s} is not True".format(safe_repr(expr)))
             raise self.failureException(msg)
 
     def _formatMessage(self, msg, standardMsg):
@@ -476,9 +473,9 @@ class TestCase(unittest.TestCase):
         if msg is None:
             return standardMsg
         try:
-            return '%s : %s' % (standardMsg, msg)
+            return '{0!s} : {1!s}'.format(standardMsg, msg)
         except UnicodeDecodeError:
-            return '%s : %s' % (safe_str(standardMsg), safe_str(msg))
+            return '{0!s} : {1!s}'.format(safe_str(standardMsg), safe_str(msg))
 
 
     def assertRaises(self, excClass, callableObj=None, *args, **kwargs):
@@ -515,7 +512,7 @@ class TestCase(unittest.TestCase):
             excName = excClass.__name__
         else:
             excName = str(excClass)
-        raise self.failureException("%s not raised" % excName)
+        raise self.failureException("{0!s} not raised".format(excName))
 
     def _getAssertEqualityFunc(self, first, second):
         """Get a detailed comparison function for the types of the two args.
@@ -544,7 +541,7 @@ class TestCase(unittest.TestCase):
     def _baseAssertEqual(self, first, second, msg=None):
         """The default assertEqual implementation, not type specific."""
         if not first == second:
-            standardMsg = '%s != %s' % (safe_repr(first), safe_repr(second))
+            standardMsg = '{0!s} != {1!s}'.format(safe_repr(first), safe_repr(second))
             msg = self._formatMessage(msg, standardMsg)
             raise self.failureException(msg)
 
@@ -560,7 +557,7 @@ class TestCase(unittest.TestCase):
            operator.
         """
         if not first != second:
-            msg = self._formatMessage(msg, '%s == %s' % (safe_repr(first), 
+            msg = self._formatMessage(msg, '{0!s} == {1!s}'.format(safe_repr(first), 
                                                            safe_repr(second)))
             raise self.failureException(msg)
 
@@ -586,7 +583,7 @@ class TestCase(unittest.TestCase):
             if abs(first - second) <= delta:
                 return
         
-            standardMsg = '%s != %s within %s delta' % (safe_repr(first), 
+            standardMsg = '{0!s} != {1!s} within {2!s} delta'.format(safe_repr(first), 
                                                         safe_repr(second), 
                                                         safe_repr(delta))
         else:
@@ -596,7 +593,7 @@ class TestCase(unittest.TestCase):
             if round(abs(second-first), places) == 0:
                 return
         
-            standardMsg = '%s != %s within %r places' % (safe_repr(first), 
+            standardMsg = '{0!s} != {1!s} within {2!r} places'.format(safe_repr(first), 
                                                           safe_repr(second), 
                                                           places)
         msg = self._formatMessage(msg, standardMsg)
@@ -618,7 +615,7 @@ class TestCase(unittest.TestCase):
         if delta is not None:
             if not (first == second) and abs(first - second) > delta:
                 return
-            standardMsg = '%s == %s within %s delta' % (safe_repr(first), 
+            standardMsg = '{0!s} == {1!s} within {2!s} delta'.format(safe_repr(first), 
                                                         safe_repr(second),
                                                         safe_repr(delta))
         else:
@@ -626,7 +623,7 @@ class TestCase(unittest.TestCase):
                 places = 7
             if not (first == second) and round(abs(second-first), places) != 0:
                 return
-            standardMsg = '%s == %s within %r places' % (safe_repr(first), 
+            standardMsg = '{0!s} == {1!s} within {2!r} places'.format(safe_repr(first), 
                                                          safe_repr(second),
                                                          places)
 
@@ -649,7 +646,7 @@ class TestCase(unittest.TestCase):
     def _deprecate(original_func):
         def deprecated_func(*args, **kwargs):
             warnings.warn(
-                ('Please use %s instead.' % original_func.__name__),
+                ('Please use {0!s} instead.'.format(original_func.__name__)),
                 PendingDeprecationWarning, 2)
             return original_func(*args, **kwargs)
         return deprecated_func
@@ -681,11 +678,9 @@ class TestCase(unittest.TestCase):
         if seq_type is not None:
             seq_type_name = seq_type.__name__
             if not isinstance(seq1, seq_type):
-                raise self.failureException('First sequence is not a %s: %s'
-                                            % (seq_type_name, safe_repr(seq1)))
+                raise self.failureException('First sequence is not a {0!s}: {1!s}'.format(seq_type_name, safe_repr(seq1)))
             if not isinstance(seq2, seq_type):
-                raise self.failureException('Second sequence is not a %s: %s'
-                                            % (seq_type_name, safe_repr(seq2)))
+                raise self.failureException('Second sequence is not a {0!s}: {1!s}'.format(seq_type_name, safe_repr(seq2)))
         else:
             seq_type_name = "sequence"
 
@@ -693,15 +688,15 @@ class TestCase(unittest.TestCase):
         try:
             len1 = len(seq1)
         except (TypeError, NotImplementedError):
-            differing = 'First %s has no length.    Non-sequence?' % (
-                    seq_type_name)
+            differing = 'First {0!s} has no length.    Non-sequence?'.format((
+                    seq_type_name))
 
         if differing is None:
             try:
                 len2 = len(seq2)
             except (TypeError, NotImplementedError):
-                differing = 'Second %s has no length.    Non-sequence?' % (
-                        seq_type_name)
+                differing = 'Second {0!s} has no length.    Non-sequence?'.format((
+                        seq_type_name))
 
         if differing is None:
             if seq1 == seq2:
@@ -714,26 +709,23 @@ class TestCase(unittest.TestCase):
             if len(seq2_repr) > 30:
                 seq2_repr = seq2_repr[:30] + '...'
             elements = (seq_type_name.capitalize(), seq1_repr, seq2_repr)
-            differing = '%ss differ: %s != %s\n' % elements
+            differing = '{0!s}s differ: {1!s} != {2!s}\n'.format(*elements)
 
             for i in xrange(min(len1, len2)):
                 try:
                     item1 = seq1[i]
                 except (TypeError, IndexError, NotImplementedError):
-                    differing += ('\nUnable to index element %d of first %s\n' %
-                                 (i, seq_type_name))
+                    differing += ('\nUnable to index element {0:d} of first {1!s}\n'.format(i, seq_type_name))
                     break
 
                 try:
                     item2 = seq2[i]
                 except (TypeError, IndexError, NotImplementedError):
-                    differing += ('\nUnable to index element %d of second %s\n' %
-                                 (i, seq_type_name))
+                    differing += ('\nUnable to index element {0:d} of second {1!s}\n'.format(i, seq_type_name))
                     break
 
                 if item1 != item2:
-                    differing += ('\nFirst differing element %d:\n%s\n%s\n' %
-                                 (i, item1, item2))
+                    differing += ('\nFirst differing element {0:d}:\n{1!s}\n{2!s}\n'.format(i, item1, item2))
                     break
             else:
                 if (len1 == len2 and seq_type is None and
@@ -745,8 +737,7 @@ class TestCase(unittest.TestCase):
                 differing += ('\nFirst %s contains %d additional '
                              'elements.\n' % (seq_type_name, len1 - len2))
                 try:
-                    differing += ('First extra element %d:\n%s\n' %
-                                  (len2, seq1[len2]))
+                    differing += ('First extra element {0:d}:\n{1!s}\n'.format(len2, seq1[len2]))
                 except (TypeError, IndexError, NotImplementedError):
                     differing += ('Unable to index element %d '
                                   'of first %s\n' % (len2, seq_type_name))
@@ -754,8 +745,7 @@ class TestCase(unittest.TestCase):
                 differing += ('\nSecond %s contains %d additional '
                              'elements.\n' % (seq_type_name, len2 - len1))
                 try:
-                    differing += ('First extra element %d:\n%s\n' %
-                                  (len1, seq2[len1]))
+                    differing += ('First extra element {0:d}:\n{1!s}\n'.format(len1, seq2[len1]))
                 except (TypeError, IndexError, NotImplementedError):
                     differing += ('Unable to index element %d '
                                   'of second %s\n' % (len1, seq_type_name))
@@ -813,16 +803,16 @@ class TestCase(unittest.TestCase):
         try:
             difference1 = set1.difference(set2)
         except TypeError as e:
-            self.fail('invalid type when attempting set difference: %s' % e)
+            self.fail('invalid type when attempting set difference: {0!s}'.format(e))
         except AttributeError as e:
-            self.fail('first argument does not support set difference: %s' % e)
+            self.fail('first argument does not support set difference: {0!s}'.format(e))
 
         try:
             difference2 = set2.difference(set1)
         except TypeError as e:
-            self.fail('invalid type when attempting set difference: %s' % e)
+            self.fail('invalid type when attempting set difference: {0!s}'.format(e))
         except AttributeError as e:
-            self.fail('second argument does not support set difference: %s' % e)
+            self.fail('second argument does not support set difference: {0!s}'.format(e))
 
         if not (difference1 or difference2):
             return
@@ -843,27 +833,27 @@ class TestCase(unittest.TestCase):
     def assertIn(self, member, container, msg=None):
         """Just like self.assertTrue(a in b), but with a nicer default message."""
         if member not in container:
-            standardMsg = '%s not found in %s' % (safe_repr(member), 
+            standardMsg = '{0!s} not found in {1!s}'.format(safe_repr(member), 
                                                    safe_repr(container))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertNotIn(self, member, container, msg=None):
         """Just like self.assertTrue(a not in b), but with a nicer default message."""
         if member in container:
-            standardMsg = '%s unexpectedly found in %s' % (safe_repr(member), 
+            standardMsg = '{0!s} unexpectedly found in {1!s}'.format(safe_repr(member), 
                                                             safe_repr(container))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertIs(self, expr1, expr2, msg=None):
         """Just like self.assertTrue(a is b), but with a nicer default message."""
         if expr1 is not expr2:
-            standardMsg = '%s is not %s' % (safe_repr(expr1), safe_repr(expr2))
+            standardMsg = '{0!s} is not {1!s}'.format(safe_repr(expr1), safe_repr(expr2))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertIsNot(self, expr1, expr2, msg=None):
         """Just like self.assertTrue(a is not b), but with a nicer default message."""
         if expr1 is expr2:
-            standardMsg = 'unexpectedly identical: %s' % (safe_repr(expr1),)
+            standardMsg = 'unexpectedly identical: {0!s}'.format(safe_repr(expr1))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertDictEqual(self, d1, d2, msg=None):
@@ -871,7 +861,7 @@ class TestCase(unittest.TestCase):
         self.assert_(isinstance(d2, dict), 'Second argument is not a dictionary')
 
         if d1 != d2:
-            standardMsg = '%s != %s' % (safe_repr(d1, True), safe_repr(d2, True))
+            standardMsg = '{0!s} != {1!s}'.format(safe_repr(d1, True), safe_repr(d2, True))
             diff = ('\n' + '\n'.join(difflib.ndiff(
                            pprint.pformat(d1).splitlines(),
                            pprint.pformat(d2).splitlines())))
@@ -886,8 +876,7 @@ class TestCase(unittest.TestCase):
             if key not in actual:
                 missing.append(key)
             elif value != actual[key]:
-                mismatched.append('%s, expected: %s, actual: %s' %
-                                  (safe_repr(key), safe_repr(value), 
+                mismatched.append('{0!s}, expected: {1!s}, actual: {2!s}'.format(safe_repr(key), safe_repr(value), 
                                    safe_repr(actual[key])))
 
         if not (missing or mismatched):
@@ -895,12 +884,12 @@ class TestCase(unittest.TestCase):
 
         standardMsg = ''
         if missing:
-            standardMsg = 'Missing: %s' % ','.join(safe_repr(m) for m in 
-                                                    missing)
+            standardMsg = 'Missing: {0!s}'.format(','.join(safe_repr(m) for m in 
+                                                    missing))
         if mismatched:
             if standardMsg:
                 standardMsg += '; '
-            standardMsg += 'Mismatched values: %s' % ','.join(mismatched)
+            standardMsg += 'Mismatched values: {0!s}'.format(','.join(mismatched))
 
         self.fail(self._formatMessage(msg, standardMsg))
 
@@ -934,11 +923,11 @@ class TestCase(unittest.TestCase):
 
         errors = []
         if missing:
-            errors.append('Expected, but missing:\n    %s' % 
-                           safe_repr(missing))
+            errors.append('Expected, but missing:\n    {0!s}'.format( 
+                           safe_repr(missing)))
         if unexpected:
-            errors.append('Unexpected, but present:\n    %s' % 
-                           safe_repr(unexpected))
+            errors.append('Unexpected, but present:\n    {0!s}'.format( 
+                           safe_repr(unexpected)))
         if errors:
             standardMsg = '\n'.join(errors)
             self.fail(self._formatMessage(msg, standardMsg))
@@ -951,7 +940,7 @@ class TestCase(unittest.TestCase):
                 'Second argument is not a string'))
 
         if first != second:
-            standardMsg = '%s != %s' % (safe_repr(first, True), safe_repr(second, True))
+            standardMsg = '{0!s} != {1!s}'.format(safe_repr(first, True), safe_repr(second, True))
             diff = '\n' + ''.join(difflib.ndiff(first.splitlines(True),
                                                        second.splitlines(True)))
             standardMsg = self._truncateMessage(standardMsg, diff)
@@ -960,31 +949,31 @@ class TestCase(unittest.TestCase):
     def assertLess(self, a, b, msg=None):
         """Just like self.assertTrue(a < b), but with a nicer default message."""
         if not a < b:
-            standardMsg = '%s not less than %s' % (safe_repr(a), safe_repr(b))
+            standardMsg = '{0!s} not less than {1!s}'.format(safe_repr(a), safe_repr(b))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertLessEqual(self, a, b, msg=None):
         """Just like self.assertTrue(a <= b), but with a nicer default message."""
         if not a <= b:
-            standardMsg = '%s not less than or equal to %s' % (safe_repr(a), safe_repr(b))
+            standardMsg = '{0!s} not less than or equal to {1!s}'.format(safe_repr(a), safe_repr(b))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertGreater(self, a, b, msg=None):
         """Just like self.assertTrue(a > b), but with a nicer default message."""
         if not a > b:
-            standardMsg = '%s not greater than %s' % (safe_repr(a), safe_repr(b))
+            standardMsg = '{0!s} not greater than {1!s}'.format(safe_repr(a), safe_repr(b))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertGreaterEqual(self, a, b, msg=None):
         """Just like self.assertTrue(a >= b), but with a nicer default message."""
         if not a >= b:
-            standardMsg = '%s not greater than or equal to %s' % (safe_repr(a), safe_repr(b))
+            standardMsg = '{0!s} not greater than or equal to {1!s}'.format(safe_repr(a), safe_repr(b))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertIsNone(self, obj, msg=None):
         """Same as self.assertTrue(obj is None), with a nicer default message."""
         if obj is not None:
-            standardMsg = '%s is not None' % (safe_repr(obj),)
+            standardMsg = '{0!s} is not None'.format(safe_repr(obj))
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertIsNotNone(self, obj, msg=None):
@@ -997,13 +986,13 @@ class TestCase(unittest.TestCase):
         """Same as self.assertTrue(isinstance(obj, cls)), with a nicer
         default message."""
         if not isinstance(obj, cls):
-            standardMsg = '%s is not an instance of %r' % (safe_repr(obj), cls)
+            standardMsg = '{0!s} is not an instance of {1!r}'.format(safe_repr(obj), cls)
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertNotIsInstance(self, obj, cls, msg=None):
         """Included for symmetry with assertIsInstance."""
         if isinstance(obj, cls):
-            standardMsg = '%s is an instance of %r' % (safe_repr(obj), cls)
+            standardMsg = '{0!s} is an instance of {1!r}'.format(safe_repr(obj), cls)
             self.fail(self._formatMessage(msg, standardMsg))
 
     def assertRaisesRegexp(self, expected_exception, expected_regexp,
@@ -1026,14 +1015,13 @@ class TestCase(unittest.TestCase):
             if isinstance(expected_regexp, six.string_types):
                 expected_regexp = re.compile(expected_regexp)
             if not expected_regexp.search(str(exc_value)):
-                raise self.failureException('"%s" does not match "%s"' %
-                         (expected_regexp.pattern, str(exc_value)))
+                raise self.failureException('"{0!s}" does not match "{1!s}"'.format(expected_regexp.pattern, str(exc_value)))
         else:
             if hasattr(expected_exception, '__name__'): 
                 excName = expected_exception.__name__
             else: 
                 excName = str(expected_exception)
-            raise self.failureException("%s not raised" % excName)
+            raise self.failureException("{0!s} not raised".format(excName))
 
 
     def assertRegexpMatches(self, text, expected_regexp, msg=None):
@@ -1042,7 +1030,7 @@ class TestCase(unittest.TestCase):
             expected_regexp = re.compile(expected_regexp)
         if not expected_regexp.search(text):
             msg = msg or "Regexp didn't match"
-            msg = '%s: %r not found in %r' % (msg, expected_regexp.pattern, text)
+            msg = '{0!s}: {1!r} not found in {2!r}'.format(msg, expected_regexp.pattern, text)
             raise self.failureException(msg)
 
     def assertNotRegexpMatches(self, text, unexpected_regexp, msg=None):
@@ -1052,7 +1040,7 @@ class TestCase(unittest.TestCase):
         match = unexpected_regexp.search(text)
         if match:
             msg = msg or "Regexp matched"
-            msg = '%s: %r matches %r in %r' % (msg,
+            msg = '{0!s}: {1!r} matches {2!r} in {3!r}'.format(msg,
                                                text[match.start():match.end()],
                                                unexpected_regexp.pattern,
                                                text)
@@ -1105,11 +1093,11 @@ class FunctionTestCase(TestCase):
                      self._testFunc, self._description))
 
     def __str__(self):
-        return "%s (%s)" % (strclass(self.__class__),
+        return "{0!s} ({1!s})".format(strclass(self.__class__),
                             self._testFunc.__name__)
 
     def __repr__(self):
-        return "<%s testFunc=%s>" % (strclass(self.__class__),
+        return "<{0!s} testFunc={1!s}>".format(strclass(self.__class__),
                                      self._testFunc)
 
     def shortDescription(self):

--- a/third_party/Python/module/unittest2/unittest2/compatibility.py
+++ b/third_party/Python/module/unittest2/unittest2/compatibility.py
@@ -23,11 +23,9 @@ def _relpath_nt(path, start=os.path.curdir):
         unc_path, rest = os.path.splitunc(path)
         unc_start, rest = os.path.splitunc(start)
         if bool(unc_path) ^ bool(unc_start):
-            raise ValueError("Cannot mix UNC and non-UNC paths (%s and %s)"
-                                                                % (path, start))
+            raise ValueError("Cannot mix UNC and non-UNC paths ({0!s} and {1!s})".format(path, start))
         else:
-            raise ValueError("path is on drive %s, start on drive %s"
-                                                % (path_list[0], start_list[0]))
+            raise ValueError("path is on drive {0!s}, start on drive {1!s}".format(path_list[0], start_list[0]))
     # Work out how much of the filepath is shared by start and path.
     for i in range(min(len(start_list), len(path_list))):
         if start_list[i].lower() != path_list[i].lower():

--- a/third_party/Python/module/unittest2/unittest2/loader.py
+++ b/third_party/Python/module/unittest2/unittest2/loader.py
@@ -26,11 +26,11 @@ VALID_MODULE_NAME = re.compile(r'[_a-z]\w*\.py$', re.IGNORECASE)
 
 
 def _make_failed_import_test(name, suiteClass):
-    message = 'Failed to import test module: %s' % name
+    message = 'Failed to import test module: {0!s}'.format(name)
     if hasattr(traceback, 'format_exc'):
         # Python 2.3 compatibility
         # format_exc returns two frames of discover.py as well
-        message += '\n%s' % traceback.format_exc()
+        message += '\n{0!s}'.format(traceback.format_exc())
     return _make_failed_test('ModuleImportFailure', name, ImportError(message),
                              suiteClass)
 
@@ -128,10 +128,9 @@ class TestLoader(unittest.TestLoader):
             elif isinstance(test, unittest.TestCase):
                 return self.suiteClass([test])
             else:
-                raise TypeError("calling %s returned %s, not a test" %
-                                (obj, test))
+                raise TypeError("calling {0!s} returned {1!s}, not a test".format(obj, test))
         else:
-            raise TypeError("don't know how to make test from: %s" % obj)
+            raise TypeError("don't know how to make test from: {0!s}".format(obj))
 
     def loadTestsFromNames(self, names, module=None):
         """Return a suite of all tests cases found using the given sequence
@@ -211,7 +210,7 @@ class TestLoader(unittest.TestLoader):
                     sys.path.remove(top_level_dir)
 
         if is_not_importable:
-            raise ImportError('Start directory is not importable: %r' % start_dir)
+            raise ImportError('Start directory is not importable: {0!r}'.format(start_dir))
 
         tests = list(self._find_tests(start_dir, pattern))
         return self.suiteClass(tests)

--- a/third_party/Python/module/unittest2/unittest2/main.py
+++ b/third_party/Python/module/unittest2/unittest2/main.py
@@ -163,7 +163,7 @@ class TestProgram(object):
 
     def _do_discovery(self, argv, Loader=loader.TestLoader):
         # handle command line args for test discovery
-        self.progName = '%s discover' % self.progName
+        self.progName = '{0!s} discover'.format(self.progName)
         import optparse
         parser = optparse.OptionParser()
         parser.prog = self.progName

--- a/third_party/Python/module/unittest2/unittest2/result.py
+++ b/third_party/Python/module/unittest2/unittest2/result.py
@@ -190,6 +190,5 @@ class TestResult(unittest.TestResult):
         return length
 
     def __repr__(self):
-        return "<%s run=%i errors=%i failures=%i>" % \
-               (util.strclass(self.__class__), self.testsRun, len(self.errors),
+        return "<{0!s} run={1:d} errors={2:d} failures={3:d}>".format(util.strclass(self.__class__), self.testsRun, len(self.errors),
                 len(self.failures))

--- a/third_party/Python/module/unittest2/unittest2/runner.py
+++ b/third_party/Python/module/unittest2/unittest2/runner.py
@@ -95,7 +95,7 @@ class TextTestResult(result.TestResult):
 
     def addSkip(self, test, reason):
         super(TextTestResult, self).addSkip(test, reason)
-        self.newTestResult(test,"s","skipped %r" % (reason,))
+        self.newTestResult(test,"s","skipped {0!r}".format(reason))
 
     def addExpectedFailure(self, test, err, bugnumber):
         super(TextTestResult, self).addExpectedFailure(test, err, bugnumber)
@@ -117,9 +117,9 @@ class TextTestResult(result.TestResult):
     def printErrorList(self, flavour, errors):
         for test, err in errors:
             self.stream.writeln(self.separator1)
-            self.stream.writeln("%s: %s" % (flavour, self.getDescription(test)))
+            self.stream.writeln("{0!s}: {1!s}".format(flavour, self.getDescription(test)))
             self.stream.writeln(self.separator2)
-            self.stream.writeln("%s" % err)
+            self.stream.writeln("{0!s}".format(err))
 
     def stopTestRun(self):
         super(TextTestResult, self).stopTestRun()
@@ -171,8 +171,7 @@ class TextTestRunner(unittest.TextTestRunner):
         if hasattr(result, 'separator2'):
             self.stream.writeln(result.separator2)
         run = result.testsRun
-        self.stream.writeln("Ran %d test%s in %.3fs" %
-                            (run, run != 1 and "s" or "", timeTaken))
+        self.stream.writeln("Ran {0:d} test{1!s} in {2:.3f}s".format(run, run != 1 and "s" or "", timeTaken))
         self.stream.writeln()
         
         expectedFails = unexpectedSuccesses = skipped = passed = failed = errored = 0
@@ -187,17 +186,17 @@ class TextTestRunner(unittest.TextTestRunner):
         except AttributeError:
             pass
         infos = []
-        infos.append("%d passes" % passed)
-        infos.append("%d failures" % failed)
-        infos.append("%d errors" % errored)
-        infos.append("%d skipped" % skipped)
-        infos.append("%d expected failures" % expectedFails)
-        infos.append("%d unexpected successes" % unexpectedSuccesses)
+        infos.append("{0:d} passes".format(passed))
+        infos.append("{0:d} failures".format(failed))
+        infos.append("{0:d} errors".format(errored))
+        infos.append("{0:d} skipped".format(skipped))
+        infos.append("{0:d} expected failures".format(expectedFails))
+        infos.append("{0:d} unexpected successes".format(unexpectedSuccesses))
         self.stream.write("RESULT: ")
         if not result.wasSuccessful():
             self.stream.write("FAILED")
         else:
             self.stream.write("PASSED")
 
-        self.stream.writeln(" (%s)" % (", ".join(infos),))
+        self.stream.writeln(" ({0!s})".format(", ".join(infos)))
         return result

--- a/third_party/Python/module/unittest2/unittest2/suite.py
+++ b/third_party/Python/module/unittest2/unittest2/suite.py
@@ -16,7 +16,7 @@ class BaseTestSuite(unittest.TestSuite):
         self.addTests(tests)
 
     def __repr__(self):
-        return "<%s tests=%s>" % (util.strclass(self.__class__), list(self))
+        return "<{0!s} tests={1!s}>".format(util.strclass(self.__class__), list(self))
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
@@ -41,7 +41,7 @@ class BaseTestSuite(unittest.TestSuite):
     def addTest(self, test):
         # sanity checks
         if not hasattr(test, '__call__'):
-            raise TypeError("%r is not callable" % (repr(test),))
+            raise TypeError("{0!r} is not callable".format(repr(test)))
         if isinstance(test, type) and issubclass(test,
                                                  (case.TestCase, TestSuite)):
             raise TypeError("TestCases and TestSuites must be instantiated "
@@ -144,7 +144,7 @@ class TestSuite(BaseTestSuite):
                     raise
                 currentClass._classSetupFailed = True
                 className = util.strclass(currentClass)
-                errorName = 'setUpClass (%s)' % className
+                errorName = 'setUpClass ({0!s})'.format(className)
                 self._addClassOrModuleLevelException(result, e, errorName)
     
     def _get_previous_module(self, result):
@@ -177,7 +177,7 @@ class TestSuite(BaseTestSuite):
                 if isinstance(result, _DebugResult):
                     raise
                 result._moduleSetUpFailed = True
-                errorName = 'setUpModule (%s)' % currentModule
+                errorName = 'setUpModule ({0!s})'.format(currentModule)
                 self._addClassOrModuleLevelException(result, e, errorName)
 
     def _addClassOrModuleLevelException(self, result, exception, errorName):
@@ -207,7 +207,7 @@ class TestSuite(BaseTestSuite):
             except Exception as e:
                 if isinstance(result, _DebugResult):
                     raise
-                errorName = 'tearDownModule (%s)' % previousModule
+                errorName = 'tearDownModule ({0!s})'.format(previousModule)
                 self._addClassOrModuleLevelException(result, e, errorName)
     
     def _tearDownPreviousClass(self, test, result):
@@ -230,7 +230,7 @@ class TestSuite(BaseTestSuite):
                 if isinstance(result, _DebugResult):
                     raise
                 className = util.strclass(previousClass)
-                errorName = 'tearDownClass (%s)' % className
+                errorName = 'tearDownClass ({0!s})'.format(className)
                 self._addClassOrModuleLevelException(result, e, errorName)
 
 
@@ -256,7 +256,7 @@ class _ErrorHolder(object):
         return None
 
     def __repr__(self):
-        return "<ErrorHolder description=%r>" % (self.description,)
+        return "<ErrorHolder description={0!r}>".format(self.description)
 
     def __str__(self):
         return self.id()

--- a/third_party/Python/module/unittest2/unittest2/test/support.py
+++ b/third_party/Python/module/unittest2/unittest2/test/support.py
@@ -106,21 +106,20 @@ class HashingMixin(object):
         for obj_1, obj_2 in self.eq_pairs:
             try:
                 if not hash(obj_1) == hash(obj_2):
-                    self.fail("%r and %r do not hash equal" % (obj_1, obj_2))
+                    self.fail("{0!r} and {1!r} do not hash equal".format(obj_1, obj_2))
             except KeyboardInterrupt:
                 raise
             except Exception as e:
-                self.fail("Problem hashing %r and %r: %s" % (obj_1, obj_2, e))
+                self.fail("Problem hashing {0!r} and {1!r}: {2!s}".format(obj_1, obj_2, e))
 
         for obj_1, obj_2 in self.ne_pairs:
             try:
                 if hash(obj_1) == hash(obj_2):
-                    self.fail("%s and %s hash equal, but shouldn't" %
-                              (obj_1, obj_2))
+                    self.fail("{0!s} and {1!s} hash equal, but shouldn't".format(obj_1, obj_2))
             except KeyboardInterrupt:
                 raise
             except Exception as e:
-                self.fail("Problem hashing %s and %s: %s" % (obj_1, obj_2, e))
+                self.fail("Problem hashing {0!s} and {1!s}: {2!s}".format(obj_1, obj_2, e))
 
 
 
@@ -139,11 +138,11 @@ except ImportError:
             if self._record:
                 args.append("record=True")
             name = type(self).__name__
-            return "%s(%s)" % (name, ", ".join(args))
+            return "{0!s}({1!s})".format(name, ", ".join(args))
     
         def __enter__(self):
             if self._entered:
-                raise RuntimeError("Cannot enter %r twice" % self)
+                raise RuntimeError("Cannot enter {0!r} twice".format(self))
             self._entered = True
             self._filters = self._module.filters
             self._module.filters = self._filters[:]
@@ -159,7 +158,7 @@ except ImportError:
     
         def __exit__(self, *exc_info):
             if not self._entered:
-                raise RuntimeError("Cannot exit %r without entering first" % self)
+                raise RuntimeError("Cannot exit {0!r} without entering first".format(self))
             self._module.filters = self._filters
             self._module.showwarning = self._showwarning
 

--- a/third_party/Python/module/unittest2/unittest2/test/test_case.py
+++ b/third_party/Python/module/unittest2/unittest2/test/test_case.py
@@ -642,16 +642,15 @@ class Test_TestCase(unittest2.TestCase, EqualityMixin, HashingMixin):
             try:
                 self.assertEqual(a, b)
             except self.failureException:
-                self.fail('assertEqual(%r, %r) failed' % (a, b))
+                self.fail('assertEqual({0!r}, {1!r}) failed'.format(a, b))
             try:
                 self.assertEqual(a, b, msg='foo')
             except self.failureException:
-                self.fail('assertEqual(%r, %r) with msg= failed' % (a, b))
+                self.fail('assertEqual({0!r}, {1!r}) with msg= failed'.format(a, b))
             try:
                 self.assertEqual(a, b, 'foo')
             except self.failureException:
-                self.fail('assertEqual(%r, %r) with third parameter failed' %
-                          (a, b))
+                self.fail('assertEqual({0!r}, {1!r}) with third parameter failed'.format(a, b))
 
         unequal_pairs = [
                ((), []),

--- a/third_party/Python/module/unittest2/unittest2/test/test_discovery.py
+++ b/third_party/Python/module/unittest2/unittest2/test/test_discovery.py
@@ -62,7 +62,7 @@ class TestDiscovery(unittest2.TestCase):
 
         expected = [name + ' module tests' for name in
                     ('test1', 'test2')]
-        expected.extend([('test_dir.%s' % name) + ' module tests' for name in
+        expected.extend([('test_dir.{0!s}'.format(name)) + ' module tests' for name in
                     ('test3', 'test4')])
         self.assertEqual(suite, expected)
 
@@ -344,7 +344,7 @@ class TestDiscovery(unittest2.TestCase):
         msg = re.escape(r"'foo' module incorrectly imported from %r. Expected %r. "
                 "Is this module globally installed?" % (mod_dir, expected_dir))
         self.assertRaisesRegexp(
-            ImportError, '^%s$' % msg, loader.discover,
+            ImportError, '^{0!s}$'.format(msg), loader.discover,
             start_dir='foo', pattern='foo.py'
         )
         self.assertEqual(sys.path[0], full_path)

--- a/third_party/Python/module/unittest2/unittest2/test/test_program.py
+++ b/third_party/Python/module/unittest2/unittest2/test/test_program.py
@@ -151,8 +151,8 @@ class TestCommandLineArgs(unittest2.TestCase):
             if attr == 'catch' and not hasInstallHandler:
                 continue
             
-            short_opt = '-%s' % arg[0]
-            long_opt = '--%s' % arg
+            short_opt = '-{0!s}'.format(arg[0])
+            long_opt = '--{0!s}'.format(arg)
             for opt in short_opt, long_opt:
                 setattr(program, attr, None)
                 

--- a/third_party/Python/module/unittest2/unittest2/test/test_result.py
+++ b/third_party/Python/module/unittest2/unittest2/test/test_result.py
@@ -405,7 +405,7 @@ class TestOutputBuffering(unittest2.TestCase):
                 Stderr:
                 bar
             """)
-            expectedFullMessage = 'None\n%s%s' % (expectedOutMessage, expectedErrMessage)
+            expectedFullMessage = 'None\n{0!s}{1!s}'.format(expectedOutMessage, expectedErrMessage)
 
             self.assertIs(test, self)
             self.assertEqual(result._original_stdout.getvalue(), expectedOutMessage)

--- a/third_party/Python/module/unittest2/unittest2/test/test_setups.py
+++ b/third_party/Python/module/unittest2/unittest2/test/test_setups.py
@@ -109,7 +109,7 @@ class TestSetups(unittest2.TestCase):
         self.assertEqual(len(result.errors), 1)
         error, _ = result.errors[0]
         self.assertEqual(str(error), 
-                    'setUpClass (%s.BrokenTest)' % __name__)
+                    'setUpClass ({0!s}.BrokenTest)'.format(__name__))
 
     def test_error_in_teardown_class(self):
         class Test(unittest2.TestCase):
@@ -142,7 +142,7 @@ class TestSetups(unittest2.TestCase):
         
         error, _ = result.errors[0]
         self.assertEqual(str(error), 
-                    'tearDownClass (%s.Test)' % __name__)
+                    'tearDownClass ({0!s}.Test)'.format(__name__))
 
     def test_class_not_torndown_when_setup_fails(self):
         class Test(unittest2.TestCase):
@@ -412,7 +412,7 @@ class TestSetups(unittest2.TestCase):
         self.assertEqual(len(result.errors), 0)
         self.assertEqual(len(result.skipped), 1)
         skipped = result.skipped[0][0]
-        self.assertEqual(str(skipped), 'setUpClass (%s.Test)' % __name__)
+        self.assertEqual(str(skipped), 'setUpClass ({0!s}.Test)'.format(__name__))
 
     def test_skiptest_in_setupmodule(self):
         class Test(unittest2.TestCase):

--- a/third_party/Python/module/unittest2/unittest2/test/test_suite.py
+++ b/third_party/Python/module/unittest2/unittest2/test/test_suite.py
@@ -189,7 +189,7 @@ class Test_TestSuite(unittest2.TestCase, EqualityMixin):
 
         class LoggingCase(unittest2.TestCase):
             def run(self, result):
-                events.append('run %s' % self._testMethodName)
+                events.append('run {0!s}'.format(self._testMethodName))
 
             def test1(self): pass
             def test2(self): pass

--- a/third_party/Python/module/unittest2/unittest2/util.py
+++ b/third_party/Python/module/unittest2/unittest2/util.py
@@ -20,7 +20,7 @@ def safe_str(obj):
         return object.__str__(obj)
 
 def strclass(cls):
-    return "%s.%s" % (cls.__module__, cls.__name__)
+    return "{0!s}.{1!s}".format(cls.__module__, cls.__name__)
 
 def sorted_list_difference(expected, actual):
     """Finds elements in only one or the other of two, sorted input lists.

--- a/utils/git-svn/convert.py
+++ b/utils/git-svn/convert.py
@@ -16,7 +16,7 @@ import StringIO
 
 def usage(problem_file=None):
     if problem_file:
-        print "%s is not a file" % problem_file
+        print "{0!s} is not a file".format(problem_file)
     print "Usage: convert.py raw-message-source [raw-message-source2 ...]"
     sys.exit(0)
 
@@ -25,7 +25,7 @@ def do_convert(file):
     Then for each line ('From: ' header included), replace the dos style CRLF
     end-of-line with unix style LF end-of-line.
     """
-    print "converting %s ..." % file
+    print "converting {0!s} ...".format(file)
 
     with open(file, 'r') as f_in:
         content = f_in.read()

--- a/utils/lui/breakwin.py
+++ b/utils/lui/breakwin.py
@@ -75,9 +75,9 @@ class BreakWin(cui.ListWin):
         id = match.group(1)
         desc = match.group(2).strip()
         if bp.IsEnabled():
-          text = '%s: %s' % (id, desc)
+          text = '{0!s}: {1!s}'.format(id, desc)
         else:
-          text = '%s: (disabled) %s' % (id, desc)
+          text = '{0!s}: (disabled) {1!s}'.format(id, desc)
       except ValueError as e:
         # bp unparsable
         pass

--- a/utils/lui/debuggerdriver.py
+++ b/utils/lui/debuggerdriver.py
@@ -65,16 +65,16 @@ class DebuggerDriver(Thread):
                                            | lldb.SBCommandInterpreter.eBroadcastBitAsynchronousErrorData
                                            )
     def createTarget(self, target_image, args=None):
-        self.handleCommand("target create %s" % target_image)
+        self.handleCommand("target create {0!s}".format(target_image))
         if args is not None:
-          self.handleCommand("settings set target.run-args %s" % args)
+          self.handleCommand("settings set target.run-args {0!s}".format(args))
 
     def attachProcess(self, pid):
-        self.handleCommand("process attach -p %d" % pid)
+        self.handleCommand("process attach -p {0:d}".format(pid))
         pass
 
     def loadCore(self, corefile):
-        self.handleCommand("target create -c %s" % corefile)
+        self.handleCommand("target create -c {0!s}".format(corefile))
         pass
 
     def setDone(self):

--- a/utils/lui/lldbutil.py
+++ b/utils/lui/lldbutil.py
@@ -317,12 +317,12 @@ def run_break_set_by_file_and_line (test, file_name, line_number, extra_options 
     If loc_exact is true, we check that there is one location, and that location must be at the input file and line number."""
 
     if file_name == None:
-        command = 'breakpoint set -l %d'%(line_number)
+        command = 'breakpoint set -l {0:d}'.format((line_number))
     else:
-        command = 'breakpoint set -f "%s" -l %d'%(file_name, line_number)
+        command = 'breakpoint set -f "{0!s}" -l {1:d}'.format(file_name, line_number)
 
     if module_name:
-        command += " --shlib '%s'" % (module_name)
+        command += " --shlib '{0!s}'".format((module_name))
 
     if extra_options:
         command += " " + extra_options
@@ -340,10 +340,10 @@ def run_break_set_by_symbol (test, symbol, extra_options = None, num_expected_lo
     """Set a breakpoint by symbol name.  Common options are the same as run_break_set_by_file_and_line.
 
     If sym_exact is true, then the output symbol must match the input exactly, otherwise we do a substring match."""
-    command = 'breakpoint set -n "%s"'%(symbol)
+    command = 'breakpoint set -n "{0!s}"'.format((symbol))
 
     if module_name:
-        command += " --shlib '%s'" % (module_name)
+        command += " --shlib '{0!s}'".format((module_name))
 
     if extra_options:
         command += " " + extra_options
@@ -360,10 +360,10 @@ def run_break_set_by_symbol (test, symbol, extra_options = None, num_expected_lo
 def run_break_set_by_selector (test, selector, extra_options = None, num_expected_locations = -1, module_name=None):
     """Set a breakpoint by selector.  Common options are the same as run_break_set_by_file_and_line."""
 
-    command = 'breakpoint set -S "%s"' % (selector)
+    command = 'breakpoint set -S "{0!s}"'.format((selector))
 
     if module_name:
-        command += ' --shlib "%s"' % (module_name)
+        command += ' --shlib "{0!s}"'.format((module_name))
 
     if extra_options:
         command += " " + extra_options
@@ -380,7 +380,7 @@ def run_break_set_by_selector (test, selector, extra_options = None, num_expecte
 def run_break_set_by_regexp (test, regexp, extra_options=None, num_expected_locations=-1):
     """Set a breakpoint by regular expression match on symbol name.  Common options are the same as run_break_set_by_file_and_line."""
 
-    command = 'breakpoint set -r "%s"'%(regexp)
+    command = 'breakpoint set -r "{0!s}"'.format((regexp))
     if extra_options:
         command += " " + extra_options
     
@@ -392,7 +392,7 @@ def run_break_set_by_regexp (test, regexp, extra_options=None, num_expected_loca
 
 def run_break_set_by_source_regexp (test, regexp, extra_options=None, num_expected_locations=-1):
     """Set a breakpoint by source regular expression.  Common options are the same as run_break_set_by_file_and_line."""
-    command = 'breakpoint set -p "%s"'%(regexp)
+    command = 'breakpoint set -p "{0!s}"'.format((regexp))
     if extra_options:
         command += " " + extra_options
     
@@ -464,20 +464,20 @@ def check_breakpoint_result (test, break_results, file_name=None, line_number=-1
     if num_locations == -1:
         test.assertTrue (out_num_locations > 0, "Expecting one or more locations, got none.")
     else:
-        test.assertTrue (num_locations == out_num_locations, "Expecting %d locations, got %d."%(num_locations, out_num_locations))
+        test.assertTrue (num_locations == out_num_locations, "Expecting {0:d} locations, got {1:d}.".format(num_locations, out_num_locations))
 
     if file_name:
         out_file_name = ""
         if 'file' in break_results:
             out_file_name = break_results['file']
-        test.assertTrue (file_name == out_file_name, "Breakpoint file name '%s' doesn't match resultant name '%s'."%(file_name, out_file_name))
+        test.assertTrue (file_name == out_file_name, "Breakpoint file name '{0!s}' doesn't match resultant name '{1!s}'.".format(file_name, out_file_name))
 
     if line_number != -1:
         out_file_line = -1
         if 'line_no' in break_results:
             out_line_number = break_results['line_no']
 
-        test.assertTrue (line_number == out_line_number, "Breakpoint line number %s doesn't match resultant line %s."%(line_number, out_line_number))
+        test.assertTrue (line_number == out_line_number, "Breakpoint line number {0!s} doesn't match resultant line {1!s}.".format(line_number, out_line_number))
 
     if symbol_name:
         out_symbol_name = ""
@@ -488,16 +488,16 @@ def check_breakpoint_result (test, break_results, file_name=None, line_number=-1
             out_symbol_name = break_results['symbol']
 
         if symbol_match_exact:
-            test.assertTrue(symbol_name == out_symbol_name, "Symbol name '%s' doesn't match resultant symbol '%s'."%(symbol_name, out_symbol_name))
+            test.assertTrue(symbol_name == out_symbol_name, "Symbol name '{0!s}' doesn't match resultant symbol '{1!s}'.".format(symbol_name, out_symbol_name))
         else:
-            test.assertTrue(out_symbol_name.find(symbol_name) != -1, "Symbol name '%s' isn't in resultant symbol '%s'."%(symbol_name, out_symbol_name))
+            test.assertTrue(out_symbol_name.find(symbol_name) != -1, "Symbol name '{0!s}' isn't in resultant symbol '{1!s}'.".format(symbol_name, out_symbol_name))
 
     if module_name:
         out_nodule_name = None
         if 'module' in break_results:
             out_module_name = break_results['module']
         
-        test.assertTrue (module_name.find(out_module_name) != -1, "Symbol module name '%s' isn't in expected module name '%s'."%(out_module_name, module_name))
+        test.assertTrue (module_name.find(out_module_name) != -1, "Symbol module name '{0!s}' isn't in expected module name '{1!s}'.".format(out_module_name, module_name))
 
 # ==================================================
 # Utility functions related to Threads and Processes
@@ -688,7 +688,7 @@ def print_stacktrace(thread, string_buffer = False):
         else:
             print >> output, "  frame #{num}: {addr:#016x} {mod}`{func} at {file}:{line} {args}".format(
                 num=i, addr=load_addr, mod=mods[i],
-                func='%s [inlined]' % funcs[i] if frame.IsInlined() else funcs[i],
+                func='{0!s} [inlined]'.format(funcs[i]) if frame.IsInlined() else funcs[i],
                 file=files[i], line=lines[i],
                 args=get_args_as_string(frame, showFuncName=False) if not frame.IsInlined() else '()')
 
@@ -739,7 +739,7 @@ def get_args_as_string(frame, showFuncName=True):
     vars = frame.GetVariables(True, False, False, True) # type of SBValueList
     args = [] # list of strings
     for var in vars:
-        args.append("(%s)%s=%s" % (var.GetTypeName(),
+        args.append("({0!s}){1!s}={2!s}".format(var.GetTypeName(),
                                    var.GetName(),
                                    var.GetValue()))
     if frame.GetFunction():
@@ -749,9 +749,9 @@ def get_args_as_string(frame, showFuncName=True):
     else:
         name = ""
     if showFuncName:
-        return "%s(%s)" % (name, ", ".join(args))
+        return "{0!s}({1!s})".format(name, ", ".join(args))
     else:
-        return "(%s)" % (", ".join(args))
+        return "({0!s})".format((", ".join(args)))
         
 def print_registers(frame, string_buffer = False):
     """Prints all the register sets of the frame."""
@@ -761,12 +761,12 @@ def print_registers(frame, string_buffer = False):
     print >> output, "Register sets for " + str(frame)
 
     registerSet = frame.GetRegisters() # Return type of SBValueList.
-    print >> output, "Frame registers (size of register set = %d):" % registerSet.GetSize()
+    print >> output, "Frame registers (size of register set = {0:d}):".format(registerSet.GetSize())
     for value in registerSet:
         #print >> output, value 
-        print >> output, "%s (number of children = %d):" % (value.GetName(), value.GetNumChildren())
+        print >> output, "{0!s} (number of children = {1:d}):".format(value.GetName(), value.GetNumChildren())
         for child in value:
-            print >> output, "Name: %s, Value: %s" % (child.GetName(), child.GetValue())
+            print >> output, "Name: {0!s}, Value: {1!s}".format(child.GetName(), child.GetValue())
 
     if string_buffer:
         return output.getvalue()
@@ -839,7 +839,7 @@ class BasicFormatter(object):
         if val == None:
             val = value.GetValue()
         if val == None and value.GetNumChildren() > 0:
-            val = "%s (location)" % value.GetLocation()
+            val = "{0!s} (location)".format(value.GetLocation())
         print >> output, "{indentation}({type}) {name} = {value}".format(
             indentation = ' ' * indent,
             type = value.GetTypeName(),

--- a/utils/lui/lui.py
+++ b/utils/lui/lui.py
@@ -45,18 +45,18 @@ def handle_args(driver, argv):
       pid = int(options.pid)
       driver.attachProcess(ui, pid)
     except ValueError:
-      print "Error: expecting integer PID, got '%s'" % options.pid
+      print "Error: expecting integer PID, got '{0!s}'".format(options.pid)
   elif options.core is not None:
     if not os.path.exists(options.core):
-      raise Exception("Specified core file '%s' does not exist." % options.core)
+      raise Exception("Specified core file '{0!s}' does not exist.".format(options.core))
     driver.loadCore(options.core)
   elif len(args) == 2:
     if not os.path.isfile(args[1]):
-      raise Exception("Specified target '%s' does not exist" % args[1])
+      raise Exception("Specified target '{0!s}' does not exist".format(args[1]))
     driver.createTarget(args[1])
   elif len(args) > 2:
     if not os.path.isfile(args[1]):
-      raise Exception("Specified target '%s' does not exist" % args[1])
+      raise Exception("Specified target '{0!s}' does not exist".format(args[1]))
     driver.createTarget(args[1], args[2:])
 
 def sigint_handler(signal, frame):

--- a/utils/lui/sandbox.py
+++ b/utils/lui/sandbox.py
@@ -34,7 +34,7 @@ class SandboxUI(cui.CursesUI):
     #self.wins.append(cui.TitledWin(w2, h2, w2, h2, "Test Window 4"))
     list_win = cui.ListWin(w2, h2, w2, h2)
     for i in range(0, 40):
-      list_win.addItem('Item %s' % i)
+      list_win.addItem('Item {0!s}'.format(i))
     self.wins.append(list_win)
     self.wins.append(cui.TitledWin( 0,  0, w2, h2, "Test Window 1"))
     self.wins.append(cui.TitledWin(w2,  0, w2, h2, "Test Window 2"))

--- a/utils/lui/sourcewin.py
+++ b/utils/lui/sourcewin.py
@@ -68,7 +68,7 @@ class SourceWin(cui.TitledWin):
     target = lldbutil.get_description(process.GetTarget())
     pid = process.GetProcessID()
     ec = process.GetExitStatus()
-    self.win.addstr("\nProcess %s [%d] has exited with exit-code %d" % (target, pid, ec))
+    self.win.addstr("\nProcess {0!s} [{1:d}] has exited with exit-code {2:d}".format(target, pid, ec))
 
   def pageUp(self):
     if self.viewline > 0:
@@ -95,7 +95,7 @@ class SourceWin(cui.TitledWin):
       self.viewline = self.pc_line - half + 1
 
     if self.viewline < 0:
-      raise Exception("negative viewline: pc=%d viewline=%d" % (self.pc_line, self.viewline))
+      raise Exception("negative viewline: pc={0:d} viewline={1:d}".format(self.pc_line, self.viewline))
 
   def refreshSource(self, process = None):
     (self.height, self.width) = self.win.getmaxyx()
@@ -151,7 +151,7 @@ class SourceWin(cui.TitledWin):
         attr = curses.A_REVERSE
       if line_num in breakpoints:
         marker = self.markerBP
-      line = "%s%3d %s" % (marker, line_num, self.highlight(content[i]))
+      line = "{0!s}{1:3d} {2!s}".format(marker, line_num, self.highlight(content[i]))
       if len(line) >= self.width:
         line = line[0:self.width-1] + "\n"
       self.win.addstr(line, attr)

--- a/utils/test/disasm.py
+++ b/utils/test/disasm.py
@@ -32,7 +32,7 @@ def do_llvm_mc_disassembly(gdb_commands, gdb_options, exe, func, mc, mc_options)
     import pexpect
 
     gdb_prompt = "\r\n\(gdb\) "
-    gdb = pexpect.spawn(('gdb %s' % gdb_options) if gdb_options else 'gdb')
+    gdb = pexpect.spawn(('gdb {0!s}'.format(gdb_options)) if gdb_options else 'gdb')
     # Turn on logging for what gdb sends back.
     gdb.logfile_read = sys.stdout
     gdb.expect(gdb_prompt)
@@ -43,11 +43,11 @@ def do_llvm_mc_disassembly(gdb_commands, gdb_options, exe, func, mc, mc_options)
         gdb.expect(gdb_prompt)
 
     # Now issue the file command.
-    gdb.sendline('file %s' % exe)
+    gdb.sendline('file {0!s}'.format(exe))
     gdb.expect(gdb_prompt)
 
     # Send the disassemble command.
-    gdb.sendline('disassemble %s' % func)
+    gdb.sendline('disassemble {0!s}'.format(func))
     gdb.expect(gdb_prompt)
 
     # Get the output from gdb.
@@ -87,7 +87,7 @@ def do_llvm_mc_disassembly(gdb_commands, gdb_options, exe, func, mc, mc_options)
 
         if prev_addr and addr_diff > 0:
             # Feed the examining memory command to gdb.
-            gdb.sendline('x /%db %s' % (addr_diff, prev_addr))
+            gdb.sendline('x /{0:d}b {1!s}'.format(addr_diff, prev_addr))
             gdb.expect(gdb_prompt)
             x_output = gdb.before
             # Get the last output line from the gdb examine memory command,
@@ -96,7 +96,7 @@ def do_llvm_mc_disassembly(gdb_commands, gdb_options, exe, func, mc, mc_options)
             memory_dump = x_output.split(os.linesep)[-1].partition('>:')[2].strip()
             #print "\nbytes:", memory_dump
             disasm_str = prev_line.partition('>:')[2]
-            print >> mc_input, '%s # %s' % (memory_dump, disasm_str)
+            print >> mc_input, '{0!s} # {1!s}'.format(memory_dump, disasm_str)
 
         # We're done with the processing.  Assign the current line to be prev_line.
         prev_line = line
@@ -110,7 +110,7 @@ def do_llvm_mc_disassembly(gdb_commands, gdb_options, exe, func, mc, mc_options)
     with open('disasm-input.txt', 'w') as f:
         f.write(mc_input.getvalue())
 
-    mc_cmd = '%s -disassemble %s disasm-input.txt' % (mc, mc_options)
+    mc_cmd = '{0!s} -disassemble {1!s} disasm-input.txt'.format(mc, mc_options)
     print "\nExecuting command:", mc_cmd
     os.system(mc_cmd)
 

--- a/utils/test/lldb-disasm.py
+++ b/utils/test/lldb-disasm.py
@@ -107,7 +107,7 @@ def do_lldb_disassembly(lldb_commands, exe, disassemble_options, num_symbols,
         run_command(ci, cmd, res, not quiet_disassembly)
 
     # Now issue the file command.
-    run_command(ci, 'file %s' % exe, res, not quiet_disassembly)
+    run_command(ci, 'file {0!s}'.format(exe), res, not quiet_disassembly)
 
     # Create a target.
     #target = dbg.CreateTarget(exe)
@@ -163,7 +163,7 @@ def do_lldb_disassembly(lldb_commands, exe, disassemble_options, num_symbols,
 
     # Disassembly time.
     for symbol in symbol_iter(num_symbols, symbols_to_disassemble, re_symbol_pattern, target, not quiet_disassembly):
-        cmd = "disassemble %s '%s'" % (disassemble_options, symbol)
+        cmd = "disassemble {0!s} '{1!s}'".format(disassemble_options, symbol)
         run_command(ci, cmd, res, not quiet_disassembly)
 
 

--- a/utils/test/llvm-mc-shell.py
+++ b/utils/test/llvm-mc-shell.py
@@ -47,8 +47,8 @@ def llvm_mc_loop(mc, mc_options):
                 contents[:] = []
 
             # Invoke llvm-mc with our newly created file.
-            mc_cmd = '%s %s %s' % (mc, mc_options, fname)
-            sys.stdout.write("Executing command: %s\n" % mc_cmd)
+            mc_cmd = '{0!s} {1!s} {2!s}'.format(mc, mc_options, fname)
+            sys.stdout.write("Executing command: {0!s}\n".format(mc_cmd))
             os.system(mc_cmd)
         else:
             # Keep accumulating our input.

--- a/utils/test/ras.py
+++ b/utils/test/ras.py
@@ -37,7 +37,7 @@ def runTestsuite(testDir, sessDir, envs = None):
 
     import shlex, subprocess
 
-    command_line = "./dotest.py -w -s %s" % sessDir
+    command_line = "./dotest.py -w -s {0!s}".format(sessDir)
     # Apply correct tokenization for subprocess.Popen().
     args = shlex.split(command_line)
 
@@ -48,7 +48,7 @@ def runTestsuite(testDir, sessDir, envs = None):
     stdout, stderr = process.communicate()
     
     # This will be used as the subject line of our email about this test.
-    cmd = "%s %s" % (' '.join(envs) if envs else "", command_line)
+    cmd = "{0!s} {1!s}".format(' '.join(envs) if envs else "", command_line)
 
     return (cmd, stderr)
 
@@ -119,7 +119,7 @@ SMTP server, which then does the normal delivery process.
     if not os.path.exists(sessDir):
         outer.attach(MIMEText(output, 'plain'))
     else:
-        outer.attach(MIMEText("%s\n%s\n\n" % (output,
+        outer.attach(MIMEText("{0!s}\n{1!s}\n\n".format(output,
                                               "Session logs of test failures/errors:"),
                               'plain'))
 

--- a/utils/test/run-dis.py
+++ b/utils/test/run-dis.py
@@ -61,7 +61,7 @@ def walk_and_invoke(sdk_root, path_regexp, suffix, num_symbols):
                 continue
 
             command = template % (scriptPath, path, num_symbols if num_symbols > 0 else 1000)
-            print "Running %s" % (command)
+            print "Running {0!s}".format((command))
             os.system(command)
 
 def main():

--- a/utils/test/run-until-faulted.py
+++ b/utils/test/run-until-faulted.py
@@ -38,7 +38,7 @@ def do_lldb_launch_loop(lldb_command, exe, exe_options):
 
     # Now issue the file command.
     #print "sending 'file %s' command..." % exe
-    lldb.sendline('file %s' % exe)
+    lldb.sendline('file {0!s}'.format(exe))
     lldb.expect(prompt)
 
     # Loop until it faults....
@@ -48,7 +48,7 @@ def do_lldb_launch_loop(lldb_command, exe, exe_options):
     for i in range(100):
         count = i
         #print "sending 'process launch -- %s' command... (iteration: %d)" % (exe_options, count)
-        lldb.sendline('process launch -- %s' % exe_options)
+        lldb.sendline('process launch -- {0!s}'.format(exe_options))
         index = lldb.expect(['Process .* exited with status',
                              'Process .* stopped',
                              pexpect.TIMEOUT])

--- a/utils/vim-lldb/python-vim-lldb/import_lldb.py
+++ b/utils/vim-lldb/python-vim-lldb/import_lldb.py
@@ -28,7 +28,7 @@ def import_lldb():
   from subprocess import check_output, CalledProcessError
   try:
     with open(os.devnull, 'w') as fnull:
-      lldb_minus_p_path = check_output("%s -P" % lldb_executable, shell=True, stderr=fnull).strip()
+      lldb_minus_p_path = check_output("{0!s} -P".format(lldb_executable), shell=True, stderr=fnull).strip()
     if not os.path.exists(lldb_minus_p_path):
       #lldb -P returned invalid path, probably too old
       pass
@@ -58,4 +58,4 @@ def import_lldb():
 
 if not import_lldb():
   import vim
-  vim.command('redraw | echo "%s"' % " Error loading lldb module; vim-lldb will be disabled. Check LLDB installation or set LLDB environment variable.")
+  vim.command('redraw | echo "{0!s}"'.format(" Error loading lldb module; vim-lldb will be disabled. Check LLDB installation or set LLDB environment variable."))

--- a/utils/vim-lldb/python-vim-lldb/lldb_controller.py
+++ b/utils/vim-lldb/python-vim-lldb/lldb_controller.py
@@ -155,7 +155,7 @@ class LLDBController(object):
     self.ui.activate()
     self.pid = self.process.GetProcessID()
 
-    print "Attached to %s (pid=%d)" % (process_name, self.pid)
+    print "Attached to {0!s} (pid={1:d})".format(process_name, self.pid)
 
   def doDetach(self):
     if self.process is not None and self.process.IsValid():
@@ -186,7 +186,7 @@ class LLDBController(object):
     self.processListener = lldb.SBListener("process_event_listener")
     self.process.GetBroadcaster().AddListener(self.processListener, lldb.SBProcess.eBroadcastBitStateChanged)
 
-    print "Launched %s %s (pid=%d)" % (exe, args, self.pid)
+    print "Launched {0!s} {1!s} (pid={2:d})".format(exe, args, self.pid)
 
     if not stop_at_entry:
       self.doContinue()
@@ -221,11 +221,11 @@ class LLDBController(object):
     err = lldb.SBError()
     self.target = self.dbg.CreateTarget(exe, None, None, self.load_dependent_modules, err)
     if not self.target:
-      sys.stderr.write("Error creating target %s. %s" % (str(exe), str(err)))
+      sys.stderr.write("Error creating target {0!s}. {1!s}".format(str(exe), str(err)))
       return
 
     self.ui.activate()
-    self.ui.update(self.target, "created target %s" % str(exe), self)
+    self.ui.update(self.target, "created target {0!s}".format(str(exe)), self)
 
   def doContinue(self):
     """ Handle 'contiue' command.
@@ -257,10 +257,10 @@ class LLDBController(object):
       # ask it if there already is one or more breakpoints at (file, line)...
       if self.ui.haveBreakpoint(name, line):
         bps = self.ui.getBreakpoints(name, line)
-        args = "delete %s" % " ".join([str(b.GetID()) for b in bps])
+        args = "delete {0!s}".format(" ".join([str(b.GetID()) for b in bps]))
         self.ui.deleteBreakpoints(name, line)
       else:
-        args = "set -f %s -l %d" % (name, line)
+        args = "set -f {0!s} -l {1:d}".format(name, line)
     else:
       show_output = True
 
@@ -292,7 +292,7 @@ class LLDBController(object):
   def getCommandResult(self, command, command_args):
     """ Run cmd in the command interpreter and returns (success, output) """
     result = lldb.SBCommandReturnObject()
-    cmd = "%s %s" % (command, command_args)
+    cmd = "{0!s} {1!s}".format(command, command_args)
 
     self.commandInterpreter.HandleCommand(cmd, result)
     return (result.Succeeded(), result.GetOutput() if result.Succeeded() else result.GetError())
@@ -310,7 +310,7 @@ class LLDBController(object):
   def getCommandOutput(self, command, command_args=""):
     """ runs cmd in the command interpreter andreturns (status, result) """
     result = lldb.SBCommandReturnObject()
-    cmd = "%s %s" % (command, command_args)
+    cmd = "{0!s} {1!s}".format(command, command_args)
     self.commandInterpreter.HandleCommand(cmd, result)
     return (result.Succeeded(), result.GetOutput() if result.Succeeded() else result.GetError())
 
@@ -369,7 +369,7 @@ def returnCompleteCommand(a, l, p):
   """
   separator = "\n"
   results = ctrl.completeCommand(a, l, p)
-  vim.command('return "%s%s"' % (separator.join(results), separator))
+  vim.command('return "{0!s}{1!s}"'.format(separator.join(results), separator))
 
 def returnCompleteWindow(a, l, p):
   """ Returns a "\n"-separated string with possible completion results
@@ -378,7 +378,7 @@ def returnCompleteWindow(a, l, p):
   """
   separator = "\n"
   results = ['breakpoints', 'backtrace', 'disassembly', 'locals', 'threads', 'registers']
-  vim.command('return "%s%s"' % (separator.join(results), separator))
+  vim.command('return "{0!s}{1!s}"'.format(separator.join(results), separator))
 
 global ctrl
 ctrl = LLDBController()

--- a/utils/vim-lldb/python-vim-lldb/vim_panes.py
+++ b/utils/vim-lldb/python-vim-lldb/vim_panes.py
@@ -94,14 +94,14 @@ def get_selected_frame(target):
   return (frame, "")
 
 def _cmd(cmd):
-  vim.command("call confirm('%s')" % cmd)
+  vim.command("call confirm('{0!s}')".format(cmd))
   vim.command(cmd)
 
 def move_cursor(line, col=0):
   """ moves cursor to specified line and col """
   cw = vim.current.window
   if cw.cursor[0] != line:
-    vim.command("execute \"normal %dgg\"" % line)
+    vim.command("execute \"normal {0:d}gg\"".format(line))
 
 def winnr():
   """ Returns currently selected window number """
@@ -109,7 +109,7 @@ def winnr():
 
 def bufwinnr(name):
   """ Returns window number corresponding with buffer name """
-  return int(vim.eval("bufwinnr('%s')" % name))
+  return int(vim.eval("bufwinnr('{0!s}')".format(name)))
 
 def goto_window(nr):
   """ go to window number nr"""
@@ -258,9 +258,9 @@ class VimPane(object):
 
     if method != 'edit':
       belowcmd = "below" if self.openBelow else ""
-      vim.command('silent %s %s %s' % (belowcmd, method, self.name))
+      vim.command('silent {0!s} {1!s} {2!s}'.format(belowcmd, method, self.name))
     else:
-      vim.command('silent %s %s' % (method, self.name))
+      vim.command('silent {0!s} {1!s}'.format(method, self.name))
 
     self.window = vim.current.window
   
@@ -325,8 +325,8 @@ class VimPane(object):
       if len(lines) == 0:
         continue
 
-      cmd = 'match %s /' % highlightType
-      lines = ['\%' + '%d' % line + 'l' for line in lines]
+      cmd = 'match {0!s} /'.format(highlightType)
+      lines = ['\%' + '{0:d}'.format(line) + 'l' for line in lines]
       cmd += '\\|'.join(lines)
       cmd += '/'
       vim.command(cmd)
@@ -337,7 +337,7 @@ class VimPane(object):
       # highlight already defined
       return
 
-    vim.command("highlight %s ctermbg=%s guibg=%s" % (name, colour, colour))
+    vim.command("highlight {0!s} ctermbg={1!s} guibg={2!s}".format(name, colour, colour))
     VimPane.highlightTypes.append(name)
 
   def write(self, msg):
@@ -395,7 +395,7 @@ class FrameKeyValuePane(VimPane):
   def format_pair(self, key, value, changed = False):
     """ Formats a key/value pair. Appends a '*' if changed == True """
     marker = '*' if changed else ' '
-    return "%s %s = %s\n" % (marker, key, value)
+    return "{0!s} {1!s} = {2!s}\n".format(marker, key, value)
 
   def get_content(self, target, controller):
     """ Get content for a frame-aware pane. Also builds the list of lines that
@@ -461,7 +461,7 @@ class LocalsPane(FrameKeyValuePane):
       # If the value is too big, SBValue.GetValue() returns None; replace with ...
       val = "..."
 
-    return ("(%s) %s" % (var.GetTypeName(), var.GetName()), "%s" % val)
+    return ("({0!s}) {1!s}".format(var.GetTypeName(), var.GetName()), "{0!s}".format(val))
 
   def get_frame_content(self, frame):
     """ Returns list of key-value pairs of local variables in frame """
@@ -490,7 +490,7 @@ class RegistersPane(FrameKeyValuePane):
     result = []
     for register_sets in frame.GetRegisters():
       # hack the register group name into the list of registers...
-      result.append((" = = %s =" % register_sets.GetName(), ""))
+      result.append((" = = {0!s} =".format(register_sets.GetName()), ""))
 
       for reg in register_sets:
         result.append(self.format_register(reg))
@@ -569,7 +569,7 @@ class DisassemblyPane(CommandPane):
     CommandPane.__init__(self, owner, name, open_below=True)
 
     # FIXME: let users customize the number of instructions to disassemble
-    self.setCommand("disassemble", "-c %d -p" % self.maxHeight)
+    self.setCommand("disassemble", "-c {0:d} -p".format(self.maxHeight))
 
 class ThreadPane(StoppedCommandPane):
   """ Pane that displays threads list """

--- a/utils/vim-lldb/python-vim-lldb/vim_signs.py
+++ b/utils/vim-lldb/python-vim-lldb/vim_signs.py
@@ -33,15 +33,15 @@ class VimSign(object):
 
   def define(self, sign_text, highlight_colour):
     """ Defines sign and highlight (if highlight_colour is not None). """
-    sign_name = "sign%d" % VimSign.name_id
+    sign_name = "sign{0:d}".format(VimSign.name_id)
     if highlight_colour is None:
-      vim.command("sign define %s text=%s" % (sign_name, sign_text))
+      vim.command("sign define {0!s} text={1!s}".format(sign_name, sign_text))
     else:
-      self.highlight_name = "highlight%d" % VimSign.name_id
-      vim.command("highlight %s ctermbg=%s guibg=%s" % (self.highlight_name,
+      self.highlight_name = "highlight{0:d}".format(VimSign.name_id)
+      vim.command("highlight {0!s} ctermbg={1!s} guibg={2!s}".format(self.highlight_name,
                                                         highlight_colour,
                                                         highlight_colour))
-      vim.command("sign define %s text=%s linehl=%s texthl=%s" % (sign_name,
+      vim.command("sign define {0!s} text={1!s} linehl={2!s} texthl={3!s}".format(sign_name,
                                                                   sign_text,
                                                                   self.highlight_name,
                                                                   self.highlight_name))
@@ -53,11 +53,11 @@ class VimSign(object):
   def show(self, name, buffer_number, line_number):
     self.id = VimSign.sign_id
     VimSign.sign_id += 1
-    vim.command("sign place %d name=%s line=%d buffer=%s" % (self.id, name, line_number, buffer_number))
+    vim.command("sign place {0:d} name={1!s} line={2:d} buffer={3!s}".format(self.id, name, line_number, buffer_number))
     pass
 
   def hide(self):
-    vim.command("sign unplace %d" % self.id)
+    vim.command("sign unplace {0:d}".format(self.id))
     pass
 
 class BreakpointSign(VimSign):

--- a/utils/vim-lldb/python-vim-lldb/vim_ui.py
+++ b/utils/vim-lldb/python-vim-lldb/vim_ui.py
@@ -104,11 +104,11 @@ class UI:
         buf = buffers[0]
         if buf != vim.current.buffer:
           # Vim has an open buffer to the required file: select it
-          vim.command('execute ":%db"' % buf.number)
+          vim.command('execute ":{0:d}b"'.format(buf.number))
       elif is_selected and vim.current.buffer.name not in fname and os.path.exists(fname) and goto_file:
         # FIXME: If current buffer is modified, vim will complain when we try to switch away.
         #        Find a way to detect if the current buffer is modified, and...warn instead?
-        vim.command('execute ":e %s"' % fname)
+        vim.command('execute ":e {0!s}"'.format(fname))
         buf = vim.current.buffer
       elif len(buffers) > 1 and goto_file:
         #FIXME: multiple open buffers match PC location
@@ -124,7 +124,7 @@ class UI:
         if curname is not None and is_same_file(curname, fname):
           move_cursor(line, 0)
         elif move_cursor:
-          print "FIXME: not sure where to move cursor because %s != %s " % (vim.current.buffer.name, fname)
+          print "FIXME: not sure where to move cursor because {0!s} != {1!s} ".format(vim.current.buffer.name, fname)
 
   def update_breakpoints(self, target, buffers):
     """ Decorates buffer with signs corresponding to breakpoints in target. """
@@ -145,7 +145,7 @@ class UI:
           lineNum = int(match.group(2).strip())
           ret.append((loc.IsResolved(), match.group(1), lineNum))
         except ValueError as e:
-          sys.stderr.write("unable to parse breakpoint location line number: '%s'" % match.group(2))
+          sys.stderr.write("unable to parse breakpoint location line number: '{0!s}'".format(match.group(2)))
           sys.stderr.write(str(e))
 
       return ret
@@ -218,7 +218,7 @@ class UI:
   def showWindow(self, name):
     """ Shows (un-hides) window pane specified by name """
     if not self.paneCol.havePane(name):
-      sys.stderr.write("unknown window: %s" % name)
+      sys.stderr.write("unknown window: {0!s}".format(name))
       return False
     self.paneCol.prepare([name])
     return True
@@ -226,7 +226,7 @@ class UI:
   def hideWindow(self, name):
     """ Hides window pane specified by name """
     if not self.paneCol.havePane(name):
-      sys.stderr.write("unknown window: %s" % name)
+      sys.stderr.write("unknown window: {0!s}".format(name))
       return False
     self.paneCol.hide([name])
     return True


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:swift-lldb?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:swift-lldb?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
